### PR TITLE
Add user roles

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -120,3 +120,5 @@ gem "string-similarity", "~> 2.1"
 
 gem "flipper", "~> 1.2"
 gem "flipper-active_record", "~> 1.2"
+
+gem "rolify", "~> 6.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,6 +382,7 @@ GEM
       actionpack (>= 5.2)
       railties (>= 5.2)
     rexml (3.2.6)
+    rolify (6.0.1)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -571,6 +572,7 @@ DEPENDENCIES
   rails-i18n (~> 7.0)
   rails-settings-cached (~> 2.9)
   redis (~> 5.1)
+  rolify (~> 6.0)
   rspec-rails
   rubocop-i18n
   rubocop-performance (~> 1.20)

--- a/app/admin/creators.rb
+++ b/app/admin/creators.rb
@@ -12,7 +12,7 @@ ActiveAdmin.register Creator do
   #
   # permit_params do
   #   permitted = [:name]
-  #   permitted << :other if params[:action] == 'create' && current_user.admin?
+  #   permitted << :other if params[:action] == 'create' && current_user.is_administrator?
   #   permitted
   # end
 end

--- a/app/admin/libraries.rb
+++ b/app/admin/libraries.rb
@@ -12,7 +12,7 @@ ActiveAdmin.register Library do
   #
   # permit_params do
   #   permitted = [:path]
-  #   permitted << :other if params[:action] == 'create' && current_user.admin?
+  #   permitted << :other if params[:action] == 'create' && current_user.is_administrator?
   #   permitted
   # end
 end

--- a/app/admin/model_files.rb
+++ b/app/admin/model_files.rb
@@ -12,7 +12,7 @@ ActiveAdmin.register ModelFile do
   #
   # permit_params do
   #   permitted = [:filename, :model_id, :presupported, :y_up]
-  #   permitted << :other if params[:action] == 'create' && current_user.admin?
+  #   permitted << :other if params[:action] == 'create' && current_user.is_administrator?
   #   permitted
   # end
 end

--- a/app/admin/models.rb
+++ b/app/admin/models.rb
@@ -12,7 +12,7 @@ ActiveAdmin.register Model do
   #
   # permit_params do
   #   permitted = [:name, :path, :library_id, :preview_file_id, :creator_id, :thingiverse_id, :cgtrader_path, :cults3d_path, :mmf_slug, :tag_list]
-  #   permitted << :other if params[:action] == 'create' && current_user.admin?
+  #   permitted << :other if params[:action] == 'create' && current_user.is_administrator?
   #   permitted
   # end
 end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,8 +1,34 @@
 ActiveAdmin.register User do
-  permit_params :email, :password, :password_confirmation, :username
+  permit_params :email, :password, :password_confirmation, :username, role_ids: []
 
   controller do
     defaults finder: :find_by_username
+
+    # Allow form to be submitted without a password
+    def update
+      if params[:user][:password].blank?
+        params[:user].delete "password"
+        params[:user].delete "password_confirmation"
+      end
+      super
+    end
+  end
+
+  show do
+    attributes_table do
+      row :username
+      row :email
+      row :roles
+      row :created_at
+      row :updated_at
+    end
+    attributes_table title: "Settings" do
+      row :pagination_settings
+      row :renderer_settings
+      row :tag_cloud_settings
+      row :problem_settings
+      row :file_list_settings
+    end
   end
 
   index do
@@ -23,11 +49,21 @@ ActiveAdmin.register User do
   filter :created_at
 
   form do |f|
-    f.inputs do
+    f.inputs "Basics" do
       f.input :username
       f.input :email
       f.input :password
       f.input :password_confirmation
+    end
+    f.inputs "Permissions" do
+      f.input :roles, as: :check_boxes
+    end
+    f.inputs "Settings" do
+      f.input :pagination_settings
+      f.input :renderer_settings
+      f.input :tag_cloud_settings
+      f.input :problem_settings
+      f.input :file_list_settings
     end
     f.actions
   end

--- a/app/admin/users.rb
+++ b/app/admin/users.rb
@@ -1,40 +1,34 @@
-begin
-  if Flipper.enabled? :multiuser
-    ActiveAdmin.register User do
-      permit_params :email, :password, :password_confirmation, :username
+ActiveAdmin.register User do
+  permit_params :email, :password, :password_confirmation, :username
 
