### PR TITLE
Lint ERB files using erblint

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -30,7 +30,7 @@ linters:
   SpaceIndentation:
     enabled: false
   SpaceInHtmlTag:
-    enabled: false
+    enabled: true
   TrailingWhitespace:
     enabled: true
   # Non-default linters

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -11,7 +11,7 @@ linters:
   CommentSyntax:
     enabled: true
   ExtraNewline:
-    enabled: false
+    enabled: true
   FinalNewline:
     enabled: true
   NoJavascriptTagHelper:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -4,6 +4,7 @@ exclude:
   - "**/vendor/**/*"
   - "**/node_modules/**/*"
 linters:
+  # Default linters
   AllowedScriptType:
     enabled: true
   ClosingErbTagIndent:
@@ -17,8 +18,6 @@ linters:
   NoJavascriptTagHelper:
     enabled: true
   ParserErrors:
-    enabled: false
-  PartialInstanceVariable:
     enabled: false
   RequireInputAutocomplete:
     enabled: false
@@ -34,6 +33,9 @@ linters:
     enabled: false
   TrailingWhitespace:
     enabled: true
+  # Non-default linters
+  PartialInstanceVariable:
+    enabled: false
   DeprecatedClasses:
     enabled: false
   ErbSafety:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -34,8 +34,6 @@ linters:
         Enabled: false
       Layout/DotPosition:
         Enabled: false
-      Style/TernaryParentheses:
-        Enabled: false
       Style/RedundantInterpolation:
         Enabled: false
       Layout/ArgumentAlignment:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -24,8 +24,6 @@ linters:
       Lint/UselessAssignment:
         Enabled: false
       # Temporarily disabled while we fix
-      Style/TrailingCommaInArrayLiteral:
-        Enabled: false
       Layout/FirstArrayElementIndentation:
         Enabled: false
       Layout/ArrayAlignment:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -22,7 +22,7 @@ linters:
   RightTrim:
     enabled: false
   SelfClosingTag:
-    enabled: false
+    enabled: true
   SpaceAroundErbTag:
     enabled: false
   SpaceIndentation:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -28,8 +28,6 @@ linters:
         Enabled: false
       Layout/IndentationWidth:
         Enabled: false
-      Layout/MultilineBlockLayout:
-        Enabled: false
       Layout/MultilineMethodCallIndentation:
         Enabled: false
       I18n/RailsI18n/DecorateString:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -46,8 +46,6 @@ linters:
         Enabled: false
       Layout/EndAlignment:
         Enabled: false
-      Layout/LeadingEmptyLines:
-        Enabled: false
       Layout/FirstArgumentIndentation:
         Enabled: false
       I18n/RailsI18n/DecorateString:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -24,8 +24,6 @@ linters:
       Lint/UselessAssignment:
         Enabled: false
       # Temporarily disabled while we fix
-      Style/StringLiteralsInInterpolation:
-        Enabled: false
       Style/TrailingCommaInArrayLiteral:
         Enabled: false
       Layout/FirstArrayElementIndentation:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -28,8 +28,6 @@ linters:
         Enabled: false
       Layout/ArrayAlignment:
         Enabled: false
-      Layout/DotPosition:
-        Enabled: false
       Layout/ArgumentAlignment:
         Enabled: false
       Layout/FirstHashElementIndentation:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -28,7 +28,7 @@ linters:
   SpaceAroundErbTag:
     enabled: true
   SpaceIndentation:
-    enabled: false
+    enabled: true
   SpaceInHtmlTag:
     enabled: true
   TrailingWhitespace:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,5 +1,8 @@
 ---
 EnableDefaultLinters: false
+exclude:
+  - "**/vendor/**/*"
+  - "**/node_modules/**/*"
 linters:
   AllowedScriptType:
     enabled: false

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,38 +1,9 @@
 ---
-EnableDefaultLinters: false
+EnableDefaultLinters: true
 exclude:
   - "**/vendor/**/*"
   - "**/node_modules/**/*"
 linters:
-  # Default linters
-  AllowedScriptType:
-    enabled: true
-  ClosingErbTagIndent:
-    enabled: true
-  CommentSyntax:
-    enabled: true
-  ExtraNewline:
-    enabled: true
-  FinalNewline:
-    enabled: true
-  NoJavascriptTagHelper:
-    enabled: true
-  ParserErrors:
-    enabled: true
-  RequireInputAutocomplete:
-    enabled: true
-  RightTrim:
-    enabled: true
-  SelfClosingTag:
-    enabled: true
-  SpaceAroundErbTag:
-    enabled: true
-  SpaceIndentation:
-    enabled: true
-  SpaceInHtmlTag:
-    enabled: true
-  TrailingWhitespace:
-    enabled: true
   # Non-default linters
   PartialInstanceVariable:
     enabled: false

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -36,19 +36,9 @@ linters:
         Enabled: false
       Layout/HashAlignment:
         Enabled: false
-      I18n/RailsI18n/DecorateString:
-        Enabled: false
-      I18n/RailsI18n/DecorateStringFormattingUsingInterpolation:
-        Enabled: false
-      Rails/OutputSafety:
-        Enabled: false
       Layout/MultilineMethodCallIndentation:
         Enabled: false
-      Style/QuotedSymbols:
-        Enabled: false
       Layout/BlockAlignment:
-        Enabled: false
-      Style/NestedTernaryOperator:
         Enabled: false
       Layout/IndentationConsistency:
         Enabled: false
@@ -60,15 +50,25 @@ linters:
         Enabled: false
       Layout/EndAlignment:
         Enabled: false
+      Layout/LeadingEmptyLines:
+        Enabled: false
+      Layout/FirstArgumentIndentation:
+        Enabled: false
+      I18n/RailsI18n/DecorateString:
+        Enabled: false
+      I18n/RailsI18n/DecorateStringFormattingUsingInterpolation:
+        Enabled: false
+      Rails/OutputSafety:
+        Enabled: false
       Rails/NegateInclude:
         Enabled: false
-      Layout/LeadingEmptyLines:
+      Style/QuotedSymbols:
+        Enabled: false
+      Style/NestedTernaryOperator:
         Enabled: false
       Style/RedundantConditional:
         Enabled: false
       Style/IfWithBooleanLiteralBranches:
-        Enabled: false
-      Layout/FirstArgumentIndentation:
         Enabled: false
   RequireScriptNonce:
     enabled: true

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -6,11 +6,11 @@ exclude:
 linters:
   # Non-default linters
   PartialInstanceVariable:
-    enabled: false
+    enabled: false # TODO
   DeprecatedClasses:
     enabled: true
   ErbSafety:
-    enabled: false
+    enabled: false # TODO
   Rubocop:
     enabled: true
     rubocop_config:
@@ -23,15 +23,15 @@ linters:
         Enabled: false # We don't need a newline inside every ERB tag!
       # Temporarily disabled while we fix
       Lint/UselessAssignment:
-        Enabled: false
+        Enabled: false # TODO
       I18n/RailsI18n/DecorateString:
-        Enabled: false
+        Enabled: false # TODO
       I18n/RailsI18n/DecorateStringFormattingUsingInterpolation:
-        Enabled: false
+        Enabled: false # TODO
       Rails/OutputSafety:
-        Enabled: false
+        Enabled: false # TODO
       Style/NestedTernaryOperator:
-        Enabled: false
+        Enabled: false # TODO
   RequireScriptNonce:
     enabled: true
   NoUnusedDisable:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -42,8 +42,6 @@ linters:
         Enabled: false
       Rails/OutputSafety:
         Enabled: false
-      Rails/FindEach:
-        Enabled: false
       Layout/MultilineMethodCallIndentation:
         Enabled: false
       Style/QuotedSymbols:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -38,25 +38,13 @@ linters:
         Enabled: false
       Layout/DotPosition:
         Enabled: false
-      Layout/SpaceInsideHashLiteralBraces:
-        Enabled: false
       Style/TernaryParentheses:
         Enabled: false
       Style/RedundantInterpolation:
         Enabled: false
-      Layout/SpaceAfterColon:
-        Enabled: false
       Layout/ArgumentAlignment:
         Enabled: false
-      Layout/SpaceAfterComma:
-        Enabled: false
-      Layout/SpaceBeforeBlockBraces:
-        Enabled: false
       Layout/FirstHashElementIndentation:
-        Enabled: false
-      Layout/SpaceAroundOperators:
-        Enabled: false
-      Layout/ExtraSpacing:
         Enabled: false
       Layout/HashAlignment:
         Enabled: false
@@ -72,13 +60,9 @@ linters:
         Enabled: false
       Style/QuotedSymbols:
         Enabled: false
-      Layout/SpaceInsideParens:
-        Enabled: false
       Layout/BlockAlignment:
         Enabled: false
       Style/NestedTernaryOperator:
-        Enabled: false
-      Layout/SpaceInsideBlockBraces:
         Enabled: false
       Layout/IndentationConsistency:
         Enabled: false

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -24,8 +24,6 @@ linters:
       Lint/UselessAssignment:
         Enabled: false
       # Temporarily disabled while we fix
-      Style/StringLiterals:
-        Enabled: false
       Style/StringLiteralsInInterpolation:
         Enabled: false
       Style/TrailingCommaInArrayLiteral:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -15,7 +15,7 @@ linters:
   FinalNewline:
     enabled: true
   NoJavascriptTagHelper:
-    enabled: false
+    enabled: true
   ParserErrors:
     enabled: false
   PartialInstanceVariable:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -17,6 +17,6 @@ linters:
       inherit_from:
         - .rubocop.yml
   RequireScriptNonce:
-    enabled: false
+    enabled: true
   NoUnusedDisable:
     enabled: true

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,11 +1,39 @@
 ---
-EnableDefaultLinters: true
+EnableDefaultLinters: false
 linters:
+  AllowedScriptType:
+    enabled: false
+  ClosingErbTagIndent:
+    enabled: false
+  CommentSyntax:
+    enabled: false
+  ExtraNewline:
+    enabled: false
+  FinalNewline:
+    enabled: false
+  NoJavascriptTagHelper:
+    enabled: false
+  ParserErrors:
+    enabled: false
+  PartialInstanceVariable:
+    enabled: false
+  RequireInputAutocomplete:
+    enabled: false
+  RightTrim:
+    enabled: false
+  SelfClosingTag:
+    enabled: false
+  SpaceAroundErbTag:
+    enabled: false
+  SpaceIndentation:
+    enabled: false
+  SpaceInHtmlTag:
+    enabled: false
+  TrailingWhitespace:
+    enabled: false
   DeprecatedClasses:
     enabled: false
   ErbSafety:
-    enabled: false
-  PartialInstanceVariable:
     enabled: false
   Rubocop:
     enabled: false

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -40,8 +40,6 @@ linters:
         Enabled: false
       Layout/IndentationConsistency:
         Enabled: false
-      Layout/BlockEndNewline:
-        Enabled: false
       Layout/IndentationWidth:
         Enabled: false
       Layout/MultilineBlockLayout:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -66,8 +66,6 @@ linters:
         Enabled: false
       Style/NestedTernaryOperator:
         Enabled: false
-      Style/RedundantConditional:
-        Enabled: false
   RequireScriptNonce:
     enabled: true
   NoUnusedDisable:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -24,19 +24,21 @@ linters:
       Lint/UselessAssignment:
         Enabled: false
       # Temporarily disabled while we fix
-      Layout/FirstArrayElementIndentation:
+      Layout/ArgumentAlignment:
         Enabled: false
       Layout/ArrayAlignment:
         Enabled: false
-      Layout/ArgumentAlignment:
+      Layout/BlockAlignment:
+        Enabled: false
+      Layout/EndAlignment:
+        Enabled: false
+      Layout/FirstArgumentIndentation:
+        Enabled: false
+      Layout/FirstArrayElementIndentation:
         Enabled: false
       Layout/FirstHashElementIndentation:
         Enabled: false
       Layout/HashAlignment:
-        Enabled: false
-      Layout/MultilineMethodCallIndentation:
-        Enabled: false
-      Layout/BlockAlignment:
         Enabled: false
       Layout/IndentationConsistency:
         Enabled: false
@@ -44,9 +46,7 @@ linters:
         Enabled: false
       Layout/MultilineBlockLayout:
         Enabled: false
-      Layout/EndAlignment:
-        Enabled: false
-      Layout/FirstArgumentIndentation:
+      Layout/MultilineMethodCallIndentation:
         Enabled: false
       I18n/RailsI18n/DecorateString:
         Enabled: false

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -24,12 +24,6 @@ linters:
       Lint/UselessAssignment:
         Enabled: false
       # Temporarily disabled while we fix
-      Layout/FirstArgumentIndentation:
-        Enabled: false
-      Layout/FirstArrayElementIndentation:
-        Enabled: false
-      Layout/FirstHashElementIndentation:
-        Enabled: false
       Layout/IndentationConsistency:
         Enabled: false
       Layout/IndentationWidth:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -1,0 +1,16 @@
+---
+EnableDefaultLinters: true
+linters:
+  DeprecatedClasses:
+    enabled: false
+  ErbSafety:
+    enabled: false
+  PartialInstanceVariable:
+    enabled: false
+  Rubocop:
+    enabled: false
+    rubocop_config:
+      inherit_from:
+        - .rubocop.yml
+  RequireScriptNonce:
+    enabled: false

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -28,8 +28,6 @@ linters:
         Enabled: false
       Layout/IndentationWidth:
         Enabled: false
-      Layout/MultilineMethodCallIndentation:
-        Enabled: false
       I18n/RailsI18n/DecorateString:
         Enabled: false
       I18n/RailsI18n/DecorateStringFormattingUsingInterpolation:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -26,8 +26,6 @@ linters:
       # Temporarily disabled while we fix
       Layout/IndentationConsistency:
         Enabled: false
-      Layout/IndentationWidth:
-        Enabled: false
       I18n/RailsI18n/DecorateString:
         Enabled: false
       I18n/RailsI18n/DecorateStringFormattingUsingInterpolation:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -62,8 +62,6 @@ linters:
         Enabled: false
       Rails/NegateInclude:
         Enabled: false
-      Style/QuotedSymbols:
-        Enabled: false
       Style/NestedTernaryOperator:
         Enabled: false
   RequireScriptNonce:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -18,12 +18,12 @@ linters:
         - .rubocop.yml
       # Disable unhelpful rules for ERB templates
       Layout/InitialIndentation:
-        Enabled: false
+        Enabled: false # ERB tags start at unusual indentations
       Layout/TrailingEmptyLines:
-        Enabled: false
+        Enabled: false # We don't need a newline inside every ERB tag!
+      # Temporarily disabled while we fix
       Lint/UselessAssignment:
         Enabled: false
-      # Temporarily disabled while we fix
       I18n/RailsI18n/DecorateString:
         Enabled: false
       I18n/RailsI18n/DecorateStringFormattingUsingInterpolation:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -5,7 +5,7 @@ exclude:
   - "**/node_modules/**/*"
 linters:
   AllowedScriptType:
-    enabled: false
+    enabled: true
   ClosingErbTagIndent:
     enabled: false
   CommentSyntax:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -18,7 +18,7 @@ linters:
   NoJavascriptTagHelper:
     enabled: true
   ParserErrors:
-    enabled: false
+    enabled: true
   RequireInputAutocomplete:
     enabled: false
   RightTrim:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -30,7 +30,7 @@ linters:
   SpaceInHtmlTag:
     enabled: false
   TrailingWhitespace:
-    enabled: false
+    enabled: true
   DeprecatedClasses:
     enabled: false
   ErbSafety:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -7,7 +7,7 @@ linters:
   AllowedScriptType:
     enabled: true
   ClosingErbTagIndent:
-    enabled: false
+    enabled: true
   CommentSyntax:
     enabled: true
   ExtraNewline:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -6,11 +6,11 @@ linters:
   ClosingErbTagIndent:
     enabled: false
   CommentSyntax:
-    enabled: false
+    enabled: true
   ExtraNewline:
     enabled: false
   FinalNewline:
-    enabled: false
+    enabled: true
   NoJavascriptTagHelper:
     enabled: false
   ParserErrors:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -60,8 +60,6 @@ linters:
         Enabled: false
       Rails/OutputSafety:
         Enabled: false
-      Rails/NegateInclude:
-        Enabled: false
       Style/NestedTernaryOperator:
         Enabled: false
   RequireScriptNonce:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -8,7 +8,7 @@ linters:
   PartialInstanceVariable:
     enabled: false
   DeprecatedClasses:
-    enabled: false
+    enabled: true
   ErbSafety:
     enabled: false
   Rubocop:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -34,8 +34,6 @@ linters:
         Enabled: false
       Layout/DotPosition:
         Enabled: false
-      Style/RedundantInterpolation:
-        Enabled: false
       Layout/ArgumentAlignment:
         Enabled: false
       Layout/FirstHashElementIndentation:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -20,7 +20,7 @@ linters:
   ParserErrors:
     enabled: true
   RequireInputAutocomplete:
-    enabled: false
+    enabled: true
   RightTrim:
     enabled: false
   SelfClosingTag:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -62,8 +62,6 @@ linters:
         Enabled: false
       Rails/NegateInclude:
         Enabled: false
-      Layout/TrailingWhitespace:
-        Enabled: false
       Layout/LeadingEmptyLines:
         Enabled: false
       Style/RedundantConditional:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -26,7 +26,7 @@ linters:
   SelfClosingTag:
     enabled: true
   SpaceAroundErbTag:
-    enabled: false
+    enabled: true
   SpaceIndentation:
     enabled: false
   SpaceInHtmlTag:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -45,3 +45,5 @@ linters:
         - .rubocop.yml
   RequireScriptNonce:
     enabled: false
+  NoUnusedDisable:
+    enabled: true

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -24,8 +24,6 @@ linters:
       Lint/UselessAssignment:
         Enabled: false
       # Temporarily disabled while we fix
-      Layout/IndentationConsistency:
-        Enabled: false
       I18n/RailsI18n/DecorateString:
         Enabled: false
       I18n/RailsI18n/DecorateStringFormattingUsingInterpolation:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -24,21 +24,11 @@ linters:
       Lint/UselessAssignment:
         Enabled: false
       # Temporarily disabled while we fix
-      Layout/ArgumentAlignment:
-        Enabled: false
-      Layout/ArrayAlignment:
-        Enabled: false
-      Layout/BlockAlignment:
-        Enabled: false
-      Layout/EndAlignment:
-        Enabled: false
       Layout/FirstArgumentIndentation:
         Enabled: false
       Layout/FirstArrayElementIndentation:
         Enabled: false
       Layout/FirstHashElementIndentation:
-        Enabled: false
-      Layout/HashAlignment:
         Enabled: false
       Layout/IndentationConsistency:
         Enabled: false

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -68,8 +68,6 @@ linters:
         Enabled: false
       Style/RedundantConditional:
         Enabled: false
-      Style/IfWithBooleanLiteralBranches:
-        Enabled: false
   RequireScriptNonce:
     enabled: true
   NoUnusedDisable:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -12,10 +12,96 @@ linters:
   ErbSafety:
     enabled: false
   Rubocop:
-    enabled: false
+    enabled: true
     rubocop_config:
       inherit_from:
         - .rubocop.yml
+      # Disable unhelpful rules for ERB templates
+      Layout/InitialIndentation:
+        Enabled: false
+      Layout/TrailingEmptyLines:
+        Enabled: false
+      Lint/UselessAssignment:
+        Enabled: false
+      # Temporarily disabled while we fix
+      Style/HashSyntax:
+        Enabled: false
+      Style/StringLiterals:
+        Enabled: false
+      Style/StringLiteralsInInterpolation:
+        Enabled: false
+      Style/TrailingCommaInArrayLiteral:
+        Enabled: false
+      Layout/FirstArrayElementIndentation:
+        Enabled: false
+      Layout/ArrayAlignment:
+        Enabled: false
+      Layout/DotPosition:
+        Enabled: false
+      Layout/SpaceInsideHashLiteralBraces:
+        Enabled: false
+      Style/TernaryParentheses:
+        Enabled: false
+      Style/RedundantInterpolation:
+        Enabled: false
+      Layout/SpaceAfterColon:
+        Enabled: false
+      Layout/ArgumentAlignment:
+        Enabled: false
+      Layout/SpaceAfterComma:
+        Enabled: false
+      Layout/SpaceBeforeBlockBraces:
+        Enabled: false
+      Layout/FirstHashElementIndentation:
+        Enabled: false
+      Layout/SpaceAroundOperators:
+        Enabled: false
+      Layout/ExtraSpacing:
+        Enabled: false
+      Layout/HashAlignment:
+        Enabled: false
+      I18n/RailsI18n/DecorateString:
+        Enabled: false
+      I18n/RailsI18n/DecorateStringFormattingUsingInterpolation:
+        Enabled: false
+      Rails/OutputSafety:
+        Enabled: false
+      Rails/FindEach:
+        Enabled: false
+      Layout/MultilineMethodCallIndentation:
+        Enabled: false
+      Style/QuotedSymbols:
+        Enabled: false
+      Layout/SpaceInsideParens:
+        Enabled: false
+      Layout/BlockAlignment:
+        Enabled: false
+      Style/NestedTernaryOperator:
+        Enabled: false
+      Layout/SpaceInsideBlockBraces:
+        Enabled: false
+      Layout/IndentationConsistency:
+        Enabled: false
+      Layout/BlockEndNewline:
+        Enabled: false
+      Layout/IndentationWidth:
+        Enabled: false
+      Layout/MultilineBlockLayout:
+        Enabled: false
+      Layout/EndAlignment:
+        Enabled: false
+      Rails/NegateInclude:
+        Enabled: false
+      Layout/TrailingWhitespace:
+        Enabled: false
+      Layout/LeadingEmptyLines:
+        Enabled: false
+      Style/RedundantConditional:
+        Enabled: false
+      Style/IfWithBooleanLiteralBranches:
+        Enabled: false
+      Layout/FirstArgumentIndentation:
+        Enabled: false
   RequireScriptNonce:
     enabled: true
   NoUnusedDisable:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -24,8 +24,6 @@ linters:
       Lint/UselessAssignment:
         Enabled: false
       # Temporarily disabled while we fix
-      Style/HashSyntax:
-        Enabled: false
       Style/StringLiterals:
         Enabled: false
       Style/StringLiteralsInInterpolation:

--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -22,7 +22,7 @@ linters:
   RequireInputAutocomplete:
     enabled: true
   RightTrim:
-    enabled: false
+    enabled: true
   SelfClosingTag:
     enabled: true
   SpaceAroundErbTag:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -57,5 +57,7 @@ jobs:
         run: yarn install
       - name: Lint Ruby code
         run: bundle exec rake rubocop
+      - name: Lint ERB templates
+        run: bundle exec erblint --lint-all
       - name: Lint Typescript code
         run: yarn run lint:ts

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,4 +2,5 @@
 . "$(dirname "$0")/_/husky.sh"
 
 bundle exec rake rubocop:autocorrect
+bundle exec erblint --lint-all
 yarn run lint:ts

