### PR TITLE
Restrict permission for demo instances

### DIFF
--- a/app/controllers/libraries_controller.rb
+++ b/app/controllers/libraries_controller.rb
@@ -16,12 +16,15 @@ class LibrariesController < ApplicationController
   def new
     @library = Library.new
     @title = "New Library"
+    authorize @library
   end
 
   def edit
+    authorize @library
   end
 
   def create
+    authorize Library
     @library = Library.create(library_params)
     @library.tag_regex = params[:tag_regex]
     if @library.valid?
@@ -33,6 +36,7 @@ class LibrariesController < ApplicationController
   end
 
   def update
+    authorize @library
     @library.update(library_params)
     uptags = library_params[:tag_regex].reject(&:empty?)
     @library.tag_regex = uptags
@@ -57,6 +61,7 @@ class LibrariesController < ApplicationController
   end
 
   def destroy
+    authorize @library
     @library.destroy
     redirect_to libraries_path
   end

--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -44,6 +44,7 @@ class ModelFilesController < ApplicationController
   end
 
   def destroy
+    authorize @file
     @file.delete_from_disk_and_destroy
     redirect_to library_model_path(@library, @model)
   end

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -88,6 +88,7 @@ class ModelsController < ApplicationController
   end
 
   def destroy
+    authorize @file
     @model.delete_from_disk_and_destroy
     redirect_to library_path(@library)
   end

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -1,4 +1,6 @@
 class UploadsController < ApplicationController
+  before_action { authorize :upload }
+
   def create
     library = Library.find(params[:post][:library_pick])
     save_files(params[:upload], File.join(library.path, ""))

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -10,4 +10,8 @@ class SiteSettings < RailsSettings::Base
   field :model_path_template, type: :string, default: "{tags}/{modelName}{modelId}"
   field :parse_metadata_from_path, type: :boolean, default: true
   field :safe_folder_names, type: :boolean, default: true
+
+  def self.demo_mode?
+    ENV.fetch("DEMO_MODE", nil) == "enabled"
+  end
 end

--- a/app/policies/active_admin_policy.rb
+++ b/app/policies/active_admin_policy.rb
@@ -1,0 +1,27 @@
+class ActiveAdminPolicy < ApplicationPolicy
+  def initialize(user, record)
+    raise Pundit::NotAuthorizedError, "not available in demo mode" if SiteSettings.demo_mode?
+    @user = user
+    @record = record
+  end
+
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    true
+  end
+
+  def update?
+    true
+  end
+
+  def destroy?
+    true
+  end
+end

--- a/app/policies/library_policy.rb
+++ b/app/policies/library_policy.rb
@@ -1,0 +1,13 @@
+class LibraryPolicy < ApplicationPolicy
+  def create?
+    !SiteSettings.demo_mode?
+  end
+
+  def update?
+    !SiteSettings.demo_mode?
+  end
+
+  def destroy?
+    !SiteSettings.demo_mode?
+  end
+end

--- a/app/policies/model_file_policy.rb
+++ b/app/policies/model_file_policy.rb
@@ -1,0 +1,5 @@
+class ModelFilePolicy < ApplicationPolicy
+  def destroy?
+    !SiteSettings.demo_mode?
+  end
+end

--- a/app/policies/model_policy.rb
+++ b/app/policies/model_policy.rb
@@ -1,0 +1,5 @@
+class ModelPolicy < ApplicationPolicy
+  def destroy?
+    !SiteSettings.demo_mode?
+  end
+end

--- a/app/policies/upload_policy.rb
+++ b/app/policies/upload_policy.rb
@@ -1,0 +1,9 @@
+class UploadPolicy < ApplicationPolicy
+  def index?
+    !SiteSettings.demo_mode?
+  end
+
+  def create?
+    !SiteSettings.demo_mode?
+  end
+end

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -31,7 +31,7 @@
 					<%= nav_link 'plus-circle', t('libraries.general.new'), new_library_path, text_style: "d-lg-none" %>
 				</li>
 				<li class="nav-item">
