### PR TITLE
Fix models with square brackets in folder name not scanning properly

### DIFF
--- a/app/jobs/model_scan_job.rb
+++ b/app/jobs/model_scan_job.rb
@@ -1,3 +1,5 @@
+require "shellwords"
+
 class ModelScanJob < ApplicationJob
   queue_as :default
 
@@ -5,10 +7,10 @@ class ModelScanJob < ApplicationJob
     list = []
     Dir.open(model_path) do |dir|
       list = Dir.glob(
-        [File.join(dir.path, ApplicationJob.file_pattern)] +
+        [File.join(Shellwords.escape(dir.path), ApplicationJob.file_pattern)] +
         ApplicationJob.common_subfolders.map do |name, pattern|
           File.join(
-            dir.path,
+            Shellwords.escape(dir.path),
             ApplicationJob.case_insensitive_glob_string(name),
             pattern
           )

--- a/app/jobs/scan/detect_filesystem_changes_job.rb
+++ b/app/jobs/scan/detect_filesystem_changes_job.rb
@@ -1,9 +1,11 @@
+require "shellwords"
+
 class Scan::DetectFilesystemChangesJob < ApplicationJob
   queue_as :default
 
   # Find all files in the library that we might need to look at
   def filenames_on_disk(library)
-    Dir.glob(File.join(library.path, "**", ApplicationJob.file_pattern)).filter { |x| File.file?(x) }
+    Dir.glob(File.join(Shellwords.escape(library.path), "**", ApplicationJob.file_pattern)).filter { |x| File.file?(x) }
   end
 
   # Get a list of all the existing filenames

--- a/spec/jobs/scan/detect_filesystem_changes_job_spec.rb
+++ b/spec/jobs/scan/detect_filesystem_changes_job_spec.rb
@@ -186,4 +186,21 @@ RSpec.describe Scan::DetectFilesystemChangesJob do
       expect(described_class.new.filenames_on_disk(library)).to include File.join(library.path, "model/file.Obj")
     end
   end
+
+  context "with unusual characters in model folder names" do
+    around do |ex|
+      MockDirectory.create([
+        "model [test]/file.obj"
+      ]) do |path|
+        @library_path = path
+        ex.run
+      end
+    end
+
+    let(:library) { create(:library, path: @library_path) } # rubocop:todo RSpec/InstanceVariable
+
+    it "detects files inside models with square brackets" do
+      expect(described_class.new.filenames_on_disk(library)).to include File.join(library.path, "model [test]/file.obj")
+    end
+  end
 end


### PR DESCRIPTION
Square brackets are special characters in shell globs, so paths need escaping before we build globs with them.

Resolves #1930.