-      controller do
-        defaults finder: :find_by_username
-      end
-
-      index do
-        selectable_column
-        id_column
-        column :username
-        column :email
-        column :current_sign_in_at
-        column :sign_in_count
-        column :created_at
-        actions
-      end
-
-      filter :username
-      filter :email
-      filter :current_sign_in_at
-      filter :sign_in_count
-      filter :created_at
-
-      form do |f|
-        f.inputs do
-          f.input :username
-          f.input :email
-          f.input :password
-          f.input :password_confirmation
-        end
-        f.actions
-      end
-    end
+  controller do
+    defaults finder: :find_by_username
   end
-rescue ActiveRecord::StatementInvalid
-  # If we've not migrated Flipper yet, we'll get an exception, which we can swallow
+
+  index do
+    selectable_column
+    id_column
+    column :username
+    column :email
+    column :current_sign_in_at
+    column :sign_in_count
+    column :created_at
+    actions
+  end
+
+  filter :username
+  filter :email
+  filter :current_sign_in_at
+  filter :sign_in_count
+  filter :created_at
+
+  form do |f|
+    f.inputs do
+      f.input :username
+      f.input :email
+      f.input :password
+      f.input :password_confirmation
+    end
+    f.actions
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,7 +13,7 @@ class ApplicationController < ActionController::Base
 
   def authenticate_admin_user!
     authenticate_user!
-    render plain: "401 Unauthorized", status: :unauthorized unless current_user.admin?
+    render plain: "401 Unauthorized", status: :unauthorized unless current_user.is_administrator?
   end
 
   def check_scan_status

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -14,7 +14,7 @@ class SettingsController < ApplicationController
     update_file_list_settings(params[:file_list])
     @user.save!
     # Save site-wide settings if user is an admin
-    if current_user.admin?
+    if current_user.is_administrator?
       update_folder_settings(params[:folders])
       update_tagging_settings(params[:model_tags])
     end
@@ -92,6 +92,6 @@ class SettingsController < ApplicationController
   end
 
   def check_owner_permission
-    render plain: "401 Unauthorized", status: :unauthorized unless @user == current_user || current_user.admin?
+    render plain: "401 Unauthorized", status: :unauthorized unless @user == current_user || current_user.is_administrator?
   end
 end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -31,10 +31,10 @@ class Users::SessionsController < Devise::SessionsController
 
   def auto_login_single_user
     # Autocreate an admin user if there isn't one
-    create_admin_user if User.where(admin: true).empty?
+    create_admin_user if User.with_role(:administrator).empty?
     # If in single user mode, automatically log in with an admin account
     unless Flipper.enabled?(:multiuser)
-      sign_in(:user, User.where(admin: true).first)
+      sign_in(:user, User.with_role(:administrator).first)
       flash.discard
       redirect_back_or_to root_path, alert: nil
     end
@@ -42,12 +42,13 @@ class Users::SessionsController < Devise::SessionsController
 
   def create_admin_user
     password = SecureRandom.hex
