### PR TITLE
Improve Rails output safety

### DIFF
--- a/.erb-lint.yml
+++ b/.erb-lint.yml
@@ -10,7 +10,7 @@ linters:
   DeprecatedClasses:
     enabled: true
   ErbSafety:
-    enabled: false # TODO
+    enabled: true
   Rubocop:
     enabled: true
     rubocop_config:
@@ -27,8 +27,6 @@ linters:
       I18n/RailsI18n/DecorateString:
         Enabled: false # TODO
       I18n/RailsI18n/DecorateStringFormattingUsingInterpolation:
-        Enabled: false # TODO
-      Rails/OutputSafety:
         Enabled: false # TODO
       Style/NestedTernaryOperator:
         Enabled: false # TODO

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -61,13 +61,6 @@ Rails/NotNullColumn:
   Exclude:
     - "db/migrate/20220614211256_add_username_to_users.rb"
 
-# Offense count: 4
-Rails/OutputSafety:
-  Exclude:
-    - "app/admin/delayed_job.rb"
-    - "app/helpers/application_helper.rb"
-    - "config/initializers/field_with_errors.rb"
-
 # Offense count: 1
 # Configuration parameters: Include.
 # Include: db/**/*.rb

--- a/app/admin/delayed_job.rb
+++ b/app/admin/delayed_job.rb
@@ -41,10 +41,12 @@ ActiveAdmin.register Delayed::Job, as: "Task" do
   end
 
   action_item :run do
-    links = link_to("Run All Tasks", run_all_admin_tasks_url, method: :post)
-    links += (" " + link_to("Mark all for re-run", mark_all_for_re_run_admin_tasks_url, method: :post)).html_safe
-    links += (" " + link_to("Delete All Tasks", delete_all_admin_tasks_url, method: :post)).html_safe if Rails.env.development?
-    links
+    links = [
+      link_to("Run All Tasks", run_all_admin_tasks_url, method: :post),
+      link_to("Mark all for re-run", mark_all_for_re_run_admin_tasks_url, method: :post)
+    ]
+    links.push link_to("Delete All Tasks", delete_all_admin_tasks_url, method: :post) if Rails.env.development?
+    safe_join links, " "
   end
 
   index do

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,7 +6,7 @@ module ApplicationHelper
   def card(style, title, options = {}, &content)
     id = "card-#{SecureRandom.hex(4)}"
     tag.div class: "card mb-4" do
