### PR TITLE
Read .ruby-version into Gemfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,7 @@ RUN yarn install
 RUN gem install bundler -v 2.4.13
 RUN bundle config set --local deployment 'true'
 RUN bundle config set --local without 'development test'
+COPY .ruby-version .
 COPY Gemfile* ./
 RUN bundle install
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "~> 3.3.0"
+ruby file: ".ruby-version"
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem "rails", "~> 7.0.8"


### PR DESCRIPTION
With gem version >= 3.4.19, we can read the ruby version straight from a file. Let's try it!