-    User.create!(
+    u = User.create!(
       username: SecureRandom.hex(4),
       email: "root@localhost",
-      admin: true,
       password:,
       password_confirmation: password
     )
+    u.add_role :administrator
+    u
   end
 end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,0 +1,13 @@
+class Role < ApplicationRecord
+  has_many :users, through: :users_roles
+
+  belongs_to :resource,
+    polymorphic: true,
+    optional: true
+
+  validates :resource_type,
+    inclusion: {in: Rolify.resource_types},
+    allow_nil: true
+
+  scopify
+end

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -1,4 +1,11 @@
 class Role < ApplicationRecord
+  ROLES = [
+    :administrator,   # Can do everything
+    :editor,          # Can edit any models
+    :contributor,     # Can upload models and edit their own
+    :viewer           # Can view models; read only access
+  ]
+
   has_many :users, through: :users_roles
 
   belongs_to :resource,
@@ -8,6 +15,9 @@ class Role < ApplicationRecord
   validates :resource_type,
     inclusion: {in: Rolify.resource_types},
     allow_nil: true
+
+  validates :name,
+    inclusion: {in: ROLES.map(&:to_s)}
 
   scopify
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -24,10 +24,26 @@ class User < ApplicationRecord
   end
 
   def is_administrator?
-    has_role? :administrator
+    has_any_role_of? :administrator
+  end
+
+  def is_editor?
+    has_any_role_of? :administrator, :editor
+  end
+
+  def is_contributor?
+    has_any_role_of? :administrator, :editor, :contributor
+  end
+
+  def is_viewer?
+    has_any_role_of? :administrator, :editor, :contributor, :viewer
   end
 
   private
+
+  def has_any_role_of?(*args)
+    args.map { |x| has_role? x }.any?
+  end
 
   def assign_default_role
     add_role(:viewer) if roles.blank?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,8 @@ class User < ApplicationRecord
     uniqueness: {case_sensitive: false},
     format: {with: /\A[[:alnum:]]{3,}\z/}
 
+  after_create :assign_default_role
+
   def to_param
     username
   end
@@ -19,5 +21,11 @@ class User < ApplicationRecord
 
   def self.ransackable_attributes(auth_object = nil)
     ["created_at", "email", "id", "updated_at", "username"]
+  end
+
+  private
+
+  def assign_default_role
+    add_role(:viewer) if roles.blank?
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  rolify
   devise :database_authenticatable, :registerable, :validatable
 
   acts_as_favoritor

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,6 +23,10 @@ class User < ApplicationRecord
     ["created_at", "email", "id", "updated_at", "username"]
   end
 
+  def is_administrator?
+    has_role? :administrator
+  end
+
   private
 
   def assign_default_role

--- a/app/policies/active_admin/page_policy.rb
+++ b/app/policies/active_admin/page_policy.rb
@@ -2,6 +2,6 @@
 
 class ActiveAdmin::PagePolicy < ApplicationPolicy
   def show?
-    user.admin?
+    user&.is_administrator?
   end
 end

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -9,15 +9,15 @@ class ApplicationPolicy
   end
 
   def index?
-    user&.admin?
+    user&.is_administrator?
   end
 
   def show?
-    user&.admin?
+    user&.is_administrator?
   end
 
   def create?
-    user&.admin?
+    user&.is_administrator?
   end
 
   def new?
@@ -25,7 +25,7 @@ class ApplicationPolicy
   end
 
   def update?
-    user&.admin?
+    user&.is_administrator?
   end
 
   def edit?
@@ -33,7 +33,7 @@ class ApplicationPolicy
   end
 
   def destroy?
-    user&.admin?
+    user&.is_administrator?
   end
 
   class Scope

--- a/app/policies/library_policy.rb
+++ b/app/policies/library_policy.rb
@@ -8,15 +8,15 @@ class LibraryPolicy < ApplicationPolicy
   end
 
   def create?
-    !Flipper.enabled?(:demo_mode) && user.admin?
+    !Flipper.enabled?(:demo_mode) && user&.is_administrator?
   end
 
   def update?
-    !Flipper.enabled?(:demo_mode) && user.admin?
+    !Flipper.enabled?(:demo_mode) && user&.is_administrator?
   end
 
   def destroy?
-    !Flipper.enabled?(:demo_mode) && user.admin?
+    !Flipper.enabled?(:demo_mode) && user&.is_administrator?
   end
 
   def scan?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,7 +1,7 @@
 class UserPolicy < ApplicationPolicy
   def index?
     all_of(
-      user&.admin?,
+      user&.is_administrator?,
       none_of(
         Flipper.enabled?(:demo_mode)
       )
@@ -12,7 +12,7 @@ class UserPolicy < ApplicationPolicy
     all_of(
       one_of(
         user == record,
-        user&.admin?
+        user&.is_administrator?
       ),
       none_of(
         Flipper.enabled?(:demo_mode)
@@ -25,7 +25,7 @@ class UserPolicy < ApplicationPolicy
       Flipper.enabled?(:multiuser),
       one_of(
         SiteSettings.registration_enabled,
-        user&.admin?
+        user&.is_administrator?
       ),
       none_of(
         Flipper.enabled?(:demo_mode)
@@ -36,7 +36,7 @@ class UserPolicy < ApplicationPolicy
   def update?
     one_of(
       user == record,
-      user&.admin?
+      user&.is_administrator?
     )
   end
 
@@ -44,7 +44,7 @@ class UserPolicy < ApplicationPolicy
     all_of(
       one_of(
         user == record,
-        user&.admin?
+        user&.is_administrator?
       ),
       Flipper.enabled?(:multiuser),
       none_of(

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -13,7 +13,7 @@
     </div>
   </div>
 
-  <% if current_user.admin? %>
+  <% if current_user.is_administrator? %>
 
     <div class="row mb-4">
       <div class="col">
@@ -35,7 +35,7 @@
     <div class='col'>
       <button type="submit" class="btn btn-primary"><%= icon("save", t(".submit")) %> <%= t(".submit") %></button>
     </div>
-    <% if current_user.admin? %>
+    <% if current_user.is_administrator? %>
       <div class='col text-end'>
         <%= link_to safe_join([icon("tools", t(".advanced_admin")), t(".advanced_admin")], " "),
               "/admin",

--- a/config/initializers/rolify.rb
+++ b/config/initializers/rolify.rb
@@ -1,0 +1,7 @@
+Rolify.configure do |config|
+  # Dynamic shortcuts for User class (user.is_admin? like methods). Default is: false
+  # config.use_dynamic_shortcuts
+
+  # Configuration to remove roles from database once the last resource is removed. Default is: true
+  # config.remove_role_if_empty = false
+end

--- a/config/initializers/rolify.rb
+++ b/config/initializers/rolify.rb
@@ -5,3 +5,9 @@ Rolify.configure do |config|
   # Configuration to remove roles from database once the last resource is removed. Default is: true
   # config.remove_role_if_empty = false
 end
+
+Rails.application.config.after_initialize do
+  Role::ROLES.each do |r|
+    Role.find_or_create_by name: r
+  end
+end

--- a/config/initializers/rolify.rb
+++ b/config/initializers/rolify.rb
@@ -1,6 +1,6 @@
 Rolify.configure do |config|
   # Dynamic shortcuts for User class (user.is_admin? like methods). Default is: false
-  config.use_dynamic_shortcuts
+  # config.use_dynamic_shortcuts
 
   # Configuration to remove roles from database once the last resource is removed. Default is: true
   # config.remove_role_if_empty = false

--- a/config/initializers/rolify.rb
+++ b/config/initializers/rolify.rb
@@ -10,4 +10,6 @@ Rails.application.config.after_initialize do
   Role::ROLES.each do |r|
     Role.find_or_create_by name: r
   end
+rescue ActiveRecord::StatementInvalid
+  # Not migrated yet
 end

--- a/config/initializers/rolify.rb
+++ b/config/initializers/rolify.rb
@@ -1,6 +1,6 @@
 Rolify.configure do |config|
   # Dynamic shortcuts for User class (user.is_admin? like methods). Default is: false
-  # config.use_dynamic_shortcuts
+  config.use_dynamic_shortcuts
 
   # Configuration to remove roles from database once the last resource is removed. Default is: true
   # config.remove_role_if_empty = false

--- a/db/data/20240319155526_convert_admin_flag_to_role.rb
+++ b/db/data/20240319155526_convert_admin_flag_to_role.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ConvertAdminFlagToRole < ActiveRecord::Migration[7.0]
+  def up
+    User.where(admin: true).find_each { |u| u.add_role :administrator }
+  end
+
+  def down
+    User.with_role(:administrator).find_each { |u| u.update!(admin: true) }
+  end
+end

--- a/db/data/20240319155526_convert_admin_flag_to_role.rb
+++ b/db/data/20240319155526_convert_admin_flag_to_role.rb
@@ -3,6 +3,7 @@
 class ConvertAdminFlagToRole < ActiveRecord::Migration[7.0]
   def up
     User.where(admin: true).find_each { |u| u.add_role :administrator }
+  rescue ActiveRecord::StatementInvalid
   end
 
   def down

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20230628194944)
+DataMigrate::Data.define(version: 20240319155526)

--- a/db/migrate/20240319155251_rolify_create_roles.rb
+++ b/db/migrate/20240319155251_rolify_create_roles.rb
@@ -1,0 +1,19 @@
+class RolifyCreateRoles < ActiveRecord::Migration[7.0]
+  def change
+    create_table(:roles) do |t|
+      t.string :name
+      t.references :resource, polymorphic: true
+
+      t.timestamps
+    end
+
+    create_table(:users_roles, id: false) do |t|
+      t.references :user
+      t.references :role
+    end
+
+    add_index(:roles, :name)
+    add_index(:roles, [:name, :resource_type, :resource_id])
+    add_index(:users_roles, [:user_id, :role_id])
+  end
+end

--- a/db/migrate/20240319155903_remove_admin_from_users.rb
+++ b/db/migrate/20240319155903_remove_admin_from_users.rb
@@ -1,0 +1,5 @@
+class RemoveAdminFromUsers < ActiveRecord::Migration[7.0]
+  def change
+    remove_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_06_095646) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_19_155251) do
   create_table "collections", force: :cascade do |t|
     t.string "name"
     t.text "notes"
@@ -159,6 +159,17 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_06_095646) do
     t.index ["problematic_type", "problematic_id"], name: "index_problems_on_problematic"
   end
 
+  create_table "roles", force: :cascade do |t|
+    t.string "name"
+    t.string "resource_type"
+    t.integer "resource_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name", "resource_type", "resource_id"], name: "index_roles_on_name_and_resource_type_and_resource_id"
+    t.index ["name"], name: "index_roles_on_name"
+    t.index ["resource_type", "resource_id"], name: "index_roles_on_resource"
+  end
+
   create_table "settings", force: :cascade do |t|
     t.string "var", null: false
     t.text "value"
@@ -208,6 +219,14 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_06_095646) do
     t.json "file_list_settings", default: {"hide_presupported_versions"=>true}
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
+  end
+
+  create_table "users_roles", id: false, force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "role_id"
+    t.index ["role_id"], name: "index_users_roles_on_role_id"
+    t.index ["user_id", "role_id"], name: "index_users_roles_on_user_id_and_role_id"
+    t.index ["user_id"], name: "index_users_roles_on_user_id"
   end
 
   add_foreign_key "collections", "collections"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_03_19_155251) do
