### PR TITLE
Improve translation.io sync config

### DIFF
--- a/config/initializers/translation.rb
+++ b/config/initializers/translation.rb
@@ -3,7 +3,17 @@ if Rails.env.development?
     config.api_key = ENV["TRANSLATION_IO_API_KEY"]
     config.disable_gettext = true
     config.ignored_key_prefixes = [
-      "errors" # built-in errors that get picked up
+      # No ActiveAdmin for now, too much cruft
+      "active_admin",
+      "activerecord.attributes.active_admin",
+      "formtastic",
+      "ransack",
+      # Other things we don't want to translate or don't know what they are
+      "i18n_tasks",
+      "number",
+      "errors",
+      "flash",
+      "helpers.page_entries_info"
     ]
     config.source_locale = "en"
     config.target_locales = ["ru", "es", "fr", "de"]

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,7 +1,7 @@
 # Additional translations at https://github.com/heartcombo/devise/wiki/I18n
 
 en:
-#   devise:
+  devise:
 #     confirmations:
 #       confirmed: "Your email address has been successfully confirmed."
 #       send_instructions: "You will receive an email with instructions for how to confirm your email address in a few minutes."


### PR DESCRIPTION
The empty devise.en.yml was confusing things with the sync