-      [
+      safe_join [
         tag.div(class: "card-header text-white bg-#{style}") do
           options[:collapse] ?
             safe_join([
@@ -28,7 +28,7 @@ module ApplicationHelper
             yield
           end
         end
-      ].join.html_safe
+      ]
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -70,10 +70,10 @@ module ApplicationHelper
 
   def rich_text_input_row(form, name)
     content_tag :div, class: "row mb-3 input-group" do
-      [
+      safe_join [
         form.label(name, class: "col-sm-2 col-form-label"),
         form.text_area(name, class: "form-control col-auto")
-      ].join.html_safe
+      ]
     end
   end
 

--- a/app/views/application/_content_header.html.erb
+++ b/app/views/application/_content_header.html.erb
@@ -2,8 +2,8 @@
   <div class="row row-cols-2 align-items-baseline">
     <% if !current_page?(root_path) %>
       <div class="ms-auto col col-auto mt-2 mb-2">
-        <%= link_to icon("book", "Sort by Name").to_s.html_safe, @filters.merge(order: "name"), class: "btn #{(session["order"] == "name") ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
-        <%= link_to icon("clock", "Sort by Time").to_s.html_safe, @filters.merge(order: "recent"), class: "btn #{(session["order"] == "recent") ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
+        <%= link_to icon("book", "Sort by Name"), @filters.merge(order: "name"), class: "btn #{(session["order"] == "name") ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
+        <%= link_to icon("clock", "Sort by Time"), @filters.merge(order: "recent"), class: "btn #{(session["order"] == "recent") ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
       </div>
     <% end %>
   </div>

--- a/app/views/application/_tag_list.html.erb
+++ b/app/views/application/_tag_list.html.erb
@@ -17,18 +17,20 @@
 <% if current_user.tag_cloud_settings["keypair"] %>
   <ul class="list-unstyled">
     <% tiers.each do |tier| %>
-      <%= content_tag(:li, content_tag(:details,
-            content_tag(:summary, tier) +
-              tiertags.select { |obj| obj.name.match?("^#{tier}:") }
-                .map { |tag|
-                render partial: "tag", locals: {
+      <li>
+        <details id="<%= tier %>">
+          <summary><%= tier %></summary>
+          <%- tiertags.select { |obj| obj.name.match?("^#{tier}:") }.each do |tag| %>
+            <%= render partial: "tag", locals: {
                   tag: tag,
                   state: (defined?(muted_tags) && muted_tags.include?(tag)) ? (current_user.tag_cloud_settings["hide_unrelated"] ? :hide : :mute) : :normal
-                }
-              }.join.html_safe +
-              ((tierunset && tierunset[tier] > 0) ? (link_to "unset (#{tierunset[tier]})",
-                (@filters || {}).merge(missingtag: tier), {class: "badge rounded-pill border border-muted text-danger tag"}) : ""),
-            id: tier)).html_safe %>
+                } %>
+          <%- end %>
+          <%- if tierunset && tierunset[tier] > 0 %>
+            <%= link_to "unset (#{tierunset[tier]})", (@filters || {}).merge(missingtag: tier), {class: "badge rounded-pill border border-muted text-danger tag"} %>
+          <%- end %>
+        </details>
+      </li>
     <% end %>
   </ul>
 <% end %>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -6,5 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <%= link_to_unless current_page.first?, t("views.pagination.first").html_safe, url, remote: remote, class: "page-link" %>
+  <%= link_to_unless current_page.first?, t("views.pagination.first"), url, remote: remote, class: "page-link" %>
 </li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -5,5 +5,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <span class="page-link"><%= t("views.pagination.truncate").html_safe %></span>
+  <span class="page-link"><%= t("views.pagination.truncate") %></span>
 </li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -6,5 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <%= link_to_unless current_page.last?, t("views.pagination.last").html_safe, url, remote: remote, class: "page-link" %>
+  <%= link_to_unless current_page.last?, t("views.pagination.last"), url, remote: remote, class: "page-link" %>
 </li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -6,5 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <%= link_to_unless current_page.last?, t("views.pagination.next").html_safe, url, rel: "next", remote: remote, class: "page-link" %>
+  <%= link_to_unless current_page.last?, t("views.pagination.next"), url, rel: "next", remote: remote, class: "page-link" %>
 </li>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -6,5 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <%= link_to_unless current_page.first?, t("views.pagination.previous").html_safe, url, rel: "prev", remote: remote, class: "page-link" %>
+  <%= link_to_unless current_page.first?, t("views.pagination.previous"), url, rel: "prev", remote: remote, class: "page-link" %>
 </span>

--- a/app/views/model_files/show.html.erb
+++ b/app/views/model_files/show.html.erb
@@ -32,8 +32,8 @@
     <%= render partial: "problem", collection: @file.problems.visible(current_user.problem_settings) %>
 
     <%= card :secondary, "Actions" do %>
-      <%= link_to "#{icon("cloud-download", "Download")} Download".html_safe, library_model_model_file_path(@library, @model, @file, @file.extension.to_sym), {class: "btn btn-secondary"} %>
-      <%= link_to "#{icon("trash", "Delete")} Delete".html_safe, library_model_model_file_path(@library, @model, @file, @file.extension.to_sym), {method: "delete", data: {confirm: "Are you sure you want to remove this file from your filesystem?"}, class: "btn btn-danger"} %>
+      <%= link_to safe_join([icon("cloud-download", "Download"), "Download"], " "), library_model_model_file_path(@library, @model, @file, @file.extension.to_sym), {class: "btn btn-secondary"} %>
+      <%= link_to safe_join([icon("trash", "Delete"), "Delete"], " "), library_model_model_file_path(@library, @model, @file, @file.extension.to_sym), {method: "delete", data: {confirm: "Are you sure you want to remove this file from your filesystem?"}, class: "btn btn-danger"} %>
     <% end %>
 
     <%= card(:secondary, "Notes") do %>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -36,7 +36,7 @@
     </div>
     <% if current_user.admin? %>
       <div class='col text-end'>
-        <%= link_to "#{icon("tools", "Administration")} Advanced Administration".html_safe, "/admin", class: "btn btn-danger #{SiteSettings.demo_mode? ? "disabled" : ""}" %>
+        <%= link_to safe_join([icon("tools", "Administration"), "Advanced Administration"], " "), "/admin", class: "btn btn-danger #{SiteSettings.demo_mode? ? "disabled" : ""}" %>
       </div>
     <% end %>
     </p>

--- a/config/initializers/field_with_errors.rb
+++ b/config/initializers/field_with_errors.rb
@@ -1,3 +1,3 @@
 ActionView::Base.field_error_proc = proc do |html_tag, _instance|
-  html_tag.gsub(/class="(.*?)"/, 'class="\1 is-invalid"').html_safe
+  html_tag.gsub(/class="(.*?)"/, 'class="\1 is-invalid"').html_safe # rubocop:disable Rails/OutputSafety
 end


### PR DESCRIPTION
Fix linter issues and enhance safety by removing uses of `html_safe`, replacing with `safe_join` where necessary, or refactoring appropriately.