+ActiveRecord::Schema[7.0].define(version: 2024_03_19_155903) do
   create_table "collections", force: :cascade do |t|
     t.string "name"
     t.text "notes"
@@ -211,7 +211,6 @@ ActiveRecord::Schema[7.0].define(version: 2024_03_19_155251) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "username", null: false
-    t.boolean "admin", default: false, null: false
     t.json "pagination_settings", default: {"models"=>true, "creators"=>true, "collections"=>true, "per_page"=>12}
     t.json "renderer_settings", default: {"grid_width"=>200, "grid_depth"=>200}
     t.json "tag_cloud_settings", default: {"threshold"=>0, "heatmap"=>true, "keypair"=>true, "sorting"=>"frequency", "hide_unrelated"=>true}

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     password { Faker::Internet.password }
 
     factory :admin do
-      admin { true }
+      after(:create) { |a| a.add_role :administrator }
     end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -7,5 +7,13 @@ FactoryBot.define do
     factory :admin do
       after(:create) { |a| a.add_role :administrator }
     end
+
+    factory :editor do
+      after(:create) { |a| a.add_role :editor }
+    end
+
+    factory :contributor do
+      after(:create) { |a| a.add_role :contributor }
+    end
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -2,7 +2,10 @@ FactoryBot.define do
   factory :user do
     email { Faker::Internet.email }
     username { Faker::Internet.username specifier: 3, separators: [] }