--- a/Gemfile
+++ b/Gemfile
@@ -108,3 +108,5 @@ gem "spdx", "~> 4.1"
 gem "rack-contrib", "~> 2.4"
 
 gem "rails-i18n", "~> 7.0"
+
+gem "erb_lint", "~> 0.5.0", group: :development, require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -147,6 +147,13 @@ GEM
     dotenv-rails (2.8.1)
       dotenv (= 2.8.1)
       railties (>= 3.2)
+    erb_lint (0.5.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop
+      smart_properties
     erubi (1.12.0)
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
@@ -507,6 +514,7 @@ DEPENDENCIES
   delayed_job_active_record (~> 4.1)
   devise (~> 4.9)
   dotenv-rails (~> 2.8)
+  erb_lint (~> 0.5.0)
   factory_bot
   faker (~> 3.2)
   ffi-libarchive (~> 1.1)

--- a/README.md
+++ b/README.md
@@ -53,9 +53,11 @@ To run the application once you've cloned this repo, you should be able to just 
 ![Code Climate maintainability](https://img.shields.io/codeclimate/maintainability/manyfold3d/manyfold)
 ![Code Climate technical debt](https://img.shields.io/codeclimate/tech-debt/manyfold3d/manyfold)
 
-We use [Rubocop](https://rubocop.org/) to monitor adherence to coding standards. We use [StandardRB](https://github.com/standardrb/standard) rules along with some other rulesets for specific libraries and frameworks.
+We use [Rubocop](https://rubocop.org/) to monitor adherence to coding standards in Ruby code. We use [StandardRB](https://github.com/standardrb/standard) rules along with some other rulesets for specific libraries and frameworks.
 
 You can run the linter with `bundle exec rubocop`.
+
+We also have linters for ERB and Typescript files. You can run these with: `bundle exec erblint --lint-all` and `yarn run lint:ts` respectively.
 
 Code linting is automatically performed by our GitHub Actions test runners, but if you set up [Husky](https://typicode.github.io/husky/get-started.html), it will also execute as a pre-commit hook.
 

--- a/app/components/model_component.html.erb
+++ b/app/components/model_component.html.erb
@@ -6,7 +6,7 @@
         <%= image_tag library_model_model_file_path(@model.library, @model, file, format: file.extension), class: "card-img-top image-preview ", alt: file.name %>
       <% elsif helpers.renderable?(file.extension) %>
         <div class="card-img-top">
-          <%= render partial: "object_preview", locals: { library: @model.library, model: @model, file: file } %>
+          <%= render partial: "object_preview", locals: {library: @model.library, model: @model, file: file} %>
         </div>
       <% end %>
        <% else %>
@@ -31,15 +31,15 @@
           <small>
             <% if @creator.nil? && @model.creator %>
               <%= helpers.icon "person", "Creator" %>
-              <%= link_to @model.creator.name, models_path((@filters||{}).merge(creator: @model.creator)) %><br>
+              <%= link_to @model.creator.name, models_path((@filters || {}).merge(creator: @model.creator)) %><br>
             <% end %>
             <% if @model.collection %>
               <%= helpers.icon "collection", "Collection" %>
-              <%= link_to @model.collection.name, models_path((@filters||{}).merge(collection: @model.collection.id)) %><br>
+              <%= link_to @model.collection.name, models_path((@filters || {}).merge(collection: @model.collection.id)) %><br>
             <% end %>
             <% if @library.nil? && @model.library %>
               <%= helpers.icon "boxes", "Library" %>
-              <%= link_to @model.library.name, models_path((@filters||{}).merge(library: @model.library)) %><br>
+              <%= link_to @model.library.name, models_path((@filters || {}).merge(library: @model.library)) %><br>
             <% end %>
             <% if @model.caption %>
               <p class="card-text"><%= sanitize @model.caption %></p>

--- a/app/components/model_component.html.erb
+++ b/app/components/model_component.html.erb
@@ -31,15 +31,15 @@
           <small>
             <% if @creator.nil? && @model.creator %>
               <%= helpers.icon "person", "Creator" %>
-              <%= link_to @model.creator.name, models_path((@filters||{}).merge(creator: @model.creator)) %><br/>
+              <%= link_to @model.creator.name, models_path((@filters||{}).merge(creator: @model.creator)) %><br>
             <% end %>
             <% if @model.collection %>
               <%= helpers.icon "collection", "Collection" %>
-              <%= link_to @model.collection.name, models_path((@filters||{}).merge(collection: @model.collection.id)) %><br/>
+              <%= link_to @model.collection.name, models_path((@filters||{}).merge(collection: @model.collection.id)) %><br>
             <% end %>
             <% if @library.nil? && @model.library %>
               <%= helpers.icon "boxes", "Library" %>
-              <%= link_to @model.library.name, models_path((@filters||{}).merge(library: @model.library)) %><br/>
+              <%= link_to @model.library.name, models_path((@filters||{}).merge(library: @model.library)) %><br>
             <% end %>
             <% if @model.caption %>
               <p class="card-text"><%= sanitize @model.caption %></p>

--- a/app/views/application/_content_header.html.erb
+++ b/app/views/application/_content_header.html.erb
@@ -2,8 +2,8 @@
   <div class="row row-cols-2 align-items-baseline">
     <% if !current_page?(root_path) %>
       <div class="ms-auto col col-auto mt-2 mb-2">
-        <%= link_to "#{icon('book','Sort by Name')}".html_safe,@filters.merge(order: "name"), class: "btn #{session["order"] == "name" ? "btn-secondary" : "btn-outline-secondary"} btn-sm"  %>
-        <%= link_to "#{icon('clock','Sort by Time')}".html_safe,@filters.merge(order: "recent"), class: "btn #{session["order"] == "recent" ? "btn-secondary" : "btn-outline-secondary"} btn-sm"  %>
+        <%= link_to "#{icon('book','Sort by Name')}".html_safe,@filters.merge(order: "name"), class: "btn #{session["order"] == "name" ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
+        <%= link_to "#{icon('clock','Sort by Time')}".html_safe,@filters.merge(order: "recent"), class: "btn #{session["order"] == "recent" ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
       </div>
     <% end %>
   </div>

--- a/app/views/application/_content_header.html.erb
+++ b/app/views/application/_content_header.html.erb
@@ -2,8 +2,8 @@
   <div class="row row-cols-2 align-items-baseline">
     <% if !current_page?(root_path) %>
       <div class="ms-auto col col-auto mt-2 mb-2">
-        <%= link_to "#{icon('book', 'Sort by Name')}".html_safe, @filters.merge(order: "name"), class: "btn #{session["order"] == "name" ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
-        <%= link_to "#{icon('clock', 'Sort by Time')}".html_safe, @filters.merge(order: "recent"), class: "btn #{session["order"] == "recent" ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
+        <%= link_to "#{icon('book', 'Sort by Name')}".html_safe, @filters.merge(order: "name"), class: "btn #{(session["order"] == "name") ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
+        <%= link_to "#{icon('clock', 'Sort by Time')}".html_safe, @filters.merge(order: "recent"), class: "btn #{(session["order"] == "recent") ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
       </div>
     <% end %>
   </div>

--- a/app/views/application/_content_header.html.erb
+++ b/app/views/application/_content_header.html.erb
@@ -2,8 +2,8 @@
   <div class="row row-cols-2 align-items-baseline">
     <% if !current_page?(root_path) %>
       <div class="ms-auto col col-auto mt-2 mb-2">
-        <%= link_to "#{icon('book','Sort by Name')}".html_safe,@filters.merge(order: "name"), class: "btn #{session["order"] == "name" ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
-        <%= link_to "#{icon('clock','Sort by Time')}".html_safe,@filters.merge(order: "recent"), class: "btn #{session["order"] == "recent" ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
+        <%= link_to "#{icon('book', 'Sort by Name')}".html_safe, @filters.merge(order: "name"), class: "btn #{session["order"] == "name" ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
+        <%= link_to "#{icon('clock', 'Sort by Time')}".html_safe, @filters.merge(order: "recent"), class: "btn #{session["order"] == "recent" ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
       </div>
     <% end %>
   </div>

--- a/app/views/application/_content_header.html.erb
+++ b/app/views/application/_content_header.html.erb
@@ -2,8 +2,8 @@
   <div class="row row-cols-2 align-items-baseline">
     <% if !current_page?(root_path) %>
       <div class="ms-auto col col-auto mt-2 mb-2">
-        <%= link_to "#{icon('book', 'Sort by Name')}".html_safe, @filters.merge(order: "name"), class: "btn #{(session["order"] == "name") ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
-        <%= link_to "#{icon('clock', 'Sort by Time')}".html_safe, @filters.merge(order: "recent"), class: "btn #{(session["order"] == "recent") ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
+        <%= link_to icon("book", "Sort by Name").to_s.html_safe, @filters.merge(order: "name"), class: "btn #{(session["order"] == "name") ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
+        <%= link_to icon("clock", "Sort by Time").to_s.html_safe, @filters.merge(order: "recent"), class: "btn #{(session["order"] == "recent") ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
       </div>
     <% end %>
   </div>

--- a/app/views/application/_filters_card.html.erb
+++ b/app/views/application/_filters_card.html.erb
@@ -32,7 +32,7 @@
       <% if @filters[:tag] %>
         <tr>
           <td><%= icon "tag", "Tags" %> Tags</td>
-          <td><span class='pe-none'><%= render partial: 'tag', collection: @tag, locals: {state: :normal} %></span></td>
+          <td><span class='pe-none'><%= render partial: "tag", collection: @tag, locals: {state: :normal} %></span></td>
           <td><%= link_to icon("trash", "Remove filter"), @filters.except(:tag), {class: "text-danger"} %></td>
         </tr>
       <% end %>

--- a/app/views/application/_filters_card.html.erb
+++ b/app/views/application/_filters_card.html.erb
@@ -18,7 +18,7 @@
       <% if @filters[:library] %>
         <tr>
           <td><%= icon "boxes", "Library" %> Library</td>
-          <td><%= [*@filters[:library]].map{ |l| Library.find(l).name }.join(", ") %></td>
+          <td><%= [*@filters[:library]].map { |l| Library.find(l).name }.join(", ") %></td>
           <td><%= link_to icon("trash", "Remove filter"), @filters.except(:library), {class: "text-danger"} %></td>
         </tr>
       <% end %>
@@ -39,7 +39,7 @@
       <% if @filters[:missingtag] %>
         <tr>
           <td><%= icon "tag", "Missing Tags" %> Missing Tags</td>
-          <td><span class='pe-none'><%= content_tag(:a, @filters[:missingtag].presence || "*", { class: "badge rounded-pill border border-muted text-danger tag" }) %></span></td>
+          <td><span class='pe-none'><%= content_tag(:a, @filters[:missingtag].presence || "*", {class: "badge rounded-pill border border-muted text-danger tag"}) %></span></td>
           <td><%= link_to icon("trash", "Remove filter"), @filters.except(:missingtag), {class: "text-danger"} %></td>
         </tr>
       <% end %>

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -8,7 +8,7 @@
       <ul class="list-unstyled small text-muted">
         <li class="mb-2">Designed and built by <a href="https://floppy.org.uk">James</a> with help from <a href="https://github.com/manyfold3d/manyfold/graphs/contributors">our contributors</a>.</li>
         <li class="mb-2">Open Source under the <a href="https://github.com/manyfold3d/manyfold/blob/main/LICENSE.md" target="_blank" rel="license noopener">MIT license</a>.</li>
-        <li class="mb-2">Version: <%= link_to "#{ENV.fetch("APP_VERSION", "unknown").split(":")[-1]} (#{ENV.fetch("GIT_SHA", "main")[0,7]})",
+        <li class="mb-2">Version: <%= link_to "#{ENV.fetch("APP_VERSION", "unknown").split(":")[-1]} (#{ENV.fetch("GIT_SHA", "main")[0, 7]})",
           "https://github.com/manyfold3d/manyfold/tree/#{ENV.fetch("GIT_SHA", "main")}" %>
         </li>
       </ul>

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -1,40 +1,40 @@
 <footer class="mt-5 py-2 border-top">
-	<div class="row">
-		<div class="col-lg-3 me-auto">
-			<span class="d-inline-flex align-items-center mb-2">
-				<%= image_tag 'logo.png', width: 48, height: 48, class: "me-2", alt: "Logo" %>
-				<span class="fs-5"><%= t "application.title" %></span>
-			</span>
-			<ul class="list-unstyled small text-muted">
-				<li class="mb-2">Designed and built by <a href="https://floppy.org.uk">James</a> with help from <a href="https://github.com/manyfold3d/manyfold/graphs/contributors">our contributors</a>.</li>
-				<li class="mb-2">Open Source under the <a href="https://github.com/manyfold3d/manyfold/blob/main/LICENSE.md" target="_blank" rel="license noopener">MIT license</a>.</li>
-				<li class="mb-2">Version: <%= link_to "#{ENV.fetch("APP_VERSION", "unknown").split(":")[-1]} (#{ENV.fetch("GIT_SHA", "main")[0,7]})",
-					"https://github.com/manyfold3d/manyfold/tree/#{ENV.fetch("GIT_SHA", "main")}" %>
-				</li>
-			</ul>
-		</div>
-		<div class="col-4 col-lg-2 mb-3">
-			<h5>Stats</h5>
-			<ul class="list-unstyled">
-				<li class="mb-2"><%= "#{Library.count} library".pluralize(Library.count) %></li>
-				<li class="mb-2"><%= "#{Model.count} model".pluralize(Model.count) %></li>
-				<li class="mb-2"><%= "#{ModelFile.count} file".pluralize(ModelFile.count) %></li>
-			</ul>
-		</div>
-		<div class="col-4 col-lg-2 mb-3">
-			<h5>Development</h5>
-			<ul class="list-unstyled">
-				<li class="mb-2"><a href="https://github.com/manyfold3d/manyfold">Code</a></li>
-				<li class="mb-2"><a href="https://github.com/manyfold3d/manyfold/issues">Issues</a></li>
-			</ul>
-		</div>
-		<div class="col-4 col-lg-2 mb-3">
-			<h5>Community</h5>
-			<ul class="list-unstyled">
-				<li class="mb-2"><a href="https://matrix.to/#/#manyfold:one.ems.host">Chat</a></li>
-				<li class="mb-2"><a href="https://3dp.chat/@manyfold">Social</a></li>
-				<li class="mb-2"><a href="https://opencollective.com/manyfold">Sponsor</a></li>
-			</ul>
-		</div>
-	</div>
+  <div class="row">
+    <div class="col-lg-3 me-auto">
+      <span class="d-inline-flex align-items-center mb-2">
+        <%= image_tag 'logo.png', width: 48, height: 48, class: "me-2", alt: "Logo" %>
+        <span class="fs-5"><%= t "application.title" %></span>
+      </span>
+      <ul class="list-unstyled small text-muted">
+        <li class="mb-2">Designed and built by <a href="https://floppy.org.uk">James</a> with help from <a href="https://github.com/manyfold3d/manyfold/graphs/contributors">our contributors</a>.</li>
+        <li class="mb-2">Open Source under the <a href="https://github.com/manyfold3d/manyfold/blob/main/LICENSE.md" target="_blank" rel="license noopener">MIT license</a>.</li>
+        <li class="mb-2">Version: <%= link_to "#{ENV.fetch("APP_VERSION", "unknown").split(":")[-1]} (#{ENV.fetch("GIT_SHA", "main")[0,7]})",
+          "https://github.com/manyfold3d/manyfold/tree/#{ENV.fetch("GIT_SHA", "main")}" %>
+        </li>
+      </ul>
+    </div>
+    <div class="col-4 col-lg-2 mb-3">
+      <h5>Stats</h5>
+      <ul class="list-unstyled">
+        <li class="mb-2"><%= "#{Library.count} library".pluralize(Library.count) %></li>
+        <li class="mb-2"><%= "#{Model.count} model".pluralize(Model.count) %></li>
+        <li class="mb-2"><%= "#{ModelFile.count} file".pluralize(ModelFile.count) %></li>
+      </ul>
+    </div>
+    <div class="col-4 col-lg-2 mb-3">
+      <h5>Development</h5>
+      <ul class="list-unstyled">
+        <li class="mb-2"><a href="https://github.com/manyfold3d/manyfold">Code</a></li>
+        <li class="mb-2"><a href="https://github.com/manyfold3d/manyfold/issues">Issues</a></li>
+      </ul>
+    </div>
+    <div class="col-4 col-lg-2 mb-3">
+      <h5>Community</h5>
+      <ul class="list-unstyled">
+        <li class="mb-2"><a href="https://matrix.to/#/#manyfold:one.ems.host">Chat</a></li>
+        <li class="mb-2"><a href="https://3dp.chat/@manyfold">Social</a></li>
+        <li class="mb-2"><a href="https://opencollective.com/manyfold">Sponsor</a></li>
+      </ul>
+    </div>
+  </div>
 </footer>

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -8,8 +8,9 @@
       <ul class="list-unstyled small text-muted">
         <li class="mb-2">Designed and built by <a href="https://floppy.org.uk">James</a> with help from <a href="https://github.com/manyfold3d/manyfold/graphs/contributors">our contributors</a>.</li>
         <li class="mb-2">Open Source under the <a href="https://github.com/manyfold3d/manyfold/blob/main/LICENSE.md" target="_blank" rel="license noopener">MIT license</a>.</li>
-        <li class="mb-2">Version: <%= link_to "#{ENV.fetch("APP_VERSION", "unknown").split(":")[-1]} (#{ENV.fetch("GIT_SHA", "main")[0, 7]})",
-          "https://github.com/manyfold3d/manyfold/tree/#{ENV.fetch("GIT_SHA", "main")}" %>
+        <li class="mb-2">Version:
+          <%= link_to "#{ENV.fetch("APP_VERSION", "unknown").split(":")[-1]} (#{ENV.fetch("GIT_SHA", "main")[0, 7]})",
+                "https://github.com/manyfold3d/manyfold/tree/#{ENV.fetch("GIT_SHA", "main")}" %>
         </li>
       </ul>
     </div>

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -9,7 +9,7 @@
 				<li class="mb-2">Designed and built by <a href="https://floppy.org.uk">James</a> with help from <a href="https://github.com/manyfold3d/manyfold/graphs/contributors">our contributors</a>.</li>
 				<li class="mb-2">Open Source under the <a href="https://github.com/manyfold3d/manyfold/blob/main/LICENSE.md" target="_blank" rel="license noopener">MIT license</a>.</li>
 				<li class="mb-2">Version: <%= link_to "#{ENV.fetch("APP_VERSION", "unknown").split(":")[-1]} (#{ENV.fetch("GIT_SHA", "main")[0,7]})",
-					"https://github.com/manyfold3d/manyfold/tree/#{ENV.fetch("GIT_SHA", "main")}"%>
+					"https://github.com/manyfold3d/manyfold/tree/#{ENV.fetch("GIT_SHA", "main")}" %>
 				</li>
 			</ul>
 		</div>

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-lg-3 me-auto">
       <span class="d-inline-flex align-items-center mb-2">
-        <%= image_tag 'logo.png', width: 48, height: 48, class: "me-2", alt: "Logo" %>
+        <%= image_tag "logo.png", width: 48, height: 48, class: "me-2", alt: "Logo" %>
         <span class="fs-5"><%= t "application.title" %></span>
       </span>
       <ul class="list-unstyled small text-muted">

--- a/app/views/application/_links_form.html.erb
+++ b/app/views/application/_links_form.html.erb
@@ -1,6 +1,6 @@
 <fieldset id='links'>
   <%= form.fields_for :links do |f| %>
-    <%= render 'link_fields', :f => f %>
+    <%= render 'link_fields', f: f %>
   <% end %>
   <div class="row mb-3">
     <%= tag.div class: "col-auto offset-sm-2 ps-0" do %>

--- a/app/views/application/_links_form.html.erb
+++ b/app/views/application/_links_form.html.erb
@@ -1,10 +1,10 @@
 <fieldset id='links'>
   <%= form.fields_for :links do |f| %>
-    <%= render 'link_fields', f: f %>
+    <%= render "link_fields", f: f %>
   <% end %>
   <div class="row mb-3">
     <%= tag.div class: "col-auto offset-sm-2 ps-0" do %>
-      <%= link_to_add_association 'add another link', form, :links, class: "btn btn-secondary" %>
+      <%= link_to_add_association "add another link", form, :links, class: "btn btn-secondary" %>
     <% end %>
   </div>
 </fieldset>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -18,11 +18,11 @@
         <% Library.find_each do |library| %>
           <li class="nav-item">
             <%= nav_link(
-              library.icon || "boxes",
-              library.name,
-              (@filters || {}).merge({controller: "models", library: library.id}),
-              title: library.caption
-            )	%>
+                  library.icon || "boxes",
+                  library.name,
+                  (@filters || {}).merge({controller: "models", library: library.id}),
+                  title: library.caption
+                )	%>
           </li>
         <% end %>
       </ul>
@@ -52,10 +52,10 @@
         <% if Problem.visible(current_user.problem_settings).count > 0 %>
           <li class="nav-item">
             <%= nav_link "exclamation-triangle-fill",
-              Problem.model_name.human.pluralize,
-              problems_path,
-              icon_style: "link-#{max_problem_severity}",
-              text_style: "d-lg-none" %>
+                  Problem.model_name.human.pluralize,
+                  problems_path,
+                  icon_style: "link-#{max_problem_severity}",
+                  text_style: "d-lg-none" %>
           </li>
         <% end %>
         <li class="nav-item">

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -39,8 +39,7 @@
 					<% else %>
 						<div class="btn-group">
 							<button type="button" data-bs-toggle="dropdown" aria-expanded="false"
-								class="btn btn-warning btn-sm mt-1 dropdown-toggle"
-							>
+								class="btn btn-warning btn-sm mt-1 dropdown-toggle">
 								<%= t ".scan" %>
 							</button>
 							<ul class="dropdown-menu">

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -7,20 +7,20 @@
     <div class="collapse navbar-collapse row" id="navbar">
       <ul class="navbar-nav col-6 ps-4 ps-lg-0 align-self-start">
         <li class="nav-item">
-          <%= nav_link 'box', Model.model_name.human.pluralize, (@filters||{}).merge(controller: 'models') %>
+          <%= nav_link 'box', Model.model_name.human.pluralize, (@filters || {}).merge(controller: 'models') %>
         </li>
         <li class="nav-item">
-          <%= nav_link 'people', Creator.model_name.human.pluralize, (@filters||{}).merge(controller: 'creators') %>
+          <%= nav_link 'people', Creator.model_name.human.pluralize, (@filters || {}).merge(controller: 'creators') %>
         </li>
         <li class="nav-item">
-          <%= nav_link 'collection', Collection.model_name.human.pluralize, (@filters||{}).merge(controller: 'collections') %>
+          <%= nav_link 'collection', Collection.model_name.human.pluralize, (@filters || {}).merge(controller: 'collections') %>
         </li>
         <% Library.all.each do |library| %>
           <li class="nav-item">
             <%= nav_link(
               library.icon || 'boxes',
               library.name,
-              (@filters||{}).merge({controller: 'models', library: library.id}),
+              (@filters || {}).merge({controller: 'models', library: library.id}),
               title: library.caption
             )	%>
           </li>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -7,20 +7,20 @@
     <div class="collapse navbar-collapse row" id="navbar">
       <ul class="navbar-nav col-6 ps-4 ps-lg-0 align-self-start">
         <li class="nav-item">
-          <%= nav_link 'box', Model.model_name.human.pluralize, (@filters || {}).merge(controller: 'models') %>
+          <%= nav_link "box", Model.model_name.human.pluralize, (@filters || {}).merge(controller: "models") %>
         </li>
         <li class="nav-item">
-          <%= nav_link 'people', Creator.model_name.human.pluralize, (@filters || {}).merge(controller: 'creators') %>
+          <%= nav_link "people", Creator.model_name.human.pluralize, (@filters || {}).merge(controller: "creators") %>
         </li>
         <li class="nav-item">
-          <%= nav_link 'collection', Collection.model_name.human.pluralize, (@filters || {}).merge(controller: 'collections') %>
+          <%= nav_link "collection", Collection.model_name.human.pluralize, (@filters || {}).merge(controller: "collections") %>
         </li>
         <% Library.all.each do |library| %>
           <li class="nav-item">
             <%= nav_link(
-              library.icon || 'boxes',
+              library.icon || "boxes",
               library.name,
-              (@filters || {}).merge({controller: 'models', library: library.id}),
+              (@filters || {}).merge({controller: "models", library: library.id}),
               title: library.caption
             )	%>
           </li>
@@ -28,14 +28,14 @@
       </ul>
       <ul class="navbar-nav col-6 pe-4 align-self-start justify-content-end">
         <li class="nav-item">
-          <%= nav_link 'plus-circle', t('libraries.general.new'), new_library_path, text_style: "d-lg-none" %>
+          <%= nav_link "plus-circle", t("libraries.general.new"), new_library_path, text_style: "d-lg-none" %>
         </li>
         <li class="nav-item">
-          <%= nav_link 'upload', t('.upload'), uploads_path, style: "btn btn-warning btn-sm me-1 mt-lg-1 #{policy(:upload).index? ? "" : "disabled"}" %>
+          <%= nav_link "upload", t(".upload"), uploads_path, style: "btn btn-warning btn-sm me-1 mt-lg-1 #{policy(:upload).index? ? "" : "disabled"}" %>
         </li>
         <li class="nav-item">
           <% if @scan_in_progress %>
-            <%= nav_link '', t('.scanning'), '/admin/tasks', style: "btn btn-outline-warning btn-sm me-1 mt-lg-1", icon_style: 'spinner-border spinner-border-sm' %>
+            <%= nav_link "", t(".scanning"), "/admin/tasks", style: "btn btn-outline-warning btn-sm me-1 mt-lg-1", icon_style: "spinner-border spinner-border-sm" %>
           <% else %>
             <div class="btn-group">
               <button type="button" data-bs-toggle="dropdown" aria-expanded="false"
@@ -43,15 +43,15 @@
                 <%= t ".scan" %>
               </button>
               <ul class="dropdown-menu">
-                <li><%= link_to t(".scan_changes"), scan_libraries_path, method: :post, class: 'dropdown-item' %></li>
-                <li><%= link_to t(".check_existing"), scan_libraries_path(type: :check), method: :post, class: 'dropdown-item' %>
+                <li><%= link_to t(".scan_changes"), scan_libraries_path, method: :post, class: "dropdown-item" %></li>
+                <li><%= link_to t(".check_existing"), scan_libraries_path(type: :check), method: :post, class: "dropdown-item" %>
               </ul>
             </div>
           <% end %>
         </li>
         <% if Problem.visible(current_user.problem_settings).count > 0 %>
           <li class="nav-item">
-            <%= nav_link 'exclamation-triangle-fill',
+            <%= nav_link "exclamation-triangle-fill",
               Problem.model_name.human.pluralize,
               problems_path,
               icon_style: "link-#{max_problem_severity}",
@@ -59,7 +59,7 @@
           </li>
         <% end %>
         <li class="nav-item">
-          <%= nav_link 'sliders', "Settings", user_settings_path(current_user), text_style: "d-lg-none" %>
+          <%= nav_link "sliders", "Settings", user_settings_path(current_user), text_style: "d-lg-none" %>
         </li>
         <li class="nav-item">
           <%= form_with url: models_path, method: :get, role: "search" do |f| %>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -1,72 +1,72 @@
 <nav class="navbar navbar-expand-lg bg-body-tertiary">
-	<div class='container-fluid'>
-		<a class="navbar-brand ms-2" href="<%= root_path %>"><%= image_tag "logo.png", alt: t("application.title"), title: t("application.title"), height: "40px", class: "me-2" %> <span class="d-lg-none"><%= t "application.title" %></span></a>
-		<button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
-			<span class="navbar-toggler-icon"></span>
-		</button>
-		<div class="collapse navbar-collapse row" id="navbar">
-			<ul class="navbar-nav col-6 ps-4 ps-lg-0 align-self-start">
-				<li class="nav-item">
-					<%= nav_link 'box', Model.model_name.human.pluralize, (@filters||{}).merge(controller: 'models') %>
-				</li>
-				<li class="nav-item">
-					<%= nav_link 'people', Creator.model_name.human.pluralize, (@filters||{}).merge(controller: 'creators') %>
-				</li>
-				<li class="nav-item">
-					<%= nav_link 'collection', Collection.model_name.human.pluralize, (@filters||{}).merge(controller: 'collections') %>
-				</li>
-				<% Library.all.each do |library| %>
-					<li class="nav-item">
-						<%= nav_link(
-							library.icon || 'boxes',
-							library.name,
-							(@filters||{}).merge({controller: 'models', library: library.id}),
-							title: library.caption
-						)	%>
-					</li>
-				<% end %>
-			</ul>
-			<ul class="navbar-nav col-6 pe-4 align-self-start justify-content-end">
-				<li class="nav-item">
-					<%= nav_link 'plus-circle', t('libraries.general.new'), new_library_path, text_style: "d-lg-none" %>
-				</li>
-				<li class="nav-item">
-					<%= nav_link 'upload', t('.upload'), uploads_path, style: "btn btn-warning btn-sm me-1 mt-lg-1 #{policy(:upload).index? ? "" : "disabled"}" %>
-				</li>
-				<li class="nav-item">
-					<% if @scan_in_progress %>
-						<%= nav_link '', t('.scanning'), '/admin/tasks', style: "btn btn-outline-warning btn-sm me-1 mt-lg-1", icon_style: 'spinner-border spinner-border-sm' %>
-					<% else %>
-						<div class="btn-group">
-							<button type="button" data-bs-toggle="dropdown" aria-expanded="false"
-								class="btn btn-warning btn-sm mt-1 dropdown-toggle">
-								<%= t ".scan" %>
-							</button>
-							<ul class="dropdown-menu">
-								<li><%= link_to t(".scan_changes"), scan_libraries_path, method: :post, class: 'dropdown-item' %></li>
-								<li><%= link_to t(".check_existing"), scan_libraries_path(type: :check), method: :post, class: 'dropdown-item' %>
-							</ul>
-						</div>
-					<% end %>
-				</li>
-				<% if Problem.visible(current_user.problem_settings).count > 0 %>
-					<li class="nav-item">
-						<%= nav_link 'exclamation-triangle-fill',
-							Problem.model_name.human.pluralize,
-							problems_path,
-							icon_style: "link-#{max_problem_severity}",
-							text_style: "d-lg-none" %>
-					</li>
-				<% end %>
-				<li class="nav-item">
-					<%= nav_link 'sliders', "Settings", user_settings_path(current_user), text_style: "d-lg-none" %>
-				</li>
-				<li class="nav-item">
-					<%= form_with url: models_path, method: :get, role: "search" do |f| %>
-						<%= f.search_field :q, class: "form-control ms-1 me-3", placeholder: "Search", aria_label: "Search", aria_describedby: "button-search", value: params[:q], autofocus: true %>
-					<% end %>
-				</li>
-			</ul>
-		</div>
-	</div>
+  <div class='container-fluid'>
+    <a class="navbar-brand ms-2" href="<%= root_path %>"><%= image_tag "logo.png", alt: t("application.title"), title: t("application.title"), height: "40px", class: "me-2" %> <span class="d-lg-none"><%= t "application.title" %></span></a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse row" id="navbar">
+      <ul class="navbar-nav col-6 ps-4 ps-lg-0 align-self-start">
+        <li class="nav-item">
+          <%= nav_link 'box', Model.model_name.human.pluralize, (@filters||{}).merge(controller: 'models') %>
+        </li>
+        <li class="nav-item">
+          <%= nav_link 'people', Creator.model_name.human.pluralize, (@filters||{}).merge(controller: 'creators') %>
+        </li>
+        <li class="nav-item">
+          <%= nav_link 'collection', Collection.model_name.human.pluralize, (@filters||{}).merge(controller: 'collections') %>
+        </li>
+        <% Library.all.each do |library| %>
+          <li class="nav-item">
+            <%= nav_link(
+              library.icon || 'boxes',
+              library.name,
+              (@filters||{}).merge({controller: 'models', library: library.id}),
+              title: library.caption
+            )	%>
+          </li>
+        <% end %>
+      </ul>
+      <ul class="navbar-nav col-6 pe-4 align-self-start justify-content-end">
+        <li class="nav-item">
+          <%= nav_link 'plus-circle', t('libraries.general.new'), new_library_path, text_style: "d-lg-none" %>
+        </li>
+        <li class="nav-item">
+          <%= nav_link 'upload', t('.upload'), uploads_path, style: "btn btn-warning btn-sm me-1 mt-lg-1 #{policy(:upload).index? ? "" : "disabled"}" %>
+        </li>
+        <li class="nav-item">
+          <% if @scan_in_progress %>
+            <%= nav_link '', t('.scanning'), '/admin/tasks', style: "btn btn-outline-warning btn-sm me-1 mt-lg-1", icon_style: 'spinner-border spinner-border-sm' %>
+          <% else %>
+            <div class="btn-group">
+              <button type="button" data-bs-toggle="dropdown" aria-expanded="false"
+                class="btn btn-warning btn-sm mt-1 dropdown-toggle">
+                <%= t ".scan" %>
+              </button>
+              <ul class="dropdown-menu">
+                <li><%= link_to t(".scan_changes"), scan_libraries_path, method: :post, class: 'dropdown-item' %></li>
+                <li><%= link_to t(".check_existing"), scan_libraries_path(type: :check), method: :post, class: 'dropdown-item' %>
+              </ul>
+            </div>
+          <% end %>
+        </li>
+        <% if Problem.visible(current_user.problem_settings).count > 0 %>
+          <li class="nav-item">
+            <%= nav_link 'exclamation-triangle-fill',
+              Problem.model_name.human.pluralize,
+              problems_path,
+              icon_style: "link-#{max_problem_severity}",
+              text_style: "d-lg-none" %>
+          </li>
+        <% end %>
+        <li class="nav-item">
+          <%= nav_link 'sliders', "Settings", user_settings_path(current_user), text_style: "d-lg-none" %>
+        </li>
+        <li class="nav-item">
+          <%= form_with url: models_path, method: :get, role: "search" do |f| %>
+            <%= f.search_field :q, class: "form-control ms-1 me-3", placeholder: "Search", aria_label: "Search", aria_describedby: "button-search", value: params[:q], autofocus: true %>
+          <% end %>
+        </li>
+      </ul>
+    </div>
+  </div>
 </nav>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -15,7 +15,7 @@
         <li class="nav-item">
           <%= nav_link "collection", Collection.model_name.human.pluralize, (@filters || {}).merge(controller: "collections") %>
         </li>
-        <% Library.all.each do |library| %>
+        <% Library.find_each do |library| %>
           <li class="nav-item">
             <%= nav_link(
               library.icon || "boxes",

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -56,8 +56,7 @@
 							Problem.model_name.human.pluralize,
 							problems_path,
 							icon_style: "link-#{max_problem_severity}",
-							text_style: "d-lg-none"
-						%>
+							text_style: "d-lg-none" %>
 					</li>
 				<% end %>
 				<li class="nav-item">

--- a/app/views/application/_object_preview.html.erb
+++ b/app/views/application/_object_preview.html.erb
@@ -10,8 +10,7 @@
     data-background-colour="<%= current_user.renderer_settings["background_colour"] %>"
     data-object-colour="<%= current_user.renderer_settings["object_colour"] %>"
     data-render-style="<%= current_user.renderer_settings["render_style"] %>"
-    data-auto-load="<%= (file.size || 9_999_999.megabytes) < ((current_user.renderer_settings["auto_load_max_size"] || 9_999_999).megabytes) ? true : false %>"
-  >
+    data-auto-load="<%= (file.size || 9_999_999.megabytes) < ((current_user.renderer_settings["auto_load_max_size"] || 9_999_999).megabytes) ? true : false %>">
     <div class="load-progress progress position-absolute top-50 start-50 translate-middle" role="presentation">
       <div class="progress-bar bg-info progress-bar-animated progress-bar-striped" aria-label="Loading progress" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
       <span class="progress-label position-absolute top-50 start-50 translate-middle" role="button">Load (<%= number_to_human_size file.size, precision: 2 %>)</span>

--- a/app/views/application/_object_preview.html.erb
+++ b/app/views/application/_object_preview.html.erb
@@ -10,7 +10,7 @@
     data-background-colour="<%= current_user.renderer_settings["background_colour"] %>"
     data-object-colour="<%= current_user.renderer_settings["object_colour"] %>"
     data-render-style="<%= current_user.renderer_settings["render_style"] %>"
-    data-auto-load="<%= (file.size || 9_999_999.megabytes) < ((current_user.renderer_settings["auto_load_max_size"] || 9_999_999).megabytes) ? true : false %>">
+    data-auto-load="<%= ((file.size || 9_999_999.megabytes) < ((current_user.renderer_settings["auto_load_max_size"] || 9_999_999).megabytes)) ? true : false %>">
     <div class="load-progress progress position-absolute top-50 start-50 translate-middle" role="presentation">
       <div class="progress-bar bg-info progress-bar-animated progress-bar-striped" aria-label="Loading progress" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
       <span class="progress-label position-absolute top-50 start-50 translate-middle" role="button">Load (<%= number_to_human_size file.size, precision: 2 %>)</span>

--- a/app/views/application/_object_preview.html.erb
+++ b/app/views/application/_object_preview.html.erb
@@ -10,7 +10,7 @@
     data-background-colour="<%= current_user.renderer_settings["background_colour"] %>"
     data-object-colour="<%= current_user.renderer_settings["object_colour"] %>"
     data-render-style="<%= current_user.renderer_settings["render_style"] %>"
-    data-auto-load="<%= ((file.size || 9_999_999.megabytes) < ((current_user.renderer_settings["auto_load_max_size"] || 9_999_999).megabytes)) ? true : false %>">
+    data-auto-load="<%= ((file.size || 9_999_999.megabytes) < ((current_user.renderer_settings["auto_load_max_size"] || 9_999_999).megabytes)) ? "true" : "false" %>">
     <div class="load-progress progress position-absolute top-50 start-50 translate-middle" role="presentation">
       <div class="progress-bar bg-info progress-bar-animated progress-bar-striped" aria-label="Loading progress" role="progressbar" style="width: 0%;" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100"></div>
       <span class="progress-label position-absolute top-50 start-50 translate-middle" role="button">Load (<%= number_to_human_size file.size, precision: 2 %>)</span>

--- a/app/views/application/_object_preview.html.erb
+++ b/app/views/application/_object_preview.html.erb
@@ -1,6 +1,6 @@
 <% if renderable?(file.extension) %>
   <div id="preview-file-<%= file.id %>" class="object-preview position-relative" data-preview
-    data-preview-url="<%= library_model_model_file_path(library, model, file, file.extension.to_sym)%>"
+    data-preview-url="<%= library_model_model_file_path(library, model, file, file.extension.to_sym) %>"
     data-format="<%= file.extension %>"
     data-y-up="<%= file.y_up %>"
     data-grid-size-x="<%= current_user.renderer_settings["grid_width"] %>"

--- a/app/views/application/_tag.html.erb
+++ b/app/views/application/_tag.html.erb
@@ -1,7 +1,7 @@
 <%- filters = @filters || {} %>
 <%- filters[:tag] ||= [] %>
 <%=
-  name = current_user.tag_cloud_settings["keypair"] ? tag.name.gsub(/^.*:/,"") : tag.name
+  name = current_user.tag_cloud_settings["keypair"] ? tag.name.gsub(/^.*:/, "") : tag.name
   link_to current_user.tag_cloud_settings["heatmap"] ? "#{name} (#{tag.taggings_count})" : name,
     filters.merge(tag: filters[:tag] | [tag.name]),
     {

--- a/app/views/application/_tag.html.erb
+++ b/app/views/application/_tag.html.erb
@@ -2,8 +2,8 @@
 <%- filters[:tag] ||= [] %>
 <%- name = current_user.tag_cloud_settings["keypair"] ? tag.name.gsub(/^.*:/, "") : tag.name %>
 <%= link_to current_user.tag_cloud_settings["heatmap"] ? "#{name} (#{tag.taggings_count})" : name,
-    filters.merge(tag: filters[:tag] | [tag.name]),
-    {
-      class: "badge rounded-pill #{tag_class(state)} tag",
-      data: {bulk_item_tags: defined?(model_id) ? model_id&.to_s : nil}
-    } %>
+      filters.merge(tag: filters[:tag] | [tag.name]),
+      {
+        class: "badge rounded-pill #{tag_class(state)} tag",
+        data: {bulk_item_tags: defined?(model_id) ? model_id&.to_s : nil}
+      } %>

--- a/app/views/application/_tag.html.erb
+++ b/app/views/application/_tag.html.erb
@@ -1,11 +1,9 @@
 <%- filters = @filters || {} %>
 <%- filters[:tag] ||= [] %>
-<%=
-  name = current_user.tag_cloud_settings["keypair"] ? tag.name.gsub(/^.*:/, "") : tag.name
-  link_to current_user.tag_cloud_settings["heatmap"] ? "#{name} (#{tag.taggings_count})" : name,
+<%- name = current_user.tag_cloud_settings["keypair"] ? tag.name.gsub(/^.*:/, "") : tag.name %>
+<%= link_to current_user.tag_cloud_settings["heatmap"] ? "#{name} (#{tag.taggings_count})" : name,
     filters.merge(tag: filters[:tag] | [tag.name]),
     {
       class: "badge rounded-pill #{tag_class(state)} tag",
       data: {bulk_item_tags: defined?(model_id) ? model_id&.to_s : nil}
-    }
-%>
+    } %>

--- a/app/views/application/_tag_list.html.erb
+++ b/app/views/application/_tag_list.html.erb
@@ -6,7 +6,7 @@
        tierunset = tiers.map { |tier|
          reg = ActiveRecord::Base.connection.quote("^" + tier + ":")
          regact = Rails.env.development? ? "REGEXP" : "~"
-           [tier, @models.where("(select count(*) from tags join taggings on tags.id=taggings.tag_id where tags.name #{regact} #{reg} and taggings.taggable_id=models.id and taggings.taggable_type='Model')<1").count]
+         [tier, @models.where("(select count(*) from tags join taggings on tags.id=taggings.tag_id where tags.name #{regact} #{reg} and taggings.taggable_id=models.id and taggings.taggable_type='Model')<1").count]
        }.to_h
      end %>
   <% tags = plaintags %>

--- a/app/views/application/_tag_list.html.erb
+++ b/app/views/application/_tag_list.html.erb
@@ -1,10 +1,10 @@
 <% if current_user.tag_cloud_settings["keypair"] %>
-  <% plaintags = tags.select{|obj| !obj.name.include?(":") } %>
-  <% tiertags = tags.select{|obj| obj.name.include?(":") } %>
-  <% tiers = tiertags.map(&:name).map {|tag| tag.split(":").first}.uniq.sort %>
+  <% plaintags = tags.select { |obj| !obj.name.include?(":") } %>
+  <% tiertags = tags.select { |obj| obj.name.include?(":") } %>
+  <% tiers = tiertags.map(&:name).map { |tag| tag.split(":").first }.uniq.sort %>
   <% if @models
-        tierunset = tiers.map{|tier|
-        reg=ActiveRecord::Base.connection.quote("^"+tier+":")
+        tierunset = tiers.map { |tier|
+        reg = ActiveRecord::Base.connection.quote("^" + tier + ":")
         regact = Rails.env.development? ? "REGEXP" : "~"
           [tier, @models.where("(select count(*) from tags join taggings on tags.id=taggings.tag_id where tags.name #{regact} #{reg} and taggings.taggable_id=models.id and taggings.taggable_type='Model')<1").count]}.to_h
       end %>
@@ -17,13 +17,13 @@
   <ul class="list-unstyled">
     <% tiers.each do |tier| %>
       <%= content_tag(:li, content_tag(:details,
-        content_tag(:summary,tier)+tiertags.select{|obj| obj.name.match?("^#{tier}:")}
-          .map{|tag| render partial: 'tag', locals: {
+        content_tag(:summary, tier) + tiertags.select { |obj| obj.name.match?("^#{tier}:") }
+          .map { |tag| render partial: 'tag', locals: {
             tag: tag,
             state: (defined?(muted_tags) && muted_tags.include?(tag)) ? (current_user.tag_cloud_settings["hide_unrelated"] ? :hide : :mute) : :normal
-          }}.join.html_safe+
+          }}.join.html_safe +
           ((tierunset && tierunset[tier] > 0) ? (link_to "unset (#{tierunset[tier]})",
-            (@filters||{}).merge(missingtag: tier), { class: "badge rounded-pill border border-muted text-danger tag" }) : ""),
+            (@filters || {}).merge(missingtag: tier), {class: "badge rounded-pill border border-muted text-danger tag"}) : ""),
         id: tier)).html_safe %>
     <% end %>
   </ul>

--- a/app/views/application/_tag_list.html.erb
+++ b/app/views/application/_tag_list.html.erb
@@ -4,9 +4,10 @@
   <% tiers = tiertags.map(&:name).map { |tag| tag.split(":").first }.uniq.sort %>
   <% if @models
         tierunset = tiers.map { |tier|
-        reg = ActiveRecord::Base.connection.quote("^" + tier + ":")
-        regact = Rails.env.development? ? "REGEXP" : "~"
-          [tier, @models.where("(select count(*) from tags join taggings on tags.id=taggings.tag_id where tags.name #{regact} #{reg} and taggings.taggable_id=models.id and taggings.taggable_type='Model')<1").count]}.to_h
+          reg = ActiveRecord::Base.connection.quote("^" + tier + ":")
+          regact = Rails.env.development? ? "REGEXP" : "~"
+            [tier, @models.where("(select count(*) from tags join taggings on tags.id=taggings.tag_id where tags.name #{regact} #{reg} and taggings.taggable_id=models.id and taggings.taggable_type='Model')<1").count]
+        }.to_h
       end %>
   <% tags = plaintags %>
 <% end %>
@@ -21,7 +22,8 @@
           .map { |tag| render partial: "tag", locals: {
             tag: tag,
             state: (defined?(muted_tags) && muted_tags.include?(tag)) ? (current_user.tag_cloud_settings["hide_unrelated"] ? :hide : :mute) : :normal
-          }}.join.html_safe +
+          }
+}.join.html_safe +
           ((tierunset && tierunset[tier] > 0) ? (link_to "unset (#{tierunset[tier]})",
             (@filters || {}).merge(missingtag: tier), {class: "badge rounded-pill border border-muted text-danger tag"}) : ""),
         id: tier)).html_safe %>

