### PR TITLE
Enable more languages on translation.io

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ docker-compose.yml
 # Translation.io artefacts that we don't want for now
 /config/locales/.translation_io
 /config/locales/localization.*.yml
+/config/locales/translation.*.yml

--- a/.gitignore
+++ b/.gitignore
@@ -56,5 +56,6 @@ docker-compose.yml
 
 # Translation.io artefacts that we don't want for now
 /config/locales/.translation_io
+/config/locales/gettext
 /config/locales/localization.*.yml
 /config/locales/translation.*.yml

--- a/config/initializers/translation.rb
+++ b/config/initializers/translation.rb
@@ -6,6 +6,6 @@ if Rails.env.development?
       "errors" # built-in errors that get picked up
     ]
     config.source_locale = "en"
-    config.target_locales = ["de"]
+    config.target_locales = ["ru", "es", "fr", "de"]
   end
 end


### PR DESCRIPTION
Enabled Russian, French, and Spanish, as well as German which was already there. So, when we get translators, we're good to go!