### PR TITLE
Fix bug with Collection.model_name inside a ViewComponent

### DIFF
--- a/app/components/model_component.html.erb
+++ b/app/components/model_component.html.erb
@@ -34,7 +34,7 @@
               <%= link_to @model.creator.name, models_path((@filters || {}).merge(creator: @model.creator)) %><br>
             <% end %>
             <% if @model.collection %>
-              <%= helpers.icon "collection", Collection.model_name.human %>
+              <%= helpers.icon "collection", @model.collection.model_name.human %>
               <%= link_to @model.collection.name, models_path((@filters || {}).merge(collection: @model.collection.id)) %><br>
             <% end %>
             <% if @library.nil? && @model.library %>


### PR DESCRIPTION
Presumably some sort of naming conflict. Fixed by using the actual object type.