--- a/app/views/application/_tag_list.html.erb
+++ b/app/views/application/_tag_list.html.erb
@@ -20,7 +20,8 @@
       <%= content_tag(:li, content_tag(:details,
             content_tag(:summary, tier) +
               tiertags.select { |obj| obj.name.match?("^#{tier}:") }
-                .map { |tag| render partial: "tag", locals: {
+                .map { |tag|
+                render partial: "tag", locals: {
                   tag: tag,
                   state: (defined?(muted_tags) && muted_tags.include?(tag)) ? (current_user.tag_cloud_settings["hide_unrelated"] ? :hide : :mute) : :normal
                 }

--- a/app/views/application/_tag_list.html.erb
+++ b/app/views/application/_tag_list.html.erb
@@ -11,14 +11,14 @@
   <% tags = plaintags %>
 <% end %>
 <% tags.each do |tag| %>
-  <%= render partial: 'tag', locals: {tag: tag, state: (defined?(muted_tags) && muted_tags.include?(tag) ? (current_user.tag_cloud_settings["hide_unrelated"] ? :hide : :mute) : :normal)} %>
+  <%= render partial: "tag", locals: {tag: tag, state: (defined?(muted_tags) && muted_tags.include?(tag) ? (current_user.tag_cloud_settings["hide_unrelated"] ? :hide : :mute) : :normal)} %>
 <% end %>
 <% if current_user.tag_cloud_settings["keypair"] %>
   <ul class="list-unstyled">
     <% tiers.each do |tier| %>
       <%= content_tag(:li, content_tag(:details,
         content_tag(:summary, tier) + tiertags.select { |obj| obj.name.match?("^#{tier}:") }
-          .map { |tag| render partial: 'tag', locals: {
+          .map { |tag| render partial: "tag", locals: {
             tag: tag,
             state: (defined?(muted_tags) && muted_tags.include?(tag)) ? (current_user.tag_cloud_settings["hide_unrelated"] ? :hide : :mute) : :normal
           }}.join.html_safe +

--- a/app/views/application/_tag_list.html.erb
+++ b/app/views/application/_tag_list.html.erb
@@ -8,7 +8,7 @@
           regact = Rails.env.development? ? "REGEXP" : "~"
             [tier, @models.where("(select count(*) from tags join taggings on tags.id=taggings.tag_id where tags.name #{regact} #{reg} and taggings.taggable_id=models.id and taggings.taggable_type='Model')<1").count]
         }.to_h
-      end %>
+     end %>
   <% tags = plaintags %>
 <% end %>
 <% tags.each do |tag| %>
@@ -18,15 +18,16 @@
   <ul class="list-unstyled">
     <% tiers.each do |tier| %>
       <%= content_tag(:li, content_tag(:details,
-        content_tag(:summary, tier) + tiertags.select { |obj| obj.name.match?("^#{tier}:") }
-          .map { |tag| render partial: "tag", locals: {
-            tag: tag,
-            state: (defined?(muted_tags) && muted_tags.include?(tag)) ? (current_user.tag_cloud_settings["hide_unrelated"] ? :hide : :mute) : :normal
-          }
-}.join.html_safe +
-          ((tierunset && tierunset[tier] > 0) ? (link_to "unset (#{tierunset[tier]})",
-            (@filters || {}).merge(missingtag: tier), {class: "badge rounded-pill border border-muted text-danger tag"}) : ""),
-        id: tier)).html_safe %>
+            content_tag(:summary, tier) +
+              tiertags.select { |obj| obj.name.match?("^#{tier}:") }
+                .map { |tag| render partial: "tag", locals: {
+                  tag: tag,
+                  state: (defined?(muted_tags) && muted_tags.include?(tag)) ? (current_user.tag_cloud_settings["hide_unrelated"] ? :hide : :mute) : :normal
+                }
+              }.join.html_safe +
+              ((tierunset && tierunset[tier] > 0) ? (link_to "unset (#{tierunset[tier]})",
+                (@filters || {}).merge(missingtag: tier), {class: "badge rounded-pill border border-muted text-danger tag"}) : ""),
+            id: tier)).html_safe %>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/application/_tag_list.html.erb
+++ b/app/views/application/_tag_list.html.erb
@@ -3,11 +3,11 @@
   <% tiertags = tags.select { |obj| obj.name.include?(":") } %>
   <% tiers = tiertags.map(&:name).map { |tag| tag.split(":").first }.uniq.sort %>
   <% if @models
-        tierunset = tiers.map { |tier|
-          reg = ActiveRecord::Base.connection.quote("^" + tier + ":")
-          regact = Rails.env.development? ? "REGEXP" : "~"
-            [tier, @models.where("(select count(*) from tags join taggings on tags.id=taggings.tag_id where tags.name #{regact} #{reg} and taggings.taggable_id=models.id and taggings.taggable_type='Model')<1").count]
-        }.to_h
+       tierunset = tiers.map { |tier|
+         reg = ActiveRecord::Base.connection.quote("^" + tier + ":")
+         regact = Rails.env.development? ? "REGEXP" : "~"
+           [tier, @models.where("(select count(*) from tags join taggings on tags.id=taggings.tag_id where tags.name #{regact} #{reg} and taggings.taggable_id=models.id and taggings.taggable_type='Model')<1").count]
+       }.to_h
      end %>
   <% tags = plaintags %>
 <% end %>

--- a/app/views/application/_tag_list.html.erb
+++ b/app/views/application/_tag_list.html.erb
@@ -11,7 +11,7 @@
   <% tags = plaintags %>
 <% end %>
 <% tags.each do |tag| %>
-  <%= render partial: "tag", locals: {tag: tag, state: (defined?(muted_tags) && muted_tags.include?(tag) ? (current_user.tag_cloud_settings["hide_unrelated"] ? :hide : :mute) : :normal)} %>
+  <%= render partial: "tag", locals: {tag: tag, state: ((defined?(muted_tags) && muted_tags.include?(tag)) ? (current_user.tag_cloud_settings["hide_unrelated"] ? :hide : :mute) : :normal)} %>
 <% end %>
 <% if current_user.tag_cloud_settings["keypair"] %>
   <ul class="list-unstyled">

--- a/app/views/application/_tag_list.html.erb
+++ b/app/views/application/_tag_list.html.erb
@@ -1,5 +1,5 @@
 <% if current_user.tag_cloud_settings["keypair"] %>
-  <% plaintags = tags.select { |obj| !obj.name.include?(":") } %>
+  <% plaintags = tags.select { |obj| obj.name.exclude?(":") } %>
   <% tiertags = tags.select { |obj| obj.name.include?(":") } %>
   <% tiers = tiertags.map(&:name).map { |tag| tag.split(":").first }.uniq.sort %>
   <% if @models

--- a/app/views/application/_tag_list.html.erb
+++ b/app/views/application/_tag_list.html.erb
@@ -2,7 +2,7 @@
   <% plaintags = tags.select{|obj| !obj.name.include?(":") } %>
   <% tiertags = tags.select{|obj| obj.name.include?(":") } %>
   <% tiers = tiertags.map(&:name).map {|tag| tag.split(":").first}.uniq.sort %>
-  <%  if @models
+  <% if @models
         tierunset = tiers.map{|tier|
         reg=ActiveRecord::Base.connection.quote("^"+tier+":")
         regact = Rails.env.development? ? "REGEXP" : "~"
@@ -28,6 +28,6 @@
     <% end %>
   </ul>
 <% end %>
-<% if defined?(muted_tags) && !muted_tags.empty? && current_user.tag_cloud_settings["hide_unrelated"]%>
+<% if defined?(muted_tags) && !muted_tags.empty? && current_user.tag_cloud_settings["hide_unrelated"] %>
   <p class="small"><%= pluralize(muted_tags.count, "unrelated tag") %> hidden</p>
 <% end %>

--- a/app/views/collections/_collection.html.erb
+++ b/app/views/collections/_collection.html.erb
@@ -12,13 +12,13 @@
         </div>
       <% end %>
        <% else %>
-       <div class='preview-empty'> <p><%= t '.no_preview' %></p></div>
+       <div class='preview-empty'> <p><%= t ".no_preview" %></p></div>
     <% end %>
     <div class="card-body">
       <h5 class="card-title"><%= collection.name.titleize %></h5>
       <div class="col-auto">
         <% if collection.collection %>
-          <%= icon "collection", t('activerecord.models.collection') %>
+          <%= icon "collection", t("activerecord.models.collection") %>
           <%= link_to collection.collection.name, (@filters || {}).merge(collection: collection.collection.id) %><br>
         <% end %>
         <% if collection.caption %>
@@ -34,9 +34,9 @@
         </ul>
       </div>
       <div>
-        <%= link_to pluralize(collection.models.count, t('activerecord.models.model')), {controller: 'models', collection: collection.id}, class: "btn btn-primary" %>
-        <%= link_to(pluralize(collection.collections.count, t('activerecord.models.collection')), (@filters || {}).merge(controller: 'collections', collection: collection.id), class: "btn btn-primary") if collection.collections.count > 0 %>
-        <%= link_to t('general.edit'), edit_collection_path(collection), {class: "btn btn-outline-secondary"} %>
+        <%= link_to pluralize(collection.models.count, t("activerecord.models.model")), {controller: "models", collection: collection.id}, class: "btn btn-primary" %>
+        <%= link_to(pluralize(collection.collections.count, t("activerecord.models.collection")), (@filters || {}).merge(controller: "collections", collection: collection.id), class: "btn btn-primary") if collection.collections.count > 0 %>
+        <%= link_to t("general.edit"), edit_collection_path(collection), {class: "btn btn-outline-secondary"} %>
       </div>
     </div>
   </div>

--- a/app/views/collections/_collection.html.erb
+++ b/app/views/collections/_collection.html.erb
@@ -35,7 +35,7 @@
       </div>
       <div>
         <%= link_to pluralize(collection.models.count, t('activerecord.models.model')), {controller: 'models', collection: collection.id}, class: "btn btn-primary" %>
-        <%= link_to(pluralize(collection.collections.count, t('activerecord.models.collection')), (@filters||{}).merge(controller: 'collections', collection: collection.id), class: "btn btn-primary") if collection.collections.count > 0%>
+        <%= link_to(pluralize(collection.collections.count, t('activerecord.models.collection')), (@filters||{}).merge(controller: 'collections', collection: collection.id), class: "btn btn-primary") if collection.collections.count > 0 %>
         <%= link_to t('general.edit'), edit_collection_path(collection), {class: "btn btn-outline-secondary"} %>
       </div>
     </div>

--- a/app/views/collections/_collection.html.erb
+++ b/app/views/collections/_collection.html.erb
@@ -19,7 +19,7 @@
       <div class="col-auto">
         <% if collection.collection %>
           <%= icon "collection", t('activerecord.models.collection') %>
-          <%= link_to collection.collection.name, (@filters||{}).merge(collection: collection.collection.id) %><br/>
+          <%= link_to collection.collection.name, (@filters||{}).merge(collection: collection.collection.id) %><br>
         <% end %>
         <% if collection.caption %>
           <h6 class="card-subtitle mb-2 text-muted"><%= sanitize collection.caption %></h6>

--- a/app/views/collections/_collection.html.erb
+++ b/app/views/collections/_collection.html.erb
@@ -8,7 +8,7 @@
         <%= image_tag library_model_model_file_path(model.library, model, file, format: file.extension), class: "card-img-top image-preview ", alt: file.name %>
       <% elsif renderable?(file.extension) %>
         <div class="card-img-top">
-          <%= render partial: "object_preview", locals: { library: model.library, model: model, file: file } %>
+          <%= render partial: "object_preview", locals: {library: model.library, model: model, file: file} %>
         </div>
       <% end %>
        <% else %>
@@ -19,7 +19,7 @@
       <div class="col-auto">
         <% if collection.collection %>
           <%= icon "collection", t('activerecord.models.collection') %>
-          <%= link_to collection.collection.name, (@filters||{}).merge(collection: collection.collection.id) %><br>
+          <%= link_to collection.collection.name, (@filters || {}).merge(collection: collection.collection.id) %><br>
         <% end %>
         <% if collection.caption %>
           <h6 class="card-subtitle mb-2 text-muted"><%= sanitize collection.caption %></h6>
@@ -35,7 +35,7 @@
       </div>
       <div>
         <%= link_to pluralize(collection.models.count, t('activerecord.models.model')), {controller: 'models', collection: collection.id}, class: "btn btn-primary" %>
-        <%= link_to(pluralize(collection.collections.count, t('activerecord.models.collection')), (@filters||{}).merge(controller: 'collections', collection: collection.id), class: "btn btn-primary") if collection.collections.count > 0 %>
+        <%= link_to(pluralize(collection.collections.count, t('activerecord.models.collection')), (@filters || {}).merge(controller: 'collections', collection: collection.id), class: "btn btn-primary") if collection.collections.count > 0 %>
         <%= link_to t('general.edit'), edit_collection_path(collection), {class: "btn btn-outline-secondary"} %>
       </div>
     </div>

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -3,18 +3,18 @@
   <div class="row mb-3 input-group">
     <%= form.label :collection_id, class: "col-sm-2 col-form-label" %>
     <%= form.collection_select :collection_id, @collections, :id, :name, {include_blank: true}, {class: "form-control col-auto form-select"} %>
-    <%= link_to t('collections.general.new'), new_collection_path, class: "btn btn-outline-secondary col-auto" %>
+    <%= link_to t("collections.general.new"), new_collection_path, class: "btn btn-outline-secondary col-auto" %>
   </div>
-  <%= render 'links_form', form: form %>
+  <%= render "links_form", form: form %>
   <%= text_input_row form, :caption %>
   <%= rich_text_input_row form, :notes %>
   <div class="row mb-4">
     <div class='col'>
-      <%= form.submit t('general.save'), class: "btn btn-primary" %>
+      <%= form.submit t("general.save"), class: "btn btn-primary" %>
     </div>
     <% if @collection.persisted? %>
       <div class='col text-end'>
-        <%= link_to t('general.delete'), collection_path(@collection), {method: :delete, class: "btn btn-outline-danger"} %>
+        <%= link_to t("general.delete"), collection_path(@collection), {method: :delete, class: "btn btn-outline-danger"} %>
       </div>
     <% end %>
   </div>

--- a/app/views/collections/edit.html.erb
+++ b/app/views/collections/edit.html.erb
@@ -1,3 +1,3 @@
-<h1><%= t 'collections.general.edit' %></h1>
+<h1><%= t "collections.general.edit" %></h1>
 
-<%= render 'form' %>
+<%= render "form" %>

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -19,13 +19,13 @@
 
 <% content_for :sidebar do %>
   <%= card :secondary, "Actions" do %>
-    <%= link_to t('.view_unassigned_models'), models_path(collection: ""), class: "btn btn-outline-secondary mb-3 me-3" %>
-    <%= link_to t('collections.general.new'), new_collection_path, class: "btn btn-primary mb-3 me-3" %>
+    <%= link_to t(".view_unassigned_models"), models_path(collection: ""), class: "btn btn-outline-secondary mb-3 me-3" %>
+    <%= link_to t("collections.general.new"), new_collection_path, class: "btn btn-primary mb-3 me-3" %>
   <% end %>
-  <%= render 'filters_card' %>
+  <%= render "filters_card" %>
   <% unless @tags.empty? %>
     <%= card :secondary, "Tags", collapse: "md" do %>
-      <%= render 'tag_list', tags: @tags - (@tag || []), muted_tags: @tags - @commontags %>
+      <%= render "tag_list", tags: @tags - (@tag || []), muted_tags: @tags - @commontags %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -25,7 +25,7 @@
   <%= render 'filters_card' %>
   <% unless @tags.empty? %>
     <%= card :secondary, "Tags", collapse: "md" do %>
-      <%= render 'tag_list', tags: @tags - (@tag||[]), muted_tags: @tags - @commontags %>
+      <%= render 'tag_list', tags: @tags - (@tag || []), muted_tags: @tags - @commontags %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/collections/new.html.erb
+++ b/app/views/collections/new.html.erb
@@ -1,3 +1,3 @@
-<h1><%= t('collections.general.new') %></h1>
+<h1><%= t("collections.general.new") %></h1>
 
-<%= render 'form' %>
+<%= render "form" %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -17,7 +17,7 @@
       <%= paginate @models %>
     <% end %>
     <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 mb-4">
-      <%= render partial: 'model', collection: @models %>
+      <%= render partial: "model", collection: @models %>
     </div>
     <% if current_user.pagination_settings["models"] %>
       <%= paginate @models %>

--- a/app/views/collections/show.html.erb
+++ b/app/views/collections/show.html.erb
@@ -5,8 +5,8 @@
         <h1><%= @collection.name.titleize %></h1>
       </div>
       <div class="col col-auto ">
-        <a href="?order=name" class="btn <%= session["order"] == "name" ? "btn-secondary" : "btn-outline-secondary" %> btn-sm" title="sort by name"><i class="bi bi-book"></i></a>
-        <a href="?order=recent" class="btn <%= session["order"] == "recent" ? "btn-secondary" : "btn-outline-secondary" %> btn-sm" title="sort by time"><i class="bi bi-clock"></i></a>
+        <a href="?order=name" class="btn <%= (session["order"] == "name") ? "btn-secondary" : "btn-outline-secondary" %> btn-sm" title="sort by name"><i class="bi bi-book"></i></a>
+        <a href="?order=recent" class="btn <%= (session["order"] == "recent") ? "btn-secondary" : "btn-outline-secondary" %> btn-sm" title="sort by time"><i class="bi bi-clock"></i></a>
       </div>
     </div>
   </div>

--- a/app/views/creators/_creator.html.erb
+++ b/app/views/creators/_creator.html.erb
@@ -13,7 +13,7 @@
           <li><%= link_to t("sites.#{link.site}"), link.url %></li>
         <% end %>
       </ul>
-      <%= link_to "#{pluralize(creator.models.count, "Model")}", models_path(creator: creator.id), {class: "btn btn-primary"} %>
+      <%= link_to pluralize(creator.models.count, "Model").to_s, models_path(creator: creator.id), {class: "btn btn-primary"} %>
       <%= link_to "Edit", edit_creator_path(creator), {class: "btn btn-outline-secondary"} %>
     </div>
   </div>

--- a/app/views/creators/_creator.html.erb
+++ b/app/views/creators/_creator.html.erb
@@ -1,5 +1,5 @@
 <div class="col mb-4">
-  <div class="card"%>
+  <div class="card">
     <div class="card-body">
       <h5 class="card-title"><%= creator.name %></h5>
       <% if creator.caption %>

--- a/app/views/creators/_form.html.erb
+++ b/app/views/creators/_form.html.erb
@@ -1,15 +1,15 @@
 <%= form_with model: @creator do |form| %>
   <%= text_input_row form, :name %>
-  <%= render 'links_form', form: form %>
+  <%= render "links_form", form: form %>
   <%= text_input_row form, :caption %>
   <%= rich_text_input_row form, :notes %>
   <div class="row mb-4">
     <div class='col'>
-      <%= form.submit t('general.save'), class: "btn btn-primary" %>
+      <%= form.submit t("general.save"), class: "btn btn-primary" %>
     </div>
     <% if @creator.persisted? %>
       <div class='col text-end'>
-        <%= link_to t('general.delete'), creator_path(@creator), {method: :delete, class: "btn btn-outline-danger"} %>
+        <%= link_to t("general.delete"), creator_path(@creator), {method: :delete, class: "btn btn-outline-danger"} %>
       </div>
     <% end %>
   </div>

--- a/app/views/creators/_form.html.erb
+++ b/app/views/creators/_form.html.erb
@@ -1,6 +1,6 @@
 <%= form_with model: @creator do |form| %>
   <%= text_input_row form, :name %>
-  <%= render 'links_form', :form => form %>
+  <%= render 'links_form', form: form %>
   <%= text_input_row form, :caption %>
   <%= rich_text_input_row form, :notes %>
   <div class="row mb-4">

--- a/app/views/creators/edit.html.erb
+++ b/app/views/creators/edit.html.erb
@@ -1,3 +1,3 @@
 <h1>Edit Creator</h1>
 
-<%= render 'form' %>
+<%= render "form" %>

--- a/app/views/creators/index.html.erb
+++ b/app/views/creators/index.html.erb
@@ -22,7 +22,7 @@
   <%= render 'filters_card' %>
   <% unless @tags.empty? %>
     <%= card :secondary, "Tags", collapse: "md" do %>
-      <%= render 'tag_list', tags: @tags - (@tag||[]), muted_tags: @tags - @commontags %>
+      <%= render 'tag_list', tags: @tags - (@tag || []), muted_tags: @tags - @commontags %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/creators/index.html.erb
+++ b/app/views/creators/index.html.erb
@@ -19,10 +19,10 @@
     <%= link_to "View unassigned", models_path(creator: ""), class: "btn btn-outline-secondary mb-3 me-3" %>
     <%= link_to "New Creator", new_creator_path, class: "btn btn-primary mb-3 me-3" %>
   <% end %>
-  <%= render 'filters_card' %>
+  <%= render "filters_card" %>
   <% unless @tags.empty? %>
     <%= card :secondary, "Tags", collapse: "md" do %>
-      <%= render 'tag_list', tags: @tags - (@tag || []), muted_tags: @tags - @commontags %>
+      <%= render "tag_list", tags: @tags - (@tag || []), muted_tags: @tags - @commontags %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/creators/new.html.erb
+++ b/app/views/creators/new.html.erb
@@ -1,3 +1,3 @@
 <h1>New Creator</h1>
 
-<%= render 'form' %>
+<%= render "form" %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -11,7 +11,7 @@
     <%= form_with url: models_path, method: :get, class: "mt-3" do |f| %>
       <div class="input-group mb-3">
         <%= f.text_field :q, class: "form-control", placeholder: "What are you looking for?", aria_label: "Search", aria_describedby: "button-search", value: @query, autofocus: true %>
-        <%= f.submit 'Search', class: "btn btn-primary", name: nil %>
+        <%= f.submit "Search", class: "btn btn-primary", name: nil %>
       </div>
     <% end %>
   </div>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -4,8 +4,7 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
+    remote:        data-remote -%>
 <li class="page-item">
   <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: "page-link" %>
 </li>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -6,5 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote, class: "page-link" %>
+  <%= link_to_unless current_page.first?, t("views.pagination.first").html_safe, url, remote: remote, class: "page-link" %>
 </li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -3,8 +3,7 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
+    remote:        data-remote -%>
 <li class="page-item">
   <span class="page-link"><%= t('views.pagination.truncate').html_safe %></span>
 </li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -5,5 +5,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <span class="page-link"><%= t('views.pagination.truncate').html_safe %></span>
+  <span class="page-link"><%= t("views.pagination.truncate").html_safe %></span>
 </li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -6,5 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, class: "page-link" %>
+  <%= link_to_unless current_page.last?, t("views.pagination.last").html_safe, url, remote: remote, class: "page-link" %>
 </li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -4,8 +4,7 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
+    remote:        data-remote -%>
 <li class="page-item">
   <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote, class: "page-link" %>
 </li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -6,5 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, class: "page-link" %>
+  <%= link_to_unless current_page.last?, t("views.pagination.next").html_safe, url, rel: "next", remote: remote, class: "page-link" %>
 </li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -4,8 +4,7 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
+    remote:        data-remote -%>
 <li class="page-item">
   <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote, class: "page-link" %>
 </li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -5,11 +5,9 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
+    remote:        data-remote -%>
 <li class="page-item <%= ' active' if page.current? %>">
   <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "page-link"} do |name|
       content_tag(:span, name, class: "page-link")
-    end
-  %>
+    end %>
 </li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -8,6 +8,6 @@
     remote:        data-remote -%>
 <li class="page-item <%= " active" if page.current? %>">
   <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "page-link"} do |name|
-      content_tag(:span, name, class: "page-link")
-    end %>
+        content_tag(:span, name, class: "page-link")
+      end %>
 </li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -6,7 +6,7 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
-<li class="page-item <%= ' active' if page.current? %>">
+<li class="page-item <%= " active" if page.current? %>">
   <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "page-link"} do |name|
       content_tag(:span, name, class: "page-link")
     end %>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -4,8 +4,7 @@
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
     remote:        data-remote
-    paginator:     the paginator that renders the pagination tags inside
--%>
+    paginator:     the paginator that renders the pagination tags inside -%>
 <%= paginator.render do -%>
   <nav aria-label="Page navigation">
     <ul class="pagination justify-content-center" aria-label="pager">

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -4,8 +4,7 @@
     current_page:  a page object for the currently displayed page
     total_pages:   total number of pages
     per_page:      number of items to fetch per page
-    remote:        data-remote
--%>
+    remote:        data-remote -%>
 <li class="page-item">
   <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, class: "page-link" %>
 </span>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -6,5 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote, class: "page-link" %>
+  <%= link_to_unless current_page.first?, t("views.pagination.previous").html_safe, url, rel: "prev", remote: remote, class: "page-link" %>
 </span>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,9 +6,9 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= favicon_link_tag "logo.png" %>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
-    <%= javascript_include_tag "application" %>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.6/js/standalone/selectize.min.js" integrity="sha512-pgmLgtHvorzxpKra2mmibwH/RDAVMlOuqU98ZjnyZrOZxgAR8hwL8A02hQFWEK25V40/9yPYb/Zc+kyWMplgaA==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js" integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer" nonce="<%= request.content_security_policy_nonce %>"></script>
+    <%= javascript_include_tag "application", nonce: true %>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/selectize.js/0.13.6/js/standalone/selectize.min.js" integrity="sha512-pgmLgtHvorzxpKra2mmibwH/RDAVMlOuqU98ZjnyZrOZxgAR8hwL8A02hQFWEK25V40/9yPYb/Zc+kyWMplgaA==" crossorigin="anonymous" referrerpolicy="no-referrer" nonce="<%= request.content_security_policy_nonce %>"></script>
     <%= stylesheet_link_tag "application" %>
 </head>
 

--- a/app/views/layouts/card_list_page.html.erb
+++ b/app/views/layouts/card_list_page.html.erb
@@ -2,11 +2,11 @@
 
 <div class="row row-cols-md-2">
   <div class="col-md-3 row-cols-md-1">
-		<%= yield :sidebar %>
-	</div>
-	<div class="col-md-9 order-md-first">
-		<%= yield :items %>
-	</div>
+    <%= yield :sidebar %>
+  </div>
+  <div class="col-md-9 order-md-first">
+    <%= yield :items %>
+  </div>
 </div>
 
 <% parent_layout 'application' %>

--- a/app/views/layouts/card_list_page.html.erb
+++ b/app/views/layouts/card_list_page.html.erb
@@ -9,4 +9,4 @@
   </div>
 </div>
 
-<% parent_layout 'application' %>
+<% parent_layout "application" %>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" >
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
     <style>
       /* Email styles need to be inline */
     </style>

--- a/app/views/layouts/mailer.html.erb
+++ b/app/views/layouts/mailer.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" >
     <style>
       /* Email styles need to be inline */
     </style>

--- a/app/views/libraries/_form.html.erb
+++ b/app/views/libraries/_form.html.erb
@@ -10,13 +10,13 @@
     <div id="newinput" class="col-sm-10 p-0">
       <% @library.tag_regex.each do |reg| %>
         <div class="input-group">
-          <%= text_field_tag "library[tag_regex][]", reg, class: "form-control col-sm-11" %>
+          <%= text_field_tag "library[tag_regex][]", reg, class: "form-control col-sm-11", autocomplete: "off" %>
           <%= link_to icon(:trash, "Delete"), '', onClick: "jQuery(this).parents('div.input-group')[0].remove(); return false;", class: "input-group-text btn btn-outline-danger col-auto" %>
         </div>
       <% end %>
       <div id="regexclone" style="display: none">
         <div class="input-group">
-          <%= text_field_tag "library[tag_regex][]", '', class: "form-control col-sm-11" %>
+          <%= text_field_tag "library[tag_regex][]", '', class: "form-control col-sm-11", autocomplete: "off" %>
           <%= link_to icon(:trash, "Delete"), '', onClick: "jQuery(this).parents('div.input-group')[0].remove(); return false;", class: "input-group-text btn btn-outline-danger col-auto" %>
         </div>
       </div>

--- a/app/views/libraries/_form.html.erb
+++ b/app/views/libraries/_form.html.erb
@@ -22,7 +22,7 @@
       </div>
     </div>
     <div class="col-sm-2"></div><div class="col-sm-10 p-0">
-      <%= link_to icon("plus-square-dotted","Add Line"), '', onClick: "$('#newinput').append($('#regexclone').html()); return false;", class: "btn btn-primary" %>
+      <%= link_to icon("plus-square-dotted", "Add Line"), '', onClick: "$('#newinput').append($('#regexclone').html()); return false;", class: "btn btn-primary" %>
       <span id="libraryRegexHelp" class="form-text">Check for models missing tags matching these regex.</span>
     </div>
   </div>

--- a/app/views/libraries/_form.html.erb
+++ b/app/views/libraries/_form.html.erb
@@ -11,18 +11,18 @@
       <% @library.tag_regex.each do |reg| %>
         <div class="input-group">
           <%= text_field_tag "library[tag_regex][]", reg, class: "form-control col-sm-11", autocomplete: "off" %>
-          <%= link_to icon(:trash, "Delete"), '', onClick: "jQuery(this).parents('div.input-group')[0].remove(); return false;", class: "input-group-text btn btn-outline-danger col-auto" %>
+          <%= link_to icon(:trash, "Delete"), "", onClick: "jQuery(this).parents('div.input-group')[0].remove(); return false;", class: "input-group-text btn btn-outline-danger col-auto" %>
         </div>
       <% end %>
       <div id="regexclone" style="display: none">
         <div class="input-group">
-          <%= text_field_tag "library[tag_regex][]", '', class: "form-control col-sm-11", autocomplete: "off" %>
-          <%= link_to icon(:trash, "Delete"), '', onClick: "jQuery(this).parents('div.input-group')[0].remove(); return false;", class: "input-group-text btn btn-outline-danger col-auto" %>
+          <%= text_field_tag "library[tag_regex][]", "", class: "form-control col-sm-11", autocomplete: "off" %>
+          <%= link_to icon(:trash, "Delete"), "", onClick: "jQuery(this).parents('div.input-group')[0].remove(); return false;", class: "input-group-text btn btn-outline-danger col-auto" %>
         </div>
       </div>
     </div>
     <div class="col-sm-2"></div><div class="col-sm-10 p-0">
-      <%= link_to icon("plus-square-dotted", "Add Line"), '', onClick: "$('#newinput').append($('#regexclone').html()); return false;", class: "btn btn-primary" %>
+      <%= link_to icon("plus-square-dotted", "Add Line"), "", onClick: "$('#newinput').append($('#regexclone').html()); return false;", class: "btn btn-primary" %>
       <span id="libraryRegexHelp" class="form-text">Check for models missing tags matching these regex.</span>
     </div>
   </div>

--- a/app/views/libraries/edit.html.erb
+++ b/app/views/libraries/edit.html.erb
@@ -1,3 +1,3 @@
 <h1>Edit Library</h1>
 
-<%= render 'form' %>
+<%= render "form" %>

--- a/app/views/libraries/new.html.erb
+++ b/app/views/libraries/new.html.erb
@@ -8,7 +8,7 @@
   <div class="row mb-3 input-group">
     <%= form.label :path, class: "col-sm-2 col-form-label" %>
     <div class='col-sm-10 ps-0'>
-      <%= form.text_field :path, class: 'form-control', placeholder: "Filesystem path" %>
+      <%= form.text_field :path, class: "form-control", placeholder: "Filesystem path" %>
       <% if @library.errors.include?(:path) %>
         <%= tag.div @library.errors.full_messages_for(:path).join("; "), class: "invalid-feedback" %>
       <% else %>
@@ -16,5 +16,5 @@
       <% end %>
     </div>
   </div>
-  <%= form.submit "Save", class: 'btn btn-primary' %>
+  <%= form.submit "Save", class: "btn btn-primary" %>
 <% end %>

--- a/app/views/libraries/new.html.erb
+++ b/app/views/libraries/new.html.erb
@@ -8,7 +8,7 @@
   <div class="row mb-3 input-group">
     <%= form.label :path, class: "col-sm-2 col-form-label" %>
     <div class='col-sm-10 ps-0'>
-      <%= form.text_field :path, class: 'form-control', placeholder:"Filesystem path" %>
+      <%= form.text_field :path, class: 'form-control', placeholder: "Filesystem path" %>
       <% if @library.errors.include?(:path) %>
         <%= tag.div @library.errors.full_messages_for(:path).join("; "), class: "invalid-feedback" %>
       <% else %>

--- a/app/views/model_files/_form.html.erb
+++ b/app/views/model_files/_form.html.erb
@@ -1,18 +1,18 @@
 <%= form_with model: [@library, @model, @file] do |form| %>
   <div class="form-check form-switch mb-3">
-    <%= form.check_box :printed, class: 'form-check-input', checked: current_user.printed?(@file) %>
+    <%= form.check_box :printed, class: "form-check-input", checked: current_user.printed?(@file) %>
     <label class="form-check-label" for="printed">Printed?</label>
   </div>
   <div class="form-check form-switch mb-3">
-    <%= form.check_box :presupported, class: 'form-check-input' %>
+    <%= form.check_box :presupported, class: "form-check-input" %>
     <label class="form-check-label" for="presupported">Presupported?</label>
   </div>
   <div class="form-check form-switch mb-3">
-    <%= form.check_box :y_up, class: 'form-check-input' %>
+    <%= form.check_box :y_up, class: "form-check-input" %>
     <label class="form-check-label" for="y_up">Y Up</label>
   </div>
 
   <%= text_input_row form, :caption %>
   <%= rich_text_input_row form, :notes %>
-  <%= form.submit "Update", class: 'btn btn-primary' %>
+  <%= form.submit "Update", class: "btn btn-primary" %>
 <% end %>

--- a/app/views/model_files/_problem.html.erb
+++ b/app/views/model_files/_problem.html.erb
@@ -1,11 +1,11 @@
 <%= card(problem_severity(problem), t("problems.model_file_#{problem.category}.title")) do %>
-	<%= t("problems.model_file_#{problem.category}.description", note: problem.note ) %>
+  <%= t("problems.model_file_#{problem.category}.description", note: problem.note ) %>
 
-	<% unless @duplicates.empty? %>
-		<ul>
-			<% @duplicates.each do |file| %>
-				<li><%= link_to "#{file.model.name}/#{file.filename}", [file.model.library, file.model, file] %></li>
-			<% end %>
-		</ul>
-	<% end %>
+  <% unless @duplicates.empty? %>
+    <ul>
+      <% @duplicates.each do |file| %>
+        <li><%= link_to "#{file.model.name}/#{file.filename}", [file.model.library, file.model, file] %></li>
+      <% end %>
+    </ul>
+  <% end %>
 <% end %>

--- a/app/views/model_files/_problem.html.erb
+++ b/app/views/model_files/_problem.html.erb
@@ -1,5 +1,5 @@
 <%= card(problem_severity(problem), t("problems.model_file_#{problem.category}.title")) do %>
-  <%= t("problems.model_file_#{problem.category}.description", note: problem.note ) %>
+  <%= t("problems.model_file_#{problem.category}.description", note: problem.note) %>
 
   <% unless @duplicates.empty? %>
     <ul>

--- a/app/views/model_files/_problem.html.erb
+++ b/app/views/model_files/_problem.html.erb
@@ -4,7 +4,7 @@
 	<% unless @duplicates.empty? %>
 		<ul>
 			<% @duplicates.each do |file| %>
-				<li><%= link_to "#{file.model.name}/#{file.filename}", [file.model.library, file.model, file]%></li>
+				<li><%= link_to "#{file.model.name}/#{file.filename}", [file.model.library, file.model, file] %></li>
 			<% end %>
 		</ul>
 	<% end %>

--- a/app/views/model_files/bulk_edit.html.erb
+++ b/app/views/model_files/bulk_edit.html.erb
@@ -17,7 +17,7 @@
     </tr>
     <% @model.model_files.each do |file| %>
       <tr>
-        <td><%= form.check_box "model_files[#{file.id}]", { data: { bulk_item:  "#{file.id}"}} %></td>
+        <td><%= form.check_box "model_files[#{file.id}]", {data: {bulk_item: "#{file.id}"}} %></td>
         <td><i class="bi bi-<%= file.is_image? ? 'image' : 'box' %>"></td>
         <td><%= link_to file.name, [@library, @model, file], title: file.filename %></td>
         <td><code><%= file.filename %></code></td>

--- a/app/views/model_files/bulk_edit.html.erb
+++ b/app/views/model_files/bulk_edit.html.erb
@@ -17,7 +17,7 @@
     </tr>
     <% @model.model_files.each do |file| %>
       <tr>
-        <td><%= form.check_box "model_files[#{file.id}]", {data: {bulk_item: "#{file.id}"}} %></td>
+        <td><%= form.check_box "model_files[#{file.id}]", {data: {bulk_item: file.id.to_s}} %></td>
         <td><i class="bi bi-<%= file.is_image? ? "image" : "box" %>"></td>
         <td><%= link_to file.name, [@library, @model, file], title: file.filename %></td>
         <td><code><%= file.filename %></code></td>

--- a/app/views/model_files/bulk_edit.html.erb
+++ b/app/views/model_files/bulk_edit.html.erb
@@ -18,12 +18,12 @@
     <% @model.model_files.each do |file| %>
       <tr>
         <td><%= form.check_box "model_files[#{file.id}]", {data: {bulk_item: "#{file.id}"}} %></td>
-        <td><i class="bi bi-<%= file.is_image? ? 'image' : 'box' %>"></td>
+        <td><i class="bi bi-<%= file.is_image? ? "image" : "box" %>"></td>
         <td><%= link_to file.name, [@library, @model, file], title: file.filename %></td>
         <td><code><%= file.filename %></code></td>
-        <td><i class="bi bi-<%= current_user.printed?(file) ? 'check-circle-fill' : 'circle' %>"></td>
-        <td><i class="bi bi-<%= file.presupported ? 'check-circle-fill' : 'circle' %>"></td>
-        <td><i class="bi bi-<%= file.y_up ? 'check-circle-fill' : 'circle' %>"></td>
+        <td><i class="bi bi-<%= current_user.printed?(file) ? "check-circle-fill" : "circle" %>"></td>
+        <td><i class="bi bi-<%= file.presupported ? "check-circle-fill" : "circle" %>"></td>
+        <td><i class="bi bi-<%= file.y_up ? "check-circle-fill" : "circle" %>"></td>
       </tr>
     <% end %>
   </table>

--- a/app/views/model_files/bulk_edit.html.erb
+++ b/app/views/model_files/bulk_edit.html.erb
@@ -17,7 +17,7 @@
     </tr>
     <% @model.model_files.each do |file| %>
       <tr>
-        <td><%= form.check_box "model_files[#{file.id}]", { data: { bulk_item:  "#{file.id}"}}%></td>
+        <td><%= form.check_box "model_files[#{file.id}]", { data: { bulk_item:  "#{file.id}"}} %></td>
         <td><i class="bi bi-<%= file.is_image? ? 'image' : 'box' %>"></td>
         <td><%= link_to file.name, [@library, @model, file], title: file.filename %></td>
         <td><code><%= file.filename %></code></td>

--- a/app/views/model_files/show.html.erb
+++ b/app/views/model_files/show.html.erb
@@ -32,8 +32,8 @@
     <%= render partial: "problem", collection: @file.problems.visible(current_user.problem_settings) %>
 
     <%= card :secondary, "Actions" do %>
-      <%= link_to "#{icon('cloud-download', 'Download')} Download".html_safe, library_model_model_file_path(@library, @model, @file, @file.extension.to_sym), {class: "btn btn-secondary"} %>
-      <%= link_to "#{icon('trash', 'Delete')} Delete".html_safe, library_model_model_file_path(@library, @model, @file, @file.extension.to_sym), {method: "delete", data: {confirm: "Are you sure you want to remove this file from your filesystem?"}, class: "btn btn-danger"} %>
+      <%= link_to "#{icon("cloud-download", "Download")} Download".html_safe, library_model_model_file_path(@library, @model, @file, @file.extension.to_sym), {class: "btn btn-secondary"} %>
+      <%= link_to "#{icon("trash", "Delete")} Delete".html_safe, library_model_model_file_path(@library, @model, @file, @file.extension.to_sym), {method: "delete", data: {confirm: "Are you sure you want to remove this file from your filesystem?"}, class: "btn btn-danger"} %>
     <% end %>
 
     <%= card(:secondary, "Notes") do %>

--- a/app/views/model_files/show.html.erb
+++ b/app/views/model_files/show.html.erb
@@ -7,7 +7,7 @@
       <% if @file.is_image? %>
         <%= image_tag library_model_model_file_path(@model.library, @model, @file, format: @file.extension), alt: @file.name, style: "width: 100%" %>
       <% elsif renderable?(@file.extension) %>
-        <%= render partial: "object_preview", locals: { library: @library, model: @model, file: @file } %>
+        <%= render partial: "object_preview", locals: {library: @library, model: @model, file: @file} %>
       <% end %>
   </div>
 
@@ -18,7 +18,7 @@
       </p>
       <% if @file.digest %>
         <p>
-          Digest: <code><%= @file.digest.slice(0,16) %></code>
+          Digest: <code><%= @file.digest.slice(0, 16) %></code>
         </p>
       <% end %>
       <% if @file.size %>

--- a/app/views/model_files/show.html.erb
+++ b/app/views/model_files/show.html.erb
@@ -26,7 +26,7 @@
           File size: <code><%= number_to_human_size @file.size, precision: 2 %></code>
         </p>
       <% end %>
-      <%= render 'form' %>
+      <%= render "form" %>
     <% end %>
 
     <%= render partial: "problem", collection: @file.problems.visible(current_user.problem_settings) %>
@@ -36,7 +36,7 @@
       <%= link_to "#{icon('trash', 'Delete')} Delete".html_safe, library_model_model_file_path(@library, @model, @file, @file.extension.to_sym), {method: "delete", data: {confirm: "Are you sure you want to remove this file from your filesystem?"}, class: "btn btn-danger"} %>
     <% end %>
 
-    <%= card(:secondary, 'Notes') do %>
+    <%= card(:secondary, "Notes") do %>
       <p class="card-text"><%= sanitize @file.notes %></p>
     <% end if @file.notes %>
 

--- a/app/views/models/_file.html.erb
+++ b/app/views/models/_file.html.erb
@@ -5,7 +5,7 @@
       <%= image_tag library_model_model_file_path(@library, @model, file, format: file.extension), class: "card-img-top image-preview", alt: file.name %>
     <% elsif renderable?(file.extension) %>
       <div class="card-img-top">
-        <%= render partial: "object_preview", locals: { library: @library, model: @model, file: file } %>
+        <%= render partial: "object_preview", locals: {library: @library, model: @model, file: file} %>
       </div>
     <% end %>
     <div class="card-body">

--- a/app/views/models/_file.html.erb
+++ b/app/views/models/_file.html.erb
@@ -1,5 +1,5 @@
 <div class="col mb-4">
-  <div class="card preview-card <%= file === @model.preview_file ? "border-primary" : "" %>">
+  <div class="card preview-card <%= (file === @model.preview_file) ? "border-primary" : "" %>">
     <% if file.is_image? %>
       <%= content_tag :div, nil, class: "card-img-top card-img-top-background", style: "background-image: url(#{library_model_model_file_path(@library, @model, file, format: file.extension)})" %>
       <%= image_tag library_model_model_file_path(@library, @model, file, format: file.extension), class: "card-img-top image-preview", alt: file.name %>
@@ -20,7 +20,7 @@
         <%= link_to "Details", library_model_model_file_path(@library, @model, file), {class: "btn btn-primary"} %>
         <%= link_to icon("cloud-download", "Download"), library_model_model_file_path(@library, @model, file, file.extension.to_sym), {class: "btn btn-secondary"} %>
         <%= form.hidden_field :preview_file_id, value: file.id %>
-        <%= form.button icon("bookmark-heart", "Set as preview"), class: "btn btn-secondary #{file == @model.preview_file ? "disabled" : ""}" %>
+        <%= form.button icon("bookmark-heart", "Set as preview"), class: "btn btn-secondary #{(file == @model.preview_file) ? "disabled" : ""}" %>
       <% end %>
     </div>
   </div>

--- a/app/views/models/_file.html.erb
+++ b/app/views/models/_file.html.erb
@@ -18,9 +18,9 @@
           <p class="card-text"><%= sanitize file.caption %></p>
         <% end %>
         <%= link_to "Details", library_model_model_file_path(@library, @model, file), {class: "btn btn-primary"} %>
-        <%= link_to icon('cloud-download', 'Download'), library_model_model_file_path(@library, @model, file, file.extension.to_sym), {class: "btn btn-secondary"} %>
+        <%= link_to icon("cloud-download", "Download"), library_model_model_file_path(@library, @model, file, file.extension.to_sym), {class: "btn btn-secondary"} %>
         <%= form.hidden_field :preview_file_id, value: file.id %>
-        <%= form.button icon('bookmark-heart', 'Set as preview'), class: "btn btn-secondary #{file == @model.preview_file ? "disabled" : ""}" %>
+        <%= form.button icon("bookmark-heart", "Set as preview"), class: "btn btn-secondary #{file == @model.preview_file ? "disabled" : ""}" %>
       <% end %>
     </div>
   </div>

--- a/app/views/models/_form.html.erb
+++ b/app/views/models/_form.html.erb
@@ -20,7 +20,7 @@
     <%= form.collection_select :library_id, Library.all, :id, :name, {include_blank: false}, {class: "form-control col-auto form-select", disabled: @model.contains_other_models?} %>
   </div>
 
-  <%= render 'tags_edit', :form => form, :name => "model[tag_list]", :value => (@model.tags.map { |tag| tag.name }).join(","), :label => "Tags", tags: @library.all_tags %>
+  <%= render 'tags_edit', form: form, name: "model[tag_list]", value: (@model.tags.map { |tag| tag.name }).join(","), label: "Tags", tags: @library.all_tags %>
 
   <div class="row mb-3 input-group">
     <%= form.label :collection_id, class: "col-sm-2 col-form-label" %>
@@ -28,7 +28,7 @@
     <%= link_to "New Collection", new_collection_path, class: "btn btn-outline-secondary col-auto" %>
   </div>
 
-  <%= render 'links_form', :form => form %>
+  <%= render 'links_form', form: form %>
   <%= text_input_row form, :caption %>
   <%= rich_text_input_row form, :notes %>
 

--- a/app/views/models/_form.html.erb
+++ b/app/views/models/_form.html.erb
@@ -20,7 +20,7 @@
     <%= form.collection_select :library_id, Library.all, :id, :name, {include_blank: false}, {class: "form-control col-auto form-select", disabled: @model.contains_other_models?} %>
   </div>
 
-  <%= render 'tags_edit', form: form, name: "model[tag_list]", value: (@model.tags.map { |tag| tag.name }).join(","), label: "Tags", tags: @library.all_tags %>
+  <%= render "tags_edit", form: form, name: "model[tag_list]", value: (@model.tags.map { |tag| tag.name }).join(","), label: "Tags", tags: @library.all_tags %>
 
   <div class="row mb-3 input-group">
     <%= form.label :collection_id, class: "col-sm-2 col-form-label" %>
@@ -28,7 +28,7 @@
     <%= link_to "New Collection", new_collection_path, class: "btn btn-outline-secondary col-auto" %>
   </div>
 
-  <%= render 'links_form', form: form %>
+  <%= render "links_form", form: form %>
   <%= text_input_row form, :caption %>
   <%= rich_text_input_row form, :notes %>
 

--- a/app/views/models/_problem.html.erb
+++ b/app/views/models/_problem.html.erb
@@ -1,5 +1,5 @@
 <%= card(problem_severity(problem), t("problems.model_#{problem.category}.title")) do %>
-	<%= t("problems.model_#{problem.category}.description", note: problem.note ) %>
+  <%= t("problems.model_#{problem.category}.description", note: problem.note ) %>
 
   <% if @model.contains_other_models? %>
     <ul>

--- a/app/views/models/_problem.html.erb
+++ b/app/views/models/_problem.html.erb
@@ -1,5 +1,5 @@
 <%= card(problem_severity(problem), t("problems.model_#{problem.category}.title")) do %>
-  <%= t("problems.model_#{problem.category}.description", note: problem.note ) %>
+  <%= t("problems.model_#{problem.category}.description", note: problem.note) %>
 
   <% if @model.contains_other_models? %>
     <ul>

--- a/app/views/models/_problem.html.erb
+++ b/app/views/models/_problem.html.erb
@@ -4,7 +4,7 @@
   <% if @model.contains_other_models? %>
     <ul>
       <% @model.contained_models.each do |target| %>
-        <li><%= link_to target.name, library_model_path(@library, target)%></li>
+        <li><%= link_to target.name, library_model_path(@library, target) %></li>
       <% end %>
     </ul>
     <p>

--- a/app/views/models/_tags_edit.html.erb
+++ b/app/views/models/_tags_edit.html.erb
@@ -7,7 +7,6 @@
           class: "form-select",
           name: name ? "#{name}[]" : nil,
           data: {selectize: "true"}
-        }
-      %>
+        } %>
   </div>
 </div>

--- a/app/views/models/_tags_edit.html.erb
+++ b/app/views/models/_tags_edit.html.erb
@@ -2,11 +2,11 @@
   <label for="tags" class="col-sm-2 col-form-label"><%= label %></label>
     <div class="form-control col-auto tag-container">
       <%= form.collection_select :tag_list, tags,
-        :name, :name, {}, {
-          multiple: true,
-          class: "form-select",
-          name: name ? "#{name}[]" : nil,
-          data: {selectize: "true"}
-        } %>
+            :name, :name, {}, {
+              multiple: true,
+              class: "form-select",
+              name: name ? "#{name}[]" : nil,
+              data: {selectize: "true"}
+            } %>
   </div>
 </div>

--- a/app/views/models/bulk_edit.html.erb
+++ b/app/views/models/bulk_edit.html.erb
@@ -15,13 +15,13 @@
     </tr>
     <% @models.each do |model| %>
       <tr>
-        <td><%= form.check_box "models[#{model.id}]", { data: { bulk_item:  "#{model.id}"}} %></td>
+        <td><%= form.check_box "models[#{model.id}]", {data: {bulk_item: "#{model.id}"}} %></td>
         <td><%= link_to model.name, [model.library, model], title: model.path %></td>
         <td><%= link_to model.collection.name, model.collection if model.collection %></td>
         <td><%= render partial: 'tag',
-          collection: (current_user.tag_cloud_settings["sorting"]=="alphabetical") ?
+          collection: (current_user.tag_cloud_settings["sorting"] == "alphabetical") ?
             model.tags.sort_by(&:name) : model.tags.sort_by(&:name).reverse.sort_by(&:taggings_count).reverse,
-            locals: {state: :normal, model_id: model.id } %></td>
+            locals: {state: :normal, model_id: model.id} %></td>
         <td><%= link_to model.creator.name, model.creator if model.creator %></td>
         <td><code><%= model.formatted_path if model.needs_organizing? %></code></td>
       </tr>
@@ -54,7 +54,7 @@
     </div>
   </div>
 
-  <%= render 'tags_edit', :form => form, :name => :add_tags, :value => "", :label => "Add Tags", tags:  @addtags || [] %>
+  <%= render 'tags_edit', :form => form, :name => :add_tags, :value => "", :label => "Add Tags", tags: @addtags || [] %>
   <%= render 'tags_edit', :form => form, :name => :remove_tags, :value => "", :label => "Remove Tags", tags: @models.includes(:tags).map(&:tags).flatten.uniq.sort_by(&:name) %>
 
   <div class="row mb-3">

--- a/app/views/models/bulk_edit.html.erb
+++ b/app/views/models/bulk_edit.html.erb
@@ -54,8 +54,8 @@
     </div>
   </div>
 
-  <%= render 'tags_edit', :form => form, :name => :add_tags, :value => "", :label => "Add Tags", tags: @addtags || [] %>
-  <%= render 'tags_edit', :form => form, :name => :remove_tags, :value => "", :label => "Remove Tags", tags: @models.includes(:tags).map(&:tags).flatten.uniq.sort_by(&:name) %>
+  <%= render 'tags_edit', form: form, name: :add_tags, value: "", label: "Add Tags", tags: @addtags || [] %>
+  <%= render 'tags_edit', form: form, name: :remove_tags, value: "", label: "Remove Tags", tags: @models.includes(:tags).map(&:tags).flatten.uniq.sort_by(&:name) %>
 
   <div class="row mb-3">
     <%= form.label :collection_id, class: "col-sm-2 col-form-label" %>

--- a/app/views/models/bulk_edit.html.erb
+++ b/app/views/models/bulk_edit.html.erb
@@ -15,7 +15,7 @@
     </tr>
     <% @models.each do |model| %>
       <tr>
-        <td><%= form.check_box "models[#{model.id}]", { data: { bulk_item:  "#{model.id}"}}%></td>
+        <td><%= form.check_box "models[#{model.id}]", { data: { bulk_item:  "#{model.id}"}} %></td>
         <td><%= link_to model.name, [model.library, model], title: model.path %></td>
         <td><%= link_to model.collection.name, model.collection if model.collection %></td>
         <td><%= render partial: 'tag',

--- a/app/views/models/bulk_edit.html.erb
+++ b/app/views/models/bulk_edit.html.erb
@@ -19,9 +19,9 @@
         <td><%= link_to model.name, [model.library, model], title: model.path %></td>
         <td><%= link_to model.collection.name, model.collection if model.collection %></td>
         <td><%= render partial: "tag",
-          collection: (current_user.tag_cloud_settings["sorting"] == "alphabetical") ?
-            model.tags.sort_by(&:name) : model.tags.sort_by(&:name).reverse.sort_by(&:taggings_count).reverse,
-            locals: {state: :normal, model_id: model.id} %></td>
+                  collection: (current_user.tag_cloud_settings["sorting"] == "alphabetical") ?
+                    model.tags.sort_by(&:name) : model.tags.sort_by(&:name).reverse.sort_by(&:taggings_count).reverse,
+                  locals: {state: :normal, model_id: model.id} %></td>
         <td><%= link_to model.creator.name, model.creator if model.creator %></td>
         <td><code><%= model.formatted_path if model.needs_organizing? %></code></td>
       </tr>

--- a/app/views/models/bulk_edit.html.erb
+++ b/app/views/models/bulk_edit.html.erb
@@ -15,7 +15,7 @@
     </tr>
     <% @models.each do |model| %>
       <tr>
-        <td><%= form.check_box "models[#{model.id}]", {data: {bulk_item: "#{model.id}"}} %></td>
+        <td><%= form.check_box "models[#{model.id}]", {data: {bulk_item: model.id.to_s}} %></td>
         <td><%= link_to model.name, [model.library, model], title: model.path %></td>
         <td><%= link_to model.collection.name, model.collection if model.collection %></td>
         <td><%= render partial: "tag",

--- a/app/views/models/bulk_edit.html.erb
+++ b/app/views/models/bulk_edit.html.erb
@@ -18,7 +18,7 @@
         <td><%= form.check_box "models[#{model.id}]", {data: {bulk_item: "#{model.id}"}} %></td>
         <td><%= link_to model.name, [model.library, model], title: model.path %></td>
         <td><%= link_to model.collection.name, model.collection if model.collection %></td>
-        <td><%= render partial: 'tag',
+        <td><%= render partial: "tag",
           collection: (current_user.tag_cloud_settings["sorting"] == "alphabetical") ?
             model.tags.sort_by(&:name) : model.tags.sort_by(&:name).reverse.sort_by(&:taggings_count).reverse,
             locals: {state: :normal, model_id: model.id} %></td>
@@ -54,8 +54,8 @@
     </div>
   </div>
 
-  <%= render 'tags_edit', form: form, name: :add_tags, value: "", label: "Add Tags", tags: @addtags || [] %>
-  <%= render 'tags_edit', form: form, name: :remove_tags, value: "", label: "Remove Tags", tags: @models.includes(:tags).map(&:tags).flatten.uniq.sort_by(&:name) %>
+  <%= render "tags_edit", form: form, name: :add_tags, value: "", label: "Add Tags", tags: @addtags || [] %>
+  <%= render "tags_edit", form: form, name: :remove_tags, value: "", label: "Remove Tags", tags: @models.includes(:tags).map(&:tags).flatten.uniq.sort_by(&:name) %>
 
   <div class="row mb-3">
     <%= form.label :collection_id, class: "col-sm-2 col-form-label" %>

--- a/app/views/models/edit.html.erb
+++ b/app/views/models/edit.html.erb
@@ -1,4 +1,4 @@
 <%= render partial: "model_files/breadcrumb" %>
 <h1>Edit Model</h1>
 
-<%= render 'form' %>
+<%= render "form" %>

--- a/app/views/models/index.html.erb
+++ b/app/views/models/index.html.erb
@@ -16,7 +16,7 @@
 
 <% content_for :sidebar do %>
   <%= card :secondary, "Actions" do %>
-    <%= link_to "Bulk Edit", edit_models_path(@filters), class: 'btn btn-secondary mb-3 me-3' %>
+    <%= link_to "Bulk Edit", edit_models_path(@filters), class: "btn btn-secondary mb-3 me-3" %>
     <% if current_user.tag_cloud_settings["heatmap"] && Model.where("(select count(*) from taggings where taggings.taggable_id=models.id and taggings.context='tags')<1").count > 0 %>
       <%= link_to "Untagged", models_path(tag: [""]), class: "btn btn-secondary mb-3 me-3" %>
     <% end %>
@@ -24,10 +24,10 @@
       <%= link_to "Missing URL", models_path(link: ""), class: "btn btn-secondary mb-3 me-3" %>
     <% end %>
   <% end %>
-  <%= render 'filters_card' %>
+  <%= render "filters_card" %>
   <% unless @tags.empty? %>
     <%= card :secondary, "Tags", collapse: "md" do %>
-      <%= render 'tag_list', tags: @tags - (@tag || []), muted_tags: @tags - @commontags %>
+      <%= render "tag_list", tags: @tags - (@tag || []), muted_tags: @tags - @commontags %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/models/index.html.erb
+++ b/app/views/models/index.html.erb
@@ -27,7 +27,7 @@
   <%= render 'filters_card' %>
   <% unless @tags.empty? %>
     <%= card :secondary, "Tags", collapse: "md" do %>
-      <%= render 'tag_list', tags: @tags - (@tag||[]), muted_tags: @tags - @commontags %>
+      <%= render 'tag_list', tags: @tags - (@tag || []), muted_tags: @tags - @commontags %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -4,8 +4,8 @@
       <%= @model.name %>
     </a>
     <%= link_to icon("search", "Search the Internet for models with this name"),
-      "https://yeggi.com/q/#{ERB::Util.url_encode(@model.name)}/",
-      class: "btn btn-outline", target: "manyfold_search" %>
+          "https://yeggi.com/q/#{ERB::Util.url_encode(@model.name)}/",
+          class: "btn btn-outline", target: "manyfold_search" %>
   </h1>
 <% end %>
 

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -5,7 +5,7 @@
     </a>
     <%= link_to icon("search", "Search the Internet for models with this name"),
       "https://yeggi.com/q/#{ERB::Util.url_encode(@model.name)}/",
-      class: 'btn btn-outline', target: "manyfold_search" %>
+      class: "btn btn-outline", target: "manyfold_search" %>
   </h1>
 <% end %>
 
@@ -64,7 +64,7 @@
       </tr>
       <tr>
         <td><%= icon "tag", "Tags" %></td>
-        <td><%= render 'tag_list', tags: @model.tags.sort_by(&:taggings_count) %></td>
+        <td><%= render "tag_list", tags: @model.tags.sort_by(&:taggings_count) %></td>
       </tr>
     </table>
     <%= link_to safe_join([icon("pencil", "Edit"), "Edit"], " "), edit_library_model_path(@library, @model), class: "btn btn-primary" %>
@@ -85,7 +85,7 @@
 
   <%= render partial: "problem", collection: @model.problems.visible(current_user.problem_settings) %>
 
-  <%= card(:secondary, 'Notes') do %>
+  <%= card(:secondary, "Notes") do %>
     <p class="card-text"><%= sanitize @model.notes %></p>
   <% end if @model.notes %>
 
@@ -96,10 +96,10 @@
         <li><a href="#<%= group.parameterize %>"><%= group %></a></li>
       <% end %>
     </ul>
-    <%= link_to "Edit all files", edit_library_model_model_files_path(@library, @model), class: 'btn btn-secondary' %>
+    <%= link_to "Edit all files", edit_library_model_model_files_path(@library, @model), class: "btn btn-secondary" %>
   <% end %>
 
-  <%= render 'links_card', links: @model.links %>
+  <%= render "links_card", links: @model.links %>
 
   <div class="modal fade" id="confirm-move" data-bs-backdrop='static' tabindex="-1" aria-labelledby="confirmMoveLabel" aria-hidden="true">
     <div class="modal-dialog">

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -5,8 +5,7 @@
     </a>
     <%= link_to icon("search", "Search the Internet for models with this name"),
       "https://yeggi.com/q/#{ERB::Util.url_encode(@model.name)}/",
-      class: 'btn btn-outline', target: "manyfold_search"
-     %>
+      class: 'btn btn-outline', target: "manyfold_search" %>
   </h1>
 <% end %>
 

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -28,19 +28,19 @@
       <% if @model.creator %>
         <tr>
           <td><%= icon "person", "Creator" %></td>
-          <td><%= link_to @model.creator.name, models_path((@filters||{}).merge(creator: @model.creator)) %></td>
+          <td><%= link_to @model.creator.name, models_path((@filters || {}).merge(creator: @model.creator)) %></td>
         </tr>
       <% end %>
       <% if @model.collection %>
         <tr>
           <td><%= icon "collection", "Collections" %></td>
-          <td><%= link_to @model.collection.name, models_path((@filters||{}).merge(collection: @model.collection.id)) %></td>
+          <td><%= link_to @model.collection.name, models_path((@filters || {}).merge(collection: @model.collection.id)) %></td>
         </tr>
       <% end %>
       <% if @model.library %>
         <tr>
           <td><%= icon "boxes", "Library" %></td>
-          <td><%= link_to @model.library.name, models_path((@filters||{}).merge(library: @model.library)) %></td>
+          <td><%= link_to @model.library.name, models_path((@filters || {}).merge(library: @model.library)) %></td>
         </tr>
       <% end %>
       <% if @model.license %>

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -34,7 +34,7 @@
       <% if @model.collection %>
         <tr>
           <td><%= icon "collection", "Collections" %></td>
-          <td><%= link_to @model.collection.name, models_path((@filters||{}).merge(collection: @model.collection.id))  %></td>
+          <td><%= link_to @model.collection.name, models_path((@filters||{}).merge(collection: @model.collection.id)) %></td>
         </tr>
       <% end %>
       <% if @model.library %>

--- a/app/views/problems/_filters.html.erb
+++ b/app/views/problems/_filters.html.erb
@@ -20,8 +20,7 @@
 									each do |cat| %>
 									<option
 										value="<%= cat %>"
-										<%= "selected" if params[:category]&.include?(cat.to_s) %>
-									><%= t("problems.categories.#{cat}") %></option>
+										<%= "selected" if params[:category]&.include?(cat.to_s) %>><%= t("problems.categories.#{cat}") %></option>
 								<% end %>
 							</select>
 						</div>
@@ -31,8 +30,7 @@
 								<% (Problem::SEVERITIES - [:silent]).each do |sev| %>
 									<option
 										value="<%= sev %>"
-										<%= "selected" if params[:severity]&.include?(sev.to_s) %>
-									><%= t("problems.severities.#{sev}") %></option>
+										<%= "selected" if params[:severity]&.include?(sev.to_s) %>><%= t("problems.severities.#{sev}") %></option>
 								<% end %>
 							</select>
 						</div>
@@ -40,11 +38,9 @@
 							<label><%= t(".type") %></label>
 							<select name="type[]" class="form-select" multiple=true>
 								<option value="<%= Model.model_name.param_key %>"
-									<%= "selected" if params[:type]&.include?(Model.model_name.param_key) %>
-								><%= Model.model_name.human %></option>
+									<%= "selected" if params[:type]&.include?(Model.model_name.param_key) %>><%= Model.model_name.human %></option>
 								<option value="<%= ModelFile.model_name.param_key %>"
-									<%= "selected" if params[:type]&.include?(ModelFile.model_name.param_key) %>
-								><%= ModelFile.model_name.human %></option>
+									<%= "selected" if params[:type]&.include?(ModelFile.model_name.param_key) %>><%= ModelFile.model_name.human %></option>
 							</select>
 						</div>
 					</div>
@@ -52,8 +48,7 @@
 						<div class="col">
 							<div class="form-check form-switch">
 								<input class="form-check-input" type="checkbox" name="show_ignored" value="true"
-									<%= "checked" if params[:show_ignored] == "true" %>
-								>
+									<%= "checked" if params[:show_ignored] == "true" %>>
 								<label class="form-check-label" for="show_ignored">
 									<%= t(".show_ignored") %>
 								</label>

--- a/app/views/problems/_filters.html.erb
+++ b/app/views/problems/_filters.html.erb
@@ -15,9 +15,9 @@
               <label><%= t(".category") %></label>
               <select name="category[]" class="form-select" multiple=true>
                 <% Problem::CATEGORIES
-                  .select { |x| Problem::DEFAULT_SEVERITIES[x].present? }
-                  .select { |x| current_user.problem_settings[x.to_s] != "silent" }
-                  .each do |cat| %>
+                     .select { |x| Problem::DEFAULT_SEVERITIES[x].present? }
+                     .select { |x| current_user.problem_settings[x.to_s] != "silent" }
+                     .each do |cat| %>
                   <option
                     value="<%= cat %>"
                     <%= "selected" if params[:category]&.include?(cat.to_s) %>><%= t("problems.categories.#{cat}") %></option>

--- a/app/views/problems/_filters.html.erb
+++ b/app/views/problems/_filters.html.erb
@@ -4,7 +4,7 @@
 		<div class="accordion-item">
 			<h2 class="accordion-header">
 				<button class="accordion-button <%= "collapsed" unless @filters_applied %>" type="button" data-bs-toggle="collapse" data-bs-target="#filters" aria-controls="filters">
-					<%= icon("filter", t(".title"))%>
+					<%= icon("filter", t(".title")) %>
 					<%= t ".title" %>
 				</button>
 			</h2>
@@ -42,7 +42,7 @@
 								<option value="<%= Model.model_name.param_key %>"
 									<%= "selected" if params[:type]&.include?(Model.model_name.param_key) %>
 								><%= Model.model_name.human %></option>
-								<option value="<%= ModelFile.model_name.param_key%>"
+								<option value="<%= ModelFile.model_name.param_key %>"
 									<%= "selected" if params[:type]&.include?(ModelFile.model_name.param_key) %>
 								><%= ModelFile.model_name.human %></option>
 							</select>

--- a/app/views/problems/_filters.html.erb
+++ b/app/views/problems/_filters.html.erb
@@ -14,10 +14,10 @@
             <div class="col col-sm-6 col-md-4">
               <label><%= t(".category") %></label>
               <select name="category[]" class="form-select" multiple=true>
-                <% Problem::CATEGORIES.
-                  select { |x| Problem::DEFAULT_SEVERITIES[x].present? }.
-                  select { |x| current_user.problem_settings[x.to_s] != "silent" }.
-                  each do |cat| %>
+                <% Problem::CATEGORIES
+                  .select { |x| Problem::DEFAULT_SEVERITIES[x].present? }
+                  .select { |x| current_user.problem_settings[x.to_s] != "silent" }
+                  .each do |cat| %>
                   <option
                     value="<%= cat %>"
                     <%= "selected" if params[:category]&.include?(cat.to_s) %>><%= t("problems.categories.#{cat}") %></option>

--- a/app/views/problems/_filters.html.erb
+++ b/app/views/problems/_filters.html.erb
@@ -1,66 +1,66 @@
 <form action="/problems" method="GET">
 
-	<div class="accordion accordion-flush mb-2">
-		<div class="accordion-item">
-			<h2 class="accordion-header">
-				<button class="accordion-button <%= "collapsed" unless @filters_applied %>" type="button" data-bs-toggle="collapse" data-bs-target="#filters" aria-controls="filters">
-					<%= icon("filter", t(".title")) %>
-					<%= t ".title" %>
-				</button>
-			</h2>
-			<div id="filters" class="accordion-collapse collapse <%= "show" if @filters_applied %>">
-				<div class="accordion-body">
-					<div class="row mb-2">
-						<div class="col col-sm-6 col-md-4">
-							<label><%= t(".category") %></label>
-							<select name="category[]" class="form-select" multiple=true>
-								<% Problem::CATEGORIES.
-									select { |x| Problem::DEFAULT_SEVERITIES[x].present? }.
-									select { |x| current_user.problem_settings[x.to_s] != "silent" }.
-									each do |cat| %>
-									<option
-										value="<%= cat %>"
-										<%= "selected" if params[:category]&.include?(cat.to_s) %>><%= t("problems.categories.#{cat}") %></option>
-								<% end %>
-							</select>
-						</div>
-						<div class="col col-sm-auto col-md-4">
-							<label><%= t(".severity") %></label>
-							<select name="severity[]" class="form-select" multiple=true>
-								<% (Problem::SEVERITIES - [:silent]).each do |sev| %>
-									<option
-										value="<%= sev %>"
-										<%= "selected" if params[:severity]&.include?(sev.to_s) %>><%= t("problems.severities.#{sev}") %></option>
-								<% end %>
-							</select>
-						</div>
-						<div class="col col-sm-auto col-md-4">
-							<label><%= t(".type") %></label>
-							<select name="type[]" class="form-select" multiple=true>
-								<option value="<%= Model.model_name.param_key %>"
-									<%= "selected" if params[:type]&.include?(Model.model_name.param_key) %>><%= Model.model_name.human %></option>
-								<option value="<%= ModelFile.model_name.param_key %>"
-									<%= "selected" if params[:type]&.include?(ModelFile.model_name.param_key) %>><%= ModelFile.model_name.human %></option>
-							</select>
-						</div>
-					</div>
-					<div class="row">
-						<div class="col">
-							<div class="form-check form-switch">
-								<input class="form-check-input" type="checkbox" name="show_ignored" value="true"
-									<%= "checked" if params[:show_ignored] == "true" %>>
-								<label class="form-check-label" for="show_ignored">
-									<%= t(".show_ignored") %>
-								</label>
-							</div>
-						</div>
-						<div class="col text-end">
-							<button type="submit" class="btn btn-primary"><%= t ".apply_filters" %></button>
-							<a href='/problems' class="btn btn-secondary"><%= t ".clear_filters" %></a>
-						</div>
-					</div>
-				</div>
-			</div>
-		</div>
-	</div>
+  <div class="accordion accordion-flush mb-2">
+    <div class="accordion-item">
+      <h2 class="accordion-header">
+        <button class="accordion-button <%= "collapsed" unless @filters_applied %>" type="button" data-bs-toggle="collapse" data-bs-target="#filters" aria-controls="filters">
+          <%= icon("filter", t(".title")) %>
+          <%= t ".title" %>
+        </button>
+      </h2>
+      <div id="filters" class="accordion-collapse collapse <%= "show" if @filters_applied %>">
+        <div class="accordion-body">
+          <div class="row mb-2">
+            <div class="col col-sm-6 col-md-4">
+              <label><%= t(".category") %></label>
+              <select name="category[]" class="form-select" multiple=true>
+                <% Problem::CATEGORIES.
+                  select { |x| Problem::DEFAULT_SEVERITIES[x].present? }.
+                  select { |x| current_user.problem_settings[x.to_s] != "silent" }.
+                  each do |cat| %>
+                  <option
+                    value="<%= cat %>"
+                    <%= "selected" if params[:category]&.include?(cat.to_s) %>><%= t("problems.categories.#{cat}") %></option>
+                <% end %>
+              </select>
+            </div>
+            <div class="col col-sm-auto col-md-4">
+              <label><%= t(".severity") %></label>
+              <select name="severity[]" class="form-select" multiple=true>
+                <% (Problem::SEVERITIES - [:silent]).each do |sev| %>
+                  <option
+                    value="<%= sev %>"
+                    <%= "selected" if params[:severity]&.include?(sev.to_s) %>><%= t("problems.severities.#{sev}") %></option>
+                <% end %>
+              </select>
+            </div>
+            <div class="col col-sm-auto col-md-4">
+              <label><%= t(".type") %></label>
+              <select name="type[]" class="form-select" multiple=true>
+                <option value="<%= Model.model_name.param_key %>"
+                  <%= "selected" if params[:type]&.include?(Model.model_name.param_key) %>><%= Model.model_name.human %></option>
+                <option value="<%= ModelFile.model_name.param_key %>"
+                  <%= "selected" if params[:type]&.include?(ModelFile.model_name.param_key) %>><%= ModelFile.model_name.human %></option>
+              </select>
+            </div>
+          </div>
+          <div class="row">
+            <div class="col">
+              <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" name="show_ignored" value="true"
+                  <%= "checked" if params[:show_ignored] == "true" %>>
+                <label class="form-check-label" for="show_ignored">
+                  <%= t(".show_ignored") %>
+                </label>
+              </div>
+            </div>
+            <div class="col text-end">
+              <button type="submit" class="btn btn-primary"><%= t ".apply_filters" %></button>
+              <a href='/problems' class="btn btn-secondary"><%= t ".clear_filters" %></a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
 </form>

--- a/app/views/problems/index.html.erb
+++ b/app/views/problems/index.html.erb
@@ -12,7 +12,7 @@
 
 <table class="table table-striped">
 	<% @problems.each do |problem| %>
-		<tr class="table-<%= problem_severity(problem) %> <%= problem.ignored && "opacity-50"%>">
+		<tr class="table-<%= problem_severity(problem) %> <%= problem.ignored && "opacity-50" %>">
 			<%= render partial: "#{problem.problematic_type.underscore}_#{problem.category}", locals: {problem: problem} %>
 			<td>
 				<% if problem.ignored %>

--- a/app/views/problems/index.html.erb
+++ b/app/views/problems/index.html.erb
@@ -5,24 +5,24 @@
 <%= paginate @problems %>
 
 <% if @problems.empty? %>
-	<div class="alert alert-info">
-		<%= t(".no_problems") %>
-	</div>
+  <div class="alert alert-info">
+    <%= t(".no_problems") %>
+  </div>
 <% end %>
 
 <table class="table table-striped">
-	<% @problems.each do |problem| %>
-		<tr class="table-<%= problem_severity(problem) %> <%= problem.ignored && "opacity-50" %>">
-			<%= render partial: "#{problem.problematic_type.underscore}_#{problem.category}", locals: {problem: problem} %>
-			<td>
-				<% if problem.ignored %>
-					<%= link_to icon("eye-fill", t(".unignore")), problem_path(problem, problem: { ignored: false }), method: :patch, class: "btn btn-outline-secondary" %>
-				<% else %>
-					<%= link_to icon("eye-slash", t(".ignore")), problem_path(problem, problem: { ignored: true }), method: :patch, class: "btn btn-outline-secondary" %>
-				<% end %>
-			</td>
-		</tr>
-	<% end %>
+  <% @problems.each do |problem| %>
+    <tr class="table-<%= problem_severity(problem) %> <%= problem.ignored && "opacity-50" %>">
+      <%= render partial: "#{problem.problematic_type.underscore}_#{problem.category}", locals: {problem: problem} %>
+      <td>
+        <% if problem.ignored %>
+          <%= link_to icon("eye-fill", t(".unignore")), problem_path(problem, problem: { ignored: false }), method: :patch, class: "btn btn-outline-secondary" %>
+        <% else %>
+          <%= link_to icon("eye-slash", t(".ignore")), problem_path(problem, problem: { ignored: true }), method: :patch, class: "btn btn-outline-secondary" %>
+        <% end %>
+      </td>
+    </tr>
+  <% end %>
 </table>
 
 <%= paginate @problems %>

--- a/app/views/problems/index.html.erb
+++ b/app/views/problems/index.html.erb
@@ -16,9 +16,9 @@
       <%= render partial: "#{problem.problematic_type.underscore}_#{problem.category}", locals: {problem: problem} %>
       <td>
         <% if problem.ignored %>
-          <%= link_to icon("eye-fill", t(".unignore")), problem_path(problem, problem: { ignored: false }), method: :patch, class: "btn btn-outline-secondary" %>
+          <%= link_to icon("eye-fill", t(".unignore")), problem_path(problem, problem: {ignored: false}), method: :patch, class: "btn btn-outline-secondary" %>
         <% else %>
-          <%= link_to icon("eye-slash", t(".ignore")), problem_path(problem, problem: { ignored: true }), method: :patch, class: "btn btn-outline-secondary" %>
+          <%= link_to icon("eye-slash", t(".ignore")), problem_path(problem, problem: {ignored: true}), method: :patch, class: "btn btn-outline-secondary" %>
         <% end %>
       </td>
     </tr>

--- a/app/views/problems/index.html.erb
+++ b/app/views/problems/index.html.erb
@@ -4,7 +4,6 @@
 
 <%= paginate @problems %>
 
-
 <% if @problems.empty? %>
 	<div class="alert alert-info">
 		<%= t(".no_problems") %>

--- a/app/views/settings/_folder_settings.html.erb
+++ b/app/views/settings/_folder_settings.html.erb
@@ -28,20 +28,20 @@
       </li>
     </ul>
     <div class="row mb-2">
-      <%= form.label "Model path template", for: "folders[model_path_template]", class: "col-sm-4 col-form-label"%>
+      <%= form.label "Model path template", for: "folders[model_path_template]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8 form-check form-switch">
         <%= form.text_field "folders[model_path_template]", value: SiteSettings.model_path_template, class: "form-control" %>
       </div>
     </div>
     <div class="row mb-2">
-      <%= form.label "Populate metadata from path and template during scan", for: "folders[parse_metadata_from_path]", class: "col-sm-4 col-form-label"%>
+      <%= form.label "Populate metadata from path and template during scan", for: "folders[parse_metadata_from_path]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8 form-check form-switch">
         <%= form.check_box "folders[parse_metadata_from_path]", checked: SiteSettings.parse_metadata_from_path, class: "form-check-input" %>
         <small>Sets creator, collection, and tags based on template</small>
       </div>
     </div>
     <div class="row mb-2">
-      <%= form.label "Use safe folder names", for: "folders[safe_folder_names]", class: "col-sm-4 col-form-label"%>
+      <%= form.label "Use safe folder names", for: "folders[safe_folder_names]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8 form-check form-switch">
         <%= form.check_box "folders[safe_folder_names]", checked: SiteSettings.safe_folder_names, class: "form-check-input" %>
         <small>e.g. <code>spinal-tap</code> instead of <code>Spın̈al Tap</code></small>

--- a/app/views/settings/_library_settings.html.erb
+++ b/app/views/settings/_library_settings.html.erb
@@ -36,7 +36,7 @@
             <div class="col-sm-10">
               <% library.tag_regex.each do |reg| %>
                 <%= link_to "Check", models_path(library: library.id, missingtag: reg), {class: "btn btn-outline-secondary"} %>
-                <%= content_tag(:span,reg, class: "col-sm-10") %><br >
+                <%= content_tag(:span,reg, class: "col-sm-10") %><br>
               <% end %>
             </div>
             <span id="libraryRegexHelp" class="form-text">Check for models missing tags matching these regex.</span>

--- a/app/views/settings/_library_settings.html.erb
+++ b/app/views/settings/_library_settings.html.erb
@@ -5,7 +5,7 @@
       See library details and modify.
     </p>
     <ul class="list-unstyled">
-    <% Library.all.each do |library| %>
+    <% Library.find_each do |library| %>
         <li><details><summary><%= library.name %></summary>
         <div class="card-body">
           <div class="row">

--- a/app/views/settings/_library_settings.html.erb
+++ b/app/views/settings/_library_settings.html.erb
@@ -36,7 +36,7 @@
             <div class="col-sm-10">
               <% library.tag_regex.each do |reg| %>
                 <%= link_to "Check", models_path(library: library.id, missingtag: reg), {class: "btn btn-outline-secondary"} %>
-                <%= content_tag(:span,reg, class: "col-sm-10") %><br />
+                <%= content_tag(:span,reg, class: "col-sm-10") %><br >
               <% end %>
             </div>
             <span id="libraryRegexHelp" class="form-text">Check for models missing tags matching these regex.</span>

--- a/app/views/settings/_library_settings.html.erb
+++ b/app/views/settings/_library_settings.html.erb
@@ -9,34 +9,34 @@
         <li><details><summary><%= library.name %></summary>
         <div class="card-body">
           <div class="row">
-            <%= content_tag(:span,"Name", class: "col-sm") %>
-            <%= content_tag(:span,library.name, class: "col-sm-10") %>
+            <%= content_tag(:span, "Name", class: "col-sm") %>
+            <%= content_tag(:span, library.name, class: "col-sm-10") %>
           </div>
           <div class="row input-group">
-            <%= content_tag(:span,"Path", class: "col-sm") %>
-            <%= content_tag(:span,library.path, class: "col-sm-10") %>
+            <%= content_tag(:span, "Path", class: "col-sm") %>
+            <%= content_tag(:span, library.path, class: "col-sm-10") %>
           </div>
           <div class="row input-group">
-            <%= content_tag(:span,"Caption", class: "col-sm") %>
-            <%= content_tag(:span,library.caption, class: "col-sm-10") %>
+            <%= content_tag(:span, "Caption", class: "col-sm") %>
+            <%= content_tag(:span, library.caption, class: "col-sm-10") %>
             <span id="libraryCaptionHelp" class="form-text">Hover over library in header to see caption.</span>
           </div>
           <div class="row input-group">
-            <%= content_tag(:span,"Icon", class: "col-sm") %>
-            <%= content_tag(:span,library.icon, class: "col-sm-10") %>
+            <%= content_tag(:span, "Icon", class: "col-sm") %>
+            <%= content_tag(:span, library.icon, class: "col-sm-10") %>
             <span id="libraryIconHelp" class="form-text">Icons per library <a href="https://icons.getbootstrap.com/" target="_blank">Boostrap icon page</a></span>
           </div>
           <div class="row input-group">
-            <%= content_tag(:span,"Notes", class: "col-sm") %>
-            <%= content_tag(:span,library.notes, class: "col-sm-10") %>
+            <%= content_tag(:span, "Notes", class: "col-sm") %>
+            <%= content_tag(:span, library.notes, class: "col-sm-10") %>
             <span id="libraryNotesHelp" class="form-text">Notes are just on this page for now.</span>
           </div>
           <div class="row input-group">
-            <%= content_tag(:span,"Required Tags", class: "col-sm") %>
+            <%= content_tag(:span, "Required Tags", class: "col-sm") %>
             <div class="col-sm-10">
               <% library.tag_regex.each do |reg| %>
                 <%= link_to "Check", models_path(library: library.id, missingtag: reg), {class: "btn btn-outline-secondary"} %>
-                <%= content_tag(:span,reg, class: "col-sm-10") %><br>
+                <%= content_tag(:span, reg, class: "col-sm-10") %><br>
               <% end %>
             </div>
             <span id="libraryRegexHelp" class="form-text">Check for models missing tags matching these regex.</span>

--- a/app/views/settings/_pagination_settings.html.erb
+++ b/app/views/settings/_pagination_settings.html.erb
@@ -8,25 +8,25 @@
     </p>
 
     <div class="row">
-      <%= form.label "Paginate models", for: "pagination[models]", class: "col col-form-label"%>
+      <%= form.label "Paginate models", for: "pagination[models]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
         <%= form.check_box "pagination[models]", checked: @user.pagination_settings["models"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
-      <%= form.label "Paginate creators", for: "pagination[creators]", class: "col col-form-label"%>
+      <%= form.label "Paginate creators", for: "pagination[creators]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
         <%= form.check_box "pagination[creators]", checked: @user.pagination_settings["creators"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
-      <%= form.label "Paginate collections", for: "pagination[collections]", class: "col col-form-label"%>
+      <%= form.label "Paginate collections", for: "pagination[collections]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
         <%= form.check_box "pagination[collections]", checked: @user.pagination_settings["collections"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
-      <%= form.label "Items per page", for: "pagination[per_page]", class: "col col-form-label"%>
+      <%= form.label "Items per page", for: "pagination[per_page]", class: "col col-form-label" %>
       <div class="col">
         <%= form.number_field "pagination[per_page]", value: @user.pagination_settings["per_page"], in: 1..100, class: 'form-control' %>
       </div>

--- a/app/views/settings/_pagination_settings.html.erb
+++ b/app/views/settings/_pagination_settings.html.erb
@@ -28,7 +28,7 @@
     <div class="row">
       <%= form.label "Items per page", for: "pagination[per_page]", class: "col col-form-label" %>
       <div class="col">
-        <%= form.number_field "pagination[per_page]", value: @user.pagination_settings["per_page"], in: 1..100, class: 'form-control' %>
+        <%= form.number_field "pagination[per_page]", value: @user.pagination_settings["per_page"], in: 1..100, class: "form-control" %>
       </div>
     </div>
   </div>

--- a/app/views/settings/_problem_settings.html.erb
+++ b/app/views/settings/_problem_settings.html.erb
@@ -8,13 +8,13 @@
       <% next if Problem::DEFAULT_SEVERITIES[category].nil? # Skip deprecated categories; they don't appear in the defaults list %>
       <div class="row">
         <%= form.label t("problems.categories.#{category}"),
-          for: "problems[#{category}]",
-          class: "col col-form-label" %>
+              for: "problems[#{category}]",
+              class: "col col-form-label" %>
         <div class="col">
           <%= form.select "problems[#{category}]",
-            Problem::SEVERITIES.map { |s| [t("problems.severities.#{s}"), s] },
-            {selected: @user.problem_settings[category.to_s]},
-            class: "form-select" %>
+                Problem::SEVERITIES.map { |s| [t("problems.severities.#{s}"), s] },
+                {selected: @user.problem_settings[category.to_s]},
+                class: "form-select" %>
         </div>
       </div>
     <% end %>

--- a/app/views/settings/_problem_settings.html.erb
+++ b/app/views/settings/_problem_settings.html.erb
@@ -2,8 +2,8 @@
   <h3 class="card-header"><%= t(".title") %></h3>
   <div class="card-body">
     <p class='lead'>
-			<%= t(".description") %>
-		</p>
+      <%= t(".description") %>
+    </p>
     <% Problem::CATEGORIES.each do |category| %>
       <% next if Problem::DEFAULT_SEVERITIES[category].nil? # Skip deprecated categories; they don't appear in the defaults list %>
       <div class="row">

--- a/app/views/settings/_problem_settings.html.erb
+++ b/app/views/settings/_problem_settings.html.erb
@@ -9,14 +9,12 @@
       <div class="row">
         <%= form.label t("problems.categories.#{category}"),
           for: "problems[#{category}]",
-          class: "col col-form-label"
-        %>
+          class: "col col-form-label" %>
         <div class="col">
           <%= form.select "problems[#{category}]",
             Problem::SEVERITIES.map { |s| [t("problems.severities.#{s}"), s] },
             {selected: @user.problem_settings[category.to_s]},
-            class: "form-select"
-          %>
+            class: "form-select" %>
         </div>
       </div>
     <% end %>

--- a/app/views/settings/_renderer_settings.html.erb
+++ b/app/views/settings/_renderer_settings.html.erb
@@ -5,7 +5,7 @@
 			Customise settings for 3d rendered previews.
 		</p>
 		<div class="row">
-			<%= form.label t(".auto_load_max_size.label"), for: "renderer[auto_load_max_size]", class: "col col-form-label"%>
+			<%= form.label t(".auto_load_max_size.label"), for: "renderer[auto_load_max_size]", class: "col col-form-label" %>
     	<div class="col">
 				<%= form.select "renderer[auto_load_max_size]", [
 						[t(".auto_load_max_size.never"), 0],
@@ -26,37 +26,37 @@
 			</div>
 		</div>
 		<div class="row">
-			<%= form.label "Show ground plane", for: "renderer[show_grid]", class: "col col-form-label"%>
+			<%= form.label "Show ground plane", for: "renderer[show_grid]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
 				<%= form.check_box "renderer[show_grid]", checked: @user.renderer_settings["show_grid"], class: "form-check-input" %>
 			</div>
 		</div>
 		<div class="row">
-			<%= form.label "Ground plane size (mm)", for: "renderer[grid_width]", class: "col col-form-label"%>
+			<%= form.label "Ground plane size (mm)", for: "renderer[grid_width]", class: "col col-form-label" %>
 			<div class="col">
 				<%= form.number_field "renderer[grid_width]", value: @user.renderer_settings["grid_width"], class: "form-control" %>
 			</div>
 		</div>
 		<div class="row">
-			<%= form.label "Enable pan/zoom controls", for: "renderer[enable_pan_zoom]", class: "col col-form-label"%>
+			<%= form.label "Enable pan/zoom controls", for: "renderer[enable_pan_zoom]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
 				<%= form.check_box "renderer[enable_pan_zoom]", checked: @user.renderer_settings["enable_pan_zoom"], class: "form-check-input" %>
 			</div>
 		</div>
 		<div class="row">
-			<%= form.label "Background colour", for: "renderer[background_colour]", class: "col col-form-label"%>
+			<%= form.label "Background colour", for: "renderer[background_colour]", class: "col col-form-label" %>
 			<div class="col">
 				<%= form.color_field "renderer[background_colour]", value: @user.renderer_settings["background_colour"], class: "form-control" %>
 			</div>
 		</div>
 		<div class="row">
-			<%= form.label "Rendering style", for: "renderer[render_style]", class: "col col-form-label"%>
+			<%= form.label "Rendering style", for: "renderer[render_style]", class: "col col-form-label" %>
     	<div class="col">
 				<%= form.select "renderer[render_style]", [[t("renderer.style.normals"), "normals"], [t("renderer.style.lambert"), "lambert"]], {selected: @user.renderer_settings["render_style"]}, {class: "form-select"} %>
 			</div>
 		</div>
 		<div class="row">
-			<%= form.label "Object colour", for: "renderer[object_colour]", class: "col col-form-label"%>
+			<%= form.label "Object colour", for: "renderer[object_colour]", class: "col col-form-label" %>
 	    <div class="col">
 				<%= form.color_field "renderer[object_colour]", value: @user.renderer_settings["object_colour"], class: "form-control" %>
 			</div>

--- a/app/views/settings/_renderer_settings.html.erb
+++ b/app/views/settings/_renderer_settings.html.erb
@@ -7,22 +7,23 @@
     <div class="row">
       <%= form.label t(".auto_load_max_size.label"), for: "renderer[auto_load_max_size]", class: "col col-form-label" %>
       <div class="col">
-        <%= form.select "renderer[auto_load_max_size]", [
-            [t(".auto_load_max_size.never"), 0],
-            [t(".auto_load_max_size.under_2"), 2],
-            [t(".auto_load_max_size.under_4"), 4],
-            [t(".auto_load_max_size.under_8"), 8],
-            [t(".auto_load_max_size.under_16"), 16],
-            [t(".auto_load_max_size.under_32"), 32],
-            [t(".auto_load_max_size.under_64"), 64],
-            [t(".auto_load_max_size.under_128"), 128],
-            [t(".auto_load_max_size.under_256"), 256],
-            [t(".auto_load_max_size.under_512"), 512],
-            [t(".auto_load_max_size.under_1024"), 1024],
-            [t(".auto_load_max_size.always"), 9_999_999]
-          ],
-          {selected: @user.renderer_settings["auto_load_max_size"] || 9_999_999},
-          {class: "form-select"} %>
+        <%= form.select "renderer[auto_load_max_size]",
+              [
+                [t(".auto_load_max_size.never"), 0],
+                [t(".auto_load_max_size.under_2"), 2],
+                [t(".auto_load_max_size.under_4"), 4],
+                [t(".auto_load_max_size.under_8"), 8],
+                [t(".auto_load_max_size.under_16"), 16],
+                [t(".auto_load_max_size.under_32"), 32],
+                [t(".auto_load_max_size.under_64"), 64],
+                [t(".auto_load_max_size.under_128"), 128],
+                [t(".auto_load_max_size.under_256"), 256],
+                [t(".auto_load_max_size.under_512"), 512],
+                [t(".auto_load_max_size.under_1024"), 1024],
+                [t(".auto_load_max_size.always"), 9_999_999]
+            ],
+              {selected: @user.renderer_settings["auto_load_max_size"] || 9_999_999},
+              {class: "form-select"} %>
       </div>
     </div>
     <div class="row">

--- a/app/views/settings/_renderer_settings.html.erb
+++ b/app/views/settings/_renderer_settings.html.erb
@@ -22,8 +22,7 @@
 						[t(".auto_load_max_size.always"), 9_999_999],
 					],
 					{selected: @user.renderer_settings["auto_load_max_size"] || 9_999_999},
-					{class: "form-select"}
-				%>
+					{class: "form-select"} %>
 			</div>
 		</div>
 		<div class="row">

--- a/app/views/settings/_renderer_settings.html.erb
+++ b/app/views/settings/_renderer_settings.html.erb
@@ -21,7 +21,7 @@
                 [t(".auto_load_max_size.under_512"), 512],
                 [t(".auto_load_max_size.under_1024"), 1024],
                 [t(".auto_load_max_size.always"), 9_999_999]
-            ],
+              ],
               {selected: @user.renderer_settings["auto_load_max_size"] || 9_999_999},
               {class: "form-select"} %>
       </div>

--- a/app/views/settings/_renderer_settings.html.erb
+++ b/app/views/settings/_renderer_settings.html.erb
@@ -19,7 +19,7 @@
             [t(".auto_load_max_size.under_256"), 256],
             [t(".auto_load_max_size.under_512"), 512],
             [t(".auto_load_max_size.under_1024"), 1024],
-            [t(".auto_load_max_size.always"), 9_999_999],
+            [t(".auto_load_max_size.always"), 9_999_999]
           ],
           {selected: @user.renderer_settings["auto_load_max_size"] || 9_999_999},
           {class: "form-select"} %>

--- a/app/views/settings/_renderer_settings.html.erb
+++ b/app/views/settings/_renderer_settings.html.erb
@@ -2,64 +2,64 @@
   <h3 class="card-header">Renderer</h3>
   <div class="card-body">
     <p class='lead'>
-			Customise settings for 3d rendered previews.
-		</p>
-		<div class="row">
-			<%= form.label t(".auto_load_max_size.label"), for: "renderer[auto_load_max_size]", class: "col col-form-label" %>
-    	<div class="col">
-				<%= form.select "renderer[auto_load_max_size]", [
-						[t(".auto_load_max_size.never"), 0],
-						[t(".auto_load_max_size.under_2"), 2],
-						[t(".auto_load_max_size.under_4"), 4],
-						[t(".auto_load_max_size.under_8"), 8],
-						[t(".auto_load_max_size.under_16"), 16],
-						[t(".auto_load_max_size.under_32"), 32],
-						[t(".auto_load_max_size.under_64"), 64],
-						[t(".auto_load_max_size.under_128"), 128],
-						[t(".auto_load_max_size.under_256"), 256],
-						[t(".auto_load_max_size.under_512"), 512],
-						[t(".auto_load_max_size.under_1024"), 1024],
-						[t(".auto_load_max_size.always"), 9_999_999],
-					],
-					{selected: @user.renderer_settings["auto_load_max_size"] || 9_999_999},
-					{class: "form-select"} %>
-			</div>
-		</div>
-		<div class="row">
-			<%= form.label "Show ground plane", for: "renderer[show_grid]", class: "col col-form-label" %>
+      Customise settings for 3d rendered previews.
+    </p>
+    <div class="row">
+      <%= form.label t(".auto_load_max_size.label"), for: "renderer[auto_load_max_size]", class: "col col-form-label" %>
+      <div class="col">
+        <%= form.select "renderer[auto_load_max_size]", [
+            [t(".auto_load_max_size.never"), 0],
+            [t(".auto_load_max_size.under_2"), 2],
+            [t(".auto_load_max_size.under_4"), 4],
+            [t(".auto_load_max_size.under_8"), 8],
+            [t(".auto_load_max_size.under_16"), 16],
+            [t(".auto_load_max_size.under_32"), 32],
+            [t(".auto_load_max_size.under_64"), 64],
+            [t(".auto_load_max_size.under_128"), 128],
+            [t(".auto_load_max_size.under_256"), 256],
+            [t(".auto_load_max_size.under_512"), 512],
+            [t(".auto_load_max_size.under_1024"), 1024],
+            [t(".auto_load_max_size.always"), 9_999_999],
+          ],
+          {selected: @user.renderer_settings["auto_load_max_size"] || 9_999_999},
+          {class: "form-select"} %>
+      </div>
+    </div>
+    <div class="row">
+      <%= form.label "Show ground plane", for: "renderer[show_grid]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
-				<%= form.check_box "renderer[show_grid]", checked: @user.renderer_settings["show_grid"], class: "form-check-input" %>
-			</div>
-		</div>
-		<div class="row">
-			<%= form.label "Ground plane size (mm)", for: "renderer[grid_width]", class: "col col-form-label" %>
-			<div class="col">
-				<%= form.number_field "renderer[grid_width]", value: @user.renderer_settings["grid_width"], class: "form-control" %>
-			</div>
-		</div>
-		<div class="row">
-			<%= form.label "Enable pan/zoom controls", for: "renderer[enable_pan_zoom]", class: "col col-form-label" %>
+        <%= form.check_box "renderer[show_grid]", checked: @user.renderer_settings["show_grid"], class: "form-check-input" %>
+      </div>
+    </div>
+    <div class="row">
+      <%= form.label "Ground plane size (mm)", for: "renderer[grid_width]", class: "col col-form-label" %>
+      <div class="col">
+        <%= form.number_field "renderer[grid_width]", value: @user.renderer_settings["grid_width"], class: "form-control" %>
+      </div>
+    </div>
+    <div class="row">
+      <%= form.label "Enable pan/zoom controls", for: "renderer[enable_pan_zoom]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
-				<%= form.check_box "renderer[enable_pan_zoom]", checked: @user.renderer_settings["enable_pan_zoom"], class: "form-check-input" %>
-			</div>
-		</div>
-		<div class="row">
-			<%= form.label "Background colour", for: "renderer[background_colour]", class: "col col-form-label" %>
-			<div class="col">
-				<%= form.color_field "renderer[background_colour]", value: @user.renderer_settings["background_colour"], class: "form-control" %>
-			</div>
-		</div>
-		<div class="row">
-			<%= form.label "Rendering style", for: "renderer[render_style]", class: "col col-form-label" %>
-    	<div class="col">
-				<%= form.select "renderer[render_style]", [[t("renderer.style.normals"), "normals"], [t("renderer.style.lambert"), "lambert"]], {selected: @user.renderer_settings["render_style"]}, {class: "form-select"} %>
-			</div>
-		</div>
-		<div class="row">
-			<%= form.label "Object colour", for: "renderer[object_colour]", class: "col col-form-label" %>
-	    <div class="col">
-				<%= form.color_field "renderer[object_colour]", value: @user.renderer_settings["object_colour"], class: "form-control" %>
-			</div>
-		</div>
-	</div>
+        <%= form.check_box "renderer[enable_pan_zoom]", checked: @user.renderer_settings["enable_pan_zoom"], class: "form-check-input" %>
+      </div>
+    </div>
+    <div class="row">
+      <%= form.label "Background colour", for: "renderer[background_colour]", class: "col col-form-label" %>
+      <div class="col">
+        <%= form.color_field "renderer[background_colour]", value: @user.renderer_settings["background_colour"], class: "form-control" %>
+      </div>
+    </div>
+    <div class="row">
+      <%= form.label "Rendering style", for: "renderer[render_style]", class: "col col-form-label" %>
+      <div class="col">
+        <%= form.select "renderer[render_style]", [[t("renderer.style.normals"), "normals"], [t("renderer.style.lambert"), "lambert"]], {selected: @user.renderer_settings["render_style"]}, {class: "form-select"} %>
+      </div>
+    </div>
+    <div class="row">
+      <%= form.label "Object colour", for: "renderer[object_colour]", class: "col col-form-label" %>
+      <div class="col">
+        <%= form.color_field "renderer[object_colour]", value: @user.renderer_settings["object_colour"], class: "form-control" %>
+      </div>
+    </div>
+  </div>
 </div>

--- a/app/views/settings/_tag_cloud_settings.html.erb
+++ b/app/views/settings/_tag_cloud_settings.html.erb
@@ -22,7 +22,7 @@
     <div class="row">
       <%= form.label "Sorting", for: "tag_cloud[sorting]", class: "col col-form-label" %>
       <div class="col">
-        <%= form.select "tag_cloud[sorting]", ["frequency","alphabetical"],
+        <%= form.select "tag_cloud[sorting]", ["frequency", "alphabetical"],
           {selected: @user.tag_cloud_settings["sorting"]},
           class: "form-select" %>
       </div>

--- a/app/views/settings/_tag_cloud_settings.html.erb
+++ b/app/views/settings/_tag_cloud_settings.html.erb
@@ -23,8 +23,8 @@
       <%= form.label "Sorting", for: "tag_cloud[sorting]", class: "col col-form-label" %>
       <div class="col">
         <%= form.select "tag_cloud[sorting]", ["frequency", "alphabetical"],
-          {selected: @user.tag_cloud_settings["sorting"]},
-          class: "form-select" %>
+              {selected: @user.tag_cloud_settings["sorting"]},
+              class: "form-select" %>
       </div>
     </div>
     <div class="row mb-2">

--- a/app/views/settings/_tag_cloud_settings.html.erb
+++ b/app/views/settings/_tag_cloud_settings.html.erb
@@ -24,8 +24,7 @@
       <div class="col">
         <%= form.select "tag_cloud[sorting]", ["frequency","alphabetical"],
           {selected: @user.tag_cloud_settings["sorting"]},
-          class: "form-select"
-        %>
+          class: "form-select" %>
       </div>
     </div>
     <div class="row mb-2">

--- a/app/views/settings/_tag_cloud_settings.html.erb
+++ b/app/views/settings/_tag_cloud_settings.html.erb
@@ -2,25 +2,25 @@
   <h3 class="card-header">Tag Cloud</h3>
   <div class="card-body">
     <div class="row">
-      <%= form.label "Minimum count of tag for display", for: "tag_cloud[threshold]", class: "col col-form-label"%>
+      <%= form.label "Minimum count of tag for display", for: "tag_cloud[threshold]", class: "col col-form-label" %>
       <div class="col">
         <%= form.text_field "tag_cloud[threshold]", value: @user.tag_cloud_settings["threshold"], class: "form-control" %>
       </div>
     </div>
     <div class="row">
-      <%= form.label "Display tag count for individual tags", for: "tag_cloud[heatmap]", class: "col col-form-label"%>
+      <%= form.label "Display tag count for individual tags", for: "tag_cloud[heatmap]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
         <%= form.check_box "tag_cloud[heatmap]", checked: @user.tag_cloud_settings["heatmap"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
-      <%= form.label "Hide unrelated tags in filtered lists", for: "tag_cloud[hide_unrelated]", class: "col col-form-label"%>
+      <%= form.label "Hide unrelated tags in filtered lists", for: "tag_cloud[hide_unrelated]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
         <%= form.check_box "tag_cloud[hide_unrelated]", checked: @user.tag_cloud_settings["hide_unrelated"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
-      <%= form.label "Sorting", for: "tag_cloud[sorting]", class: "col col-form-label"%>
+      <%= form.label "Sorting", for: "tag_cloud[sorting]", class: "col col-form-label" %>
       <div class="col">
         <%= form.select "tag_cloud[sorting]", ["frequency","alphabetical"],
           {selected: @user.tag_cloud_settings["sorting"]},
@@ -28,7 +28,7 @@
       </div>
     </div>
     <div class="row mb-2">
-      <%= form.label "Use delimiter to represent keypairs", for: "tag_cloud[keypair]", class: "col col-form-label"%>
+      <%= form.label "Use delimiter to represent keypairs", for: "tag_cloud[keypair]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
         <%= form.check_box "tag_cloud[keypair]", checked: @user.tag_cloud_settings["keypair"], class: "form-check-input" %>
       </div>

--- a/app/views/settings/_tag_settings.html.erb
+++ b/app/views/settings/_tag_settings.html.erb
@@ -7,7 +7,7 @@
     <div class="row mb-2">
       <%= form.label "Automatically tag new models with", for: "model_tags[auto_tag_new]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8">
-        <%= form.text_field "model_tags[auto_tag_new]", value: SiteSettings.model_tags_auto_tag_new, class: 'form-control' %>
+        <%= form.text_field "model_tags[auto_tag_new]", value: SiteSettings.model_tags_auto_tag_new, class: "form-control" %>
       </div>
     </div>
     <div class="row mb-2">
@@ -26,13 +26,13 @@
     <div class="row mb-2">
       <%= form.label "Stop words locale", for: "model_tags[stop_words_locale]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8">
-        <%= form.text_field "model_tags[stop_words_locale]", value: SiteSettings.model_tags_stop_words_locale, class: 'form-control' %>
+        <%= form.text_field "model_tags[stop_words_locale]", value: SiteSettings.model_tags_stop_words_locale, class: "form-control" %>
       </div>
     </div>
     <div class="row mb-2">
       <%= form.label "Custom stop words", for: "model_tags[custom_stop_words]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8">
-        <%= form.text_field "model_tags[custom_stop_words]", value: SiteSettings.model_tags_custom_stop_words, class: 'form-control' %>
+        <%= form.text_field "model_tags[custom_stop_words]", value: SiteSettings.model_tags_custom_stop_words, class: "form-control" %>
       </div>
     </div>
   </div>

--- a/app/views/settings/_tag_settings.html.erb
+++ b/app/views/settings/_tag_settings.html.erb
@@ -5,32 +5,32 @@
       Add tags to all newly-scanned models, and filter out certain words ("stop words") during automatic tag creation. Affects all users.
     </p>
     <div class="row mb-2">
-      <%= form.label "Automatically tag new models with", for: "model_tags[auto_tag_new]", class: "col-sm-4 col-form-label"%>
+      <%= form.label "Automatically tag new models with", for: "model_tags[auto_tag_new]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8">
         <%= form.text_field "model_tags[auto_tag_new]", value: SiteSettings.model_tags_auto_tag_new, class: 'form-control' %>
       </div>
     </div>
     <div class="row mb-2">
-      <%= form.label "Create tags from model directory name", for: "model_tags[tag_model_directory_name]", class: "col-sm-4 col-form-label"%>
+      <%= form.label "Create tags from model directory name", for: "model_tags[tag_model_directory_name]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8 form-check form-switch">
         <%= form.check_box "model_tags[tag_model_directory_name]", checked: SiteSettings.model_tags_tag_model_directory_name, class: "form-check-input" %>
         <small>Warning: Can produce a lot of tags!</small>
       </div>
     </div>
     <div class="row mb-2">
-      <%= form.label "Filter out stop words", for: "model_tags[filter_stop_words]", class: "col-sm-4 col-form-label"%>
+      <%= form.label "Filter out stop words", for: "model_tags[filter_stop_words]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8 form-check form-switch">
         <%= form.check_box "model_tags[filter_stop_words]", checked: SiteSettings.model_tags_filter_stop_words, class: "form-check-input" %>
       </div>
     </div>
     <div class="row mb-2">
-      <%= form.label "Stop words locale", for: "model_tags[stop_words_locale]", class: "col-sm-4 col-form-label"%>
+      <%= form.label "Stop words locale", for: "model_tags[stop_words_locale]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8">
         <%= form.text_field "model_tags[stop_words_locale]", value: SiteSettings.model_tags_stop_words_locale, class: 'form-control' %>
       </div>
     </div>
     <div class="row mb-2">
-      <%= form.label "Custom stop words", for: "model_tags[custom_stop_words]", class: "col-sm-4 col-form-label"%>
+      <%= form.label "Custom stop words", for: "model_tags[custom_stop_words]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8">
         <%= form.text_field "model_tags[custom_stop_words]", value: SiteSettings.model_tags_custom_stop_words, class: 'form-control' %>
       </div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -3,12 +3,12 @@
 <%= form_with url: user_settings_path(user: @user), method: :patch do |form| %>
   <div class="row mb-4">
     <div class="col">
-    	<%= render "pagination_settings", form: form %>
+      <%= render "pagination_settings", form: form %>
       <%= render "tag_cloud_settings", form: form %>
     </div>
     <div class="col">
       <%= render "renderer_settings", form: form %>
-    	<%= render "problem_settings", form: form %>
+      <%= render "problem_settings", form: form %>
     </div>
   </div>
 

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -32,11 +32,11 @@
 
   <div class="row mb-4">
     <div class='col'>
-      <button type="submit" class="btn btn-primary"><%= icon('save', 'Save') %> Save Settings</button>
+      <button type="submit" class="btn btn-primary"><%= icon("save", "Save") %> Save Settings</button>
     </div>
     <% if current_user.admin? %>
       <div class='col text-end'>
-        <%= link_to "#{icon('tools', 'Administration')} Advanced Administration".html_safe, '/admin', class: "btn btn-danger #{SiteSettings.demo_mode? ? "disabled" : ""}" %>
+        <%= link_to "#{icon('tools', 'Administration')} Advanced Administration".html_safe, "/admin", class: "btn btn-danger #{SiteSettings.demo_mode? ? "disabled" : ""}" %>
       </div>
     <% end %>
     </p>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -1,6 +1,5 @@
 <h1>Settings</h1>
 
-
 <%= form_with url: user_settings_path(user: @user), method: :patch do |form| %>
   <div class="row mb-4">
     <div class="col">

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -36,7 +36,7 @@
     </div>
     <% if current_user.admin? %>
       <div class='col text-end'>
-        <%= link_to "#{icon('tools', 'Administration')} Advanced Administration".html_safe, "/admin", class: "btn btn-danger #{SiteSettings.demo_mode? ? "disabled" : ""}" %>
+        <%= link_to "#{icon("tools", "Administration")} Advanced Administration".html_safe, "/admin", class: "btn btn-danger #{SiteSettings.demo_mode? ? "disabled" : ""}" %>
       </div>
     <% end %>
     </p>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -1,4 +1,4 @@
-<%= form_tag({:action => "create"}, :multipart => true) do %>
+<%= form_tag({action: "create"}, multipart: true) do %>
 
   <div class="row mb-3 input-group">
     <%= label :library_pick, "Library:", class: "col-sm-2 col-form-label" %>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -12,9 +12,9 @@
     <%= label :upload, "Select File", for: "upload", class: "col-sm-2 col-form-label" %>
     <div class='col-sm-10 ps-0'>
       <%= file_field "upload", "datafiles", {
-        multiple: true,
-        accept: "application/zip,application/x-rar-compressed,application/x-7z-compressed,application/x-bzip2,application/x-bzip,application/gzip"
-      } %>
+            multiple: true,
+            accept: "application/zip,application/x-rar-compressed,application/x-7z-compressed,application/x-bzip2,application/x-bzip,application/gzip"
+          } %>
       <div id="uploadHelp" class="form-text">Supported file types: zip, rar, 7z, bzip, gzip</div>
     </div>
   </div>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -20,7 +20,7 @@
   </div>
 
   <div class="row mb-2">
-    <%= label :scan_after_upload, "Scan After Upload", for: "scan_after_upload", class: "col-sm-4 col-form-label"%>
+    <%= label :scan_after_upload, "Scan After Upload", for: "scan_after_upload", class: "col-sm-4 col-form-label" %>
     <div class="col-sm-8 form-check form-switch">
       <%= check_box "post", "scan_after_upload" %>
     </div>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -3,7 +3,7 @@
   <div class="row mb-3 input-group">
     <%= label :library_pick, "Library:", class: "col-sm-2 col-form-label" %>
     <div class='col-sm-10 ps-0'>
-      <%= select "post", "library_pick", Library.all.map{ |lib| [lib.name, lib.id] }, {include_blank: false}, {class: "form-control form-select"} %>
+      <%= select "post", "library_pick", Library.all.map { |lib| [lib.name, lib.id] }, {include_blank: false}, {class: "form-control form-select"} %>
       <span id="libraryPick" class="form-text">The library to upload to.</span>
     </div>
   </div>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -9,11 +9,11 @@
   </div>
 
   <div class="row mb-3 input-group">
-    <%= label :upload, 'Select File', for: 'upload', class: "col-sm-2 col-form-label" %>
+    <%= label :upload, "Select File", for: "upload", class: "col-sm-2 col-form-label" %>
     <div class='col-sm-10 ps-0'>
-      <%= file_field 'upload', 'datafiles', {
+      <%= file_field "upload", "datafiles", {
         multiple: true,
-        accept: 'application/zip,application/x-rar-compressed,application/x-7z-compressed,application/x-bzip2,application/x-bzip,application/gzip'
+        accept: "application/zip,application/x-rar-compressed,application/x-7z-compressed,application/x-bzip2,application/x-bzip,application/gzip"
       } %>
       <div id="uploadHelp" class="form-text">Supported file types: zip, rar, 7z, bzip, gzip</div>
     </div>
@@ -26,6 +26,6 @@
     </div>
   </div>
 
-  <%= submit_tag "Upload", class: 'btn btn-primary' %>
+  <%= submit_tag "Upload", class: "btn btn-primary" %>
 
 <% end %>


### PR DESCRIPTION
As part of #861, we want to find untranslated text in ERB templates; this linter will help us do that. It's added to CI and the pre-commit hook, and can be run with `bundle exec erblint --lint-all`. This PR also includes a bundle of low-impact lint fixes to get to a fairly clean state.