-    admin { false }
     password { Faker::Internet.password }
+
+    factory :admin do
+      admin { true }
+    end
   end
 end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,0 +1,5 @@
+require "rails_helper"
+
+RSpec.describe Role do
+  it "needs testing"
+end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -10,6 +10,6 @@ RSpec.describe Role do
 
   it "must be from the allowed list" do # rubocop:disable RSpec/MultipleExpectations
     expect { user.add_role :batman }.to raise_error(ActiveRecord::RecordInvalid)
-    expect(user.is_batman?).to be false
+    expect(user.has_role?(:batman)).to be false
   end
 end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,5 +1,10 @@
 require "rails_helper"
 
 RSpec.describe Role do
-  it "needs testing"
+  let(:user) { create(:user) }
+
+  it "can be given to a user" do
+    user.add_role :administrator
+    expect(user.is_administrator?).to be true
+  end
 end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -1,15 +1,94 @@
 require "rails_helper"
-
 RSpec.describe Role do
   let(:user) { create(:user) }
 
   it "can be given to a user" do
     user.add_role :administrator
-    expect(user.is_administrator?).to be true
+    expect(user.has_role?(:administrator)).to be true
   end
 
   it "must be from the allowed list" do # rubocop:disable RSpec/MultipleExpectations
     expect { user.add_role :batman }.to raise_error(ActiveRecord::RecordInvalid)
     expect(user.has_role?(:batman)).to be false