-					<%= nav_link 'upload', t('.upload'), uploads_path, style: "btn btn-warning btn-sm me-1 mt-lg-1" %>
+					<%= nav_link 'upload', t('.upload'), uploads_path, style: "btn btn-warning btn-sm me-1 mt-lg-1 #{policy(:upload).index? ? "" : "disabled"}" %>
 				</li>
 				<li class="nav-item">
 					<% if @scan_in_progress %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -2,6 +2,11 @@
   <%= render "application/content_header" %>
   <h1 class="d-none d-lg-block"><%= t "application.title" %></h1>
   <p class='lead'><%= t "application.tagline" %></p>
+  <% if SiteSettings.demo_mode? %>
+    <div class="alert alert-info">
+      <%= t "application.demo_mode" %>
+    </div>
+  <% end %>
   <div class="col-8 offset-md-2">
     <%= form_with url: models_path, method: :get, class: "mt-3" do |f| %>
       <div class="input-group mb-3">

--- a/app/views/settings/_library_settings.html.erb
+++ b/app/views/settings/_library_settings.html.erb
@@ -42,7 +42,7 @@
             <span id="libraryRegexHelp" class="form-text">Check for models missing tags matching these regex.</span>
           </div>
           <%= if !library.tag_regex.empty? then link_to "Search Missing", models_path(library: library.id, missingtag: ""), {class: "btn btn-outline-secondary"} end %>
-          <%= link_to "Edit", edit_library_path(library), {class: "btn btn-outline-secondary"} %>
+          <%= link_to "Edit", edit_library_path(library), {class: "btn btn-outline-secondary, #{policy(:library).edit? ? "" : "disabled"}"} %>
         </div></li>
     <% end %>
     </ul>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -37,7 +37,7 @@
     </div>
     <% if current_user.admin? %>
       <div class='col text-end'>
-        <%= link_to "#{icon('tools', 'Administration')} Advanced Administration".html_safe, '/admin', class: "btn btn-danger" %>
+        <%= link_to "#{icon('tools', 'Administration')} Advanced Administration".html_safe, '/admin', class: "btn btn-danger #{SiteSettings.demo_mode? ? "disabled" : ""}" %>
       </div>
     <% end %>
     </p>

--- a/config/initializers/active_admin.rb
+++ b/config/initializers/active_admin.rb
@@ -58,24 +58,13 @@ ActiveAdmin.setup do |config|
 
   # == User Authorization
   #
-  # Active Admin will automatically call an authorization
-  # method in a before filter of all controller actions to
-  # ensure that there is a user with proper rights. You can use
-  # CanCanAdapter or make your own. Please refer to documentation.
-  # config.authorization_adapter = ActiveAdmin::CanCanAdapter
-
-  # In case you prefer Pundit over other solutions you can here pass
-  # the name of default policy class. This policy will be used in every
-  # case when Pundit is unable to find suitable policy.
-  # config.pundit_default_policy = "MyDefaultPunditPolicy"
+  config.authorization_adapter = ActiveAdmin::PunditAdapter
+  config.pundit_default_policy = "ActiveAdminPolicy"
 
   # If you wish to maintain a separate set of Pundit policies for admin
   # resources, you may set a namespace here that Pundit will search
   # within when looking for a resource's policy.
   # config.pundit_policy_namespace = :admin
-
-  # You can customize your CanCan Ability class name here.
-  # config.cancan_ability_class = "Ability"
 
   # You can specify a method to be called on unauthorized access.
   # This is necessary in order to prevent a redirect loop which happens

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -19,6 +19,7 @@ en:
       model: Model
       model_file: File
   application:
+    demo_mode: This instance is in demo mode. You cannot add or remove models, but you can do everything else.
     navbar:
       check_existing: Check existing models
       scan: Scan


### PR DESCRIPTION
Using pundit (#1772) we can set up checks for a demo mode that stops people changing library paths, creating new ones, uploading, or removing existing models. The rest is fair game.