### PR TITLE
Fix docker builds and add pre-merge build for PRs

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,6 +1,7 @@
 name: Docker
 
 on:
+  pull_request:
   push:
     tags:
       - v*


### PR DESCRIPTION
Now that it's faster with depot, we can do this to make sure everything builds OK before merge.