+  end
+
+  context "when administrator" do
+    let(:admin) { create(:admin) }
+
+    it "has administrator permission" do
+      expect(admin.is_administrator?).to be true
+    end
+
+    it "inherits editor permission" do
+      expect(admin.is_editor?).to be true
+    end
+
+    it "inherits contributor permission" do
+      expect(admin.is_contributor?).to be true
+    end
+
+    it "inherits viewer permission" do
+      expect(admin.is_viewer?).to be true
+    end
+  end
+
+  context "when editor" do
+    let(:editor) { create(:editor) }
+
+    it "does not have administrator permission" do
+      expect(editor.is_administrator?).to be false
+    end
+
+    it "has editor permission" do
+      expect(editor.is_editor?).to be true
+    end
+
+    it "inherits contributor permission" do
+      expect(editor.is_contributor?).to be true
+    end
+
+    it "inherits viewer permission" do
+      expect(editor.is_viewer?).to be true
+    end
+  end
+
+  context "when contributor" do
+    let(:contributor) { create(:contributor) }
+
+    it "does not have administrator permission" do
+      expect(contributor.is_administrator?).to be false
+    end
+
+    it "does not have editor permission" do
+      expect(contributor.is_editor?).to be false
+    end
+
+    it "has contributor permission" do
+      expect(contributor.is_contributor?).to be true
+    end
+
+    it "inherits viewer permission" do
+      expect(contributor.is_viewer?).to be true
+    end
+  end
+
+  context "when viewer" do
+    let(:viewer) { create(:user) }
+
+    it "does not have administrator permission" do
+      expect(viewer.is_administrator?).to be false
+    end
+
+    it "does not have editor permission" do
+      expect(viewer.is_editor?).to be false
+    end
+
+    it "does not have contributor permission" do
+      expect(viewer.is_contributor?).to be false
+    end
+
+    it "has viewer permission" do
+      expect(viewer.is_viewer?).to be true
+    end
   end
 end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -7,4 +7,9 @@ RSpec.describe Role do
     user.add_role :administrator
     expect(user.is_administrator?).to be true
   end
+
+  it "must be from the allowed list" do # rubocop:disable RSpec/MultipleExpectations
+    expect { user.add_role :batman }.to raise_error(ActiveRecord::RecordInvalid)
+    expect(user.is_batman?).to be false
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -33,4 +33,9 @@ RSpec.describe User do
     create(:user, username: "userName")
     expect(build(:user, username: "USERNAME")).not_to be_valid
   end
+
+  it "gets viewer role by default" do
+    u = create(:user)
+    expect(u).to have_role(:viewer)
+  end
 end

--- a/spec/requests/admin/collections_spec.rb
+++ b/spec/requests/admin/collections_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe "Admin::Collections" do
   it "is inaccessible to normal user" do
-    sign_in create(:user, admin: false)
+    sign_in create(:user)
     get "/admin/collections"
     expect(response).to have_http_status(:unauthorized)
   end
 
   context "with admin permission" do
     before do
-      sign_in create(:user, admin: true)
+      sign_in create(:admin)
     end
 
     it "is accessible" do

--- a/spec/requests/admin/creators_spec.rb
+++ b/spec/requests/admin/creators_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe "Admin::Creators" do
   it "is inaccessible to normal user" do
-    sign_in create(:user, admin: false)
+    sign_in create(:user)
     get "/admin/creators"
     expect(response).to have_http_status(:unauthorized)
   end
 
   context "with admin permission" do
     before do
-      sign_in create(:user, admin: true)
+      sign_in create(:admin)
     end
 
     it "is accessible" do

--- a/spec/requests/admin/dashboard_spec.rb
+++ b/spec/requests/admin/dashboard_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe "Admin::Dashboard" do
   it "is inaccessible to normal user" do
