### PR TITLE
Make file sending more memory efficient by chunking

### DIFF
--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -55,7 +55,7 @@ class ModelFilesController < ApplicationController
     filename = File.join(@library.path, @model.path, @file.filename)
     response.headers["Content-Length"] = File.size(filename).to_s
     response.headers["Content-Disposition"] = ActionDispatch::Http::ContentDisposition.format(disposition: disposition, filename: @file.filename)
-    response.headers["Content-Type"] = @file.extension.to_sym
+    response.headers["Content-Type"] = @file.mime_type.to_s
     IO.foreach(filename, 2**15) do |chunk|
       response.stream.write(chunk)
     end

--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -1,4 +1,6 @@
 class ModelFilesController < ApplicationController
+  include ActionController::Live
+
   before_action :get_library
   before_action :get_model
   before_action :get_file, except: [:bulk_edit, :bulk_update]
@@ -61,6 +63,8 @@ class ModelFilesController < ApplicationController
     end
   rescue Errno::ENOENT
     head :internal_server_error
+  ensure
+    response.stream.close
   end
 
   def bulk_update_params

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -18,6 +18,10 @@ class ModelFile < ApplicationRecord
     SupportedMimeTypes.image_extensions.include? extension
   end
 
+  def mime_type
+    Mime::Type.lookup_by_extension(extension)
+  end
+
   def name
     File.basename(filename, ".*").humanize.titleize
   end


### PR DESCRIPTION
Should be quicker and allow memory to be garbage collected, thus lowering overall app memory footprint.