### PR TITLE
Fix database bootstrapping

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -30,6 +30,8 @@ jobs:
         run: rm db/data_schema.rb
       - name: Set up database with prepare command so we catch any migration explosions
         run: bundle exec rails db:prepare:with_data
+        env:
+          RAILS_ENV: test
       - name: Run tests
         uses: paambaati/codeclimate-action@v5.0.0
         with:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -26,10 +26,10 @@ jobs:
         run: yarn typecheck
       - name: Compile assets
         run: bundle exec rails assets:precompile
-      - name: Set up database
-        run: bundle exec rails db:setup
-      - name: Migrate database
-        run: bundle exec rails db:migrate:with_data
+      - name: Remove data schema so we bootstrap from zero with data migrations
+        run: rm db/data_schema.rb
+      - name: Set up database with prepare command so we catch any migration explosions
+        run: bundle exec rails db:prepare:with_data
       - name: Run tests
         uses: paambaati/codeclimate-action@v5.0.0
         with:

--- a/bin/setup
+++ b/bin/setup
@@ -23,7 +23,7 @@ FileUtils.chdir APP_ROOT do
   # end
 
   puts "\n== Preparing database =="
-  system! "bin/rails db:prepare"
+  system! "bin/rails db:prepare:with_data"
 
   puts "\n== Removing old logs and tempfiles =="
   system! "bin/rails log:clear tmp:clear"

--- a/db/data/20230612080306_remove_destination_exists_problems.rb
+++ b/db/data/20230612080306_remove_destination_exists_problems.rb
@@ -4,6 +4,7 @@ class RemoveDestinationExistsProblems < ActiveRecord::Migration[7.0]
   def up
     # Clean up deprecated problems
     Problem.where(category: :destination_exists).destroy_all
+  rescue # To avoid crashes when the ignored field in Problem's default scope isn't available yet
   end
 
   def down

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20221220223040)
+DataMigrate::Data.define(version: 20230628194944)

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -35,6 +35,9 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_31_134832) do
     t.index ["slug"], name: "index_creators_on_slug", unique: true
   end
 
+  create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
   create_table "delayed_jobs", force: :cascade do |t|
     t.integer "priority", default: 0, null: false
     t.integer "attempts", default: 0, null: false
@@ -179,7 +182,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_01_31_134832) do
     t.json "pagination_settings", default: {"models"=>true, "creators"=>true, "collections"=>true, "per_page"=>12}
     t.json "renderer_settings", default: {"grid_width"=>200, "grid_depth"=>200}
     t.json "tag_cloud_settings", default: {"threshold"=>0, "heatmap"=>true, "keypair"=>true, "sorting"=>"frequency", "hide_unrelated"=>true}
-    t.json "problem_settings", default: {"missing"=>"danger", "empty"=>"info", "nesting"=>"warning", "inefficient"=>"info", "duplicate"=>"warning"}
+    t.json "problem_settings", default: {"missing"=>"danger", "empty"=>"info", "nesting"=>"warning", "inefficient"=>"info", "duplicate"=>"warning", "no_image"=>"silent", "no_3d_model"=>"silent"}
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end


### PR DESCRIPTION
Resolves #1820 

`bin/dev` wasn't running the full `db:prepare:with_data`, so we weren't spotting that when running migrations in order, from zero, things exploded (see #1820 and #1821).

This PR updates the test setup to replicate the situation so we catch it in future, brings schemas up to date properly, and then fixes the data migration that caused the crash. The crash was because Problem has a default scope that uses `ignored`, and that field doesn't exist yet when an earlier data migration is run. All these changes should stop that happening again.