### PR TITLE
Pin to Alpine 3.18 for docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.2-alpine AS build
+FROM ruby:3.2-alpine3.18 AS build
 
 RUN apk add --no-cache tzdata alpine-sdk postgresql-dev nodejs yarn xz libarchive mesa-gl glfw
 RUN gem install foreman


### PR DESCRIPTION
3.19 introduced changes to musl that break sqlite3. See https://github.com/sparklemotion/sqlite3-ruby/issues/434 and https://github.com/rake-compiler/rake-compiler-dock/issues/75