-    sign_in create(:user, admin: false)
+    sign_in create(:user)
     get "/admin"
     expect(response).to have_http_status(:unauthorized)
   end
 
   context "with admin permission" do
     before do
-      sign_in create(:user, admin: true)
+      sign_in create(:admin)
     end
 
     it "is accessible" do

--- a/spec/requests/admin/delayed_job_spec.rb
+++ b/spec/requests/admin/delayed_job_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe "Admin::Delayed_Job" do
   it "is inaccessible to normal user" do
-    sign_in create(:user, admin: false)
+    sign_in create(:user)
     get "/admin/delayed_backend_active_record_jobs"
     expect(response).to have_http_status(:unauthorized)
   end
 
   context "with admin permission" do
     before do
-      sign_in create(:user, admin: true)
+      sign_in create(:admin)
     end
 
     it "is accessible" do

--- a/spec/requests/admin/link_spec.rb
+++ b/spec/requests/admin/link_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe "Admin::Links" do
   it "is inaccessible to normal user" do
-    sign_in create(:user, admin: false)
+    sign_in create(:user)
     get "/admin/links"
     expect(response).to have_http_status(:unauthorized)
   end
 
   context "with admin permission" do
     before do
-      sign_in create(:user, admin: true)
+      sign_in create(:admin)
     end
 
     it "is accessible" do

--- a/spec/requests/admin/log_spec.rb
+++ b/spec/requests/admin/log_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe "Admin::Log" do
   it "is inaccessible to normal user" do
-    sign_in create(:user, admin: false)
+    sign_in create(:user)
     get "/admin/log"
     expect(response).to have_http_status(:unauthorized)
   end
 
   context "with admin permission" do
     before do
-      sign_in create(:user, admin: true)
+      sign_in create(:admin)
     end
 
     it "is accessible" do

--- a/spec/requests/admin/model_files_spec.rb
+++ b/spec/requests/admin/model_files_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe "Admin::Model_Files" do
   it "is inaccessible to normal user" do
-    sign_in create(:user, admin: false)
+    sign_in create(:user)
     get "/admin/model_files"
     expect(response).to have_http_status(:unauthorized)
   end
 
   context "with admin permission" do
     before do
-      sign_in create(:user, admin: true)
+      sign_in create(:admin)
     end
 
     it "is accessible" do

--- a/spec/requests/admin/models_spec.rb
+++ b/spec/requests/admin/models_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe "Admin::Models" do
   it "is inaccessible to normal user" do
-    sign_in create(:user, admin: false)
+    sign_in create(:user)
     get "/admin/models"
     expect(response).to have_http_status(:unauthorized)
   end
 
   context "with admin permission" do
     before do
-      sign_in create(:user, admin: true)
+      sign_in create(:admin)
     end
 
     it "is accessible" do

--- a/spec/requests/admin/problem_spec.rb
+++ b/spec/requests/admin/problem_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe "Admin::Problems" do
   it "is inaccessible to normal user" do
-    sign_in create(:user, admin: false)
+    sign_in create(:user)
     get "/admin/problems"
     expect(response).to have_http_status(:unauthorized)
   end
 
   context "with admin permission" do
     before do
-      sign_in create(:user, admin: true)
+      sign_in create(:admin)
     end
 
     it "is accessible" do

--- a/spec/requests/admin/tags_spec.rb
+++ b/spec/requests/admin/tags_spec.rb
@@ -2,14 +2,14 @@ require "rails_helper"
 
 RSpec.describe "Admin::Tags" do
   it "is inaccessible to normal user" do
-    sign_in create(:user, admin: false)
+    sign_in create(:user)
     get "/admin/acts_as_taggable_on_tags"
     expect(response).to have_http_status(:unauthorized)
   end
 
   context "with admin permission" do
     before do
-      sign_in create(:user, admin: true)
+      sign_in create(:admin)
     end
 
     it "is accessible" do

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -10,7 +10,7 @@ require "rails_helper"
 #                  DELETE /collections/:id(.:format)                                              collections#destroy
 
 RSpec.describe "Collections" do
-  let(:admin) { create(:user, admin: true) }
+  let(:admin) { create(:admin) }
   let(:collection) { create(:collection) }
 
   context "when signed out" do

--- a/spec/requests/creators_spec.rb
+++ b/spec/requests/creators_spec.rb
@@ -10,7 +10,7 @@ require "rails_helper"
 #              DELETE /creators/:id(.:format)                                                 creators#destroy
 
 RSpec.describe "Creators" do
-  let(:admin) { create(:user, admin: true) }
+  let(:admin) { create(:admin) }
   let(:creator) { create(:creator) }
 
   context "when signed out" do

--- a/spec/requests/libraries_spec.rb
+++ b/spec/requests/libraries_spec.rb
@@ -12,7 +12,7 @@ require "rails_helper"
 #                DELETE /libraries/:id(.:format)                                                libraries#destroy
 
 RSpec.describe "Libraries" do
-  let(:admin) { create(:user, admin: true) }
+  let(:admin) { create(:admin) }
 
   context "when signed out" do
     it "needs testing when multiuser is enabled"

--- a/spec/requests/model_files_spec.rb
+++ b/spec/requests/model_files_spec.rb
@@ -10,7 +10,7 @@ require "support/mock_directory"
 #                                DELETE /libraries/:library_id/models/:model_id/model_files/:id(.:format)       model_files#destroy
 
 RSpec.describe "Model Files" do
-  let(:admin) { create(:user, admin: true) }
+  let(:admin) { create(:admin) }
 
   context "when signed out" do
     it "needs testing when multiuser is enabled"

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -11,7 +11,7 @@ require "rails_helper"
 # merge_library_model POST   /libraries/:library_id/models/:id/merge(.:format)                       models#merge
 
 RSpec.describe "Models" do
-  let(:admin) { create(:user, admin: true) }
+  let(:admin) { create(:admin) }
 
   context "when signed out" do
     it "needs testing when multiuser is enabled"

--- a/spec/requests/problems_spec.rb
+++ b/spec/requests/problems_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 #  problem PATCH  /problems/:id(.:format)                                                 problems#update
 
 RSpec.describe "Problems" do
-  let(:admin) { create(:user, admin: true) }
+  let(:admin) { create(:admin) }
 
   context "when signed out" do
     it "needs testing when multiuser is enabled"

--- a/spec/requests/uploads_spec.rb
+++ b/spec/requests/uploads_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 #          POST   /uploads(.:format)                                                      uploads#create
 
 RSpec.describe "Uploads" do
-  let(:admin) { create(:user, admin: true) }
+  let(:admin) { create(:admin) }
   let(:library) { create(:library) }
 
   context "when signed out" do

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -9,7 +9,7 @@ require "rails_helper"
 #                          POST   /users(.:format)                                                        users/registrations#create
 
 RSpec.describe "Users::Registrations" do
-  let!(:admin) { create(:user, admin: true, password: "password", password_confirmation: "password") }
+  let!(:admin) { create(:admin, password: "password", password_confirmation: "password") }
   let(:post_options) {
     password = Faker::Internet.password
     {

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Users::Sessions" do
 
         it "gives default account admin permissions" do
           get "/users/sign_in"
-          expect(User.first.admin).to be true
+          expect(User.first.is_administrator?).to be true
         end
 
         it "doesn't auto log in" do
@@ -32,7 +32,7 @@ RSpec.describe "Users::Sessions" do
     context "when signed in" do
       before { sign_in admin }
 
-      let(:admin) { create(:user, admin: true) }
+      let(:admin) { create(:admin) }
 
       describe "GET /users/sign_in" do
         it "redirects to root" do
@@ -52,7 +52,7 @@ RSpec.describe "Users::Sessions" do
 
         it "gives default account admin permissions" do
           get "/users/sign_in"
-          expect(controller.current_user.admin).to be true
+          expect(controller.current_user.is_administrator?).to be true
         end
 
         it "auto logs in and redirects to root" do
@@ -70,7 +70,7 @@ RSpec.describe "Users::Sessions" do
     context "when signed in" do
       before { sign_in admin }
 
-      let(:admin) { create(:user, admin: true) }
+      let(:admin) { create(:admin) }
 
       describe "GET /users/sign_in" do
         it "redirects to root" do


### PR DESCRIPTION
Added four roles for users. This can be made more granular in the future.

We have `administrator`, `editor`, `contributor` and `viewer`. Everyone gets `viewer` by default, and each level cascades to the lower levels in the order above.

Part of #647 