### PR TITLE
Enforce permissions with the new user roles

### DIFF
--- a/app/controllers/libraries_controller.rb
+++ b/app/controllers/libraries_controller.rb
@@ -1,10 +1,8 @@
 class LibrariesController < ApplicationController
   before_action :get_library, except: [:index, :new, :create, :scan_all]
-  after_action :verify_authorized, only: [:index]
   skip_after_action :verify_policy_scoped, only: [:index]
 
   def index
-    authorize Library
     if Library.count === 0
       redirect_to new_library_path
     else
@@ -17,6 +15,7 @@ class LibrariesController < ApplicationController
   end
 
   def new
+    authorize Library
     @library = Library.new
     @title = t("libraries.general.new")
   end
@@ -25,6 +24,7 @@ class LibrariesController < ApplicationController
   end
 
   def create
+    authorize Library
     @library = Library.create(library_params)
     @library.tag_regex = params[:tag_regex]
     if @library.valid?
@@ -54,6 +54,7 @@ class LibrariesController < ApplicationController
   end
 
   def scan_all
+    authorize Library
     if params[:type] === "check"
       Scan::CheckAllJob.perform_later
     else

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -4,7 +4,6 @@ class ModelsController < ApplicationController
   include ModelFilters
   before_action :get_library, except: [:index, :bulk_edit, :bulk_update]
   before_action :get_model, except: [:bulk_edit, :bulk_update, :index]
-  skip_after_action :verify_authorized, only: [:bulk_edit, :bulk_update]
   after_action :verify_policy_scoped, only: [:bulk_edit, :bulk_update]
 
   def index
@@ -73,6 +72,7 @@ class ModelsController < ApplicationController
   end
 
   def bulk_edit
+    authorize Model
     @creators = policy_scope(Creator)
     @collections = policy_scope(Collection)
     @models = policy_scope(Model)
@@ -80,6 +80,7 @@ class ModelsController < ApplicationController
   end
 
   def bulk_update
+    authorize Model
     hash = bulk_update_params
     hash[:library_id] = hash.delete(:new_library_id) if hash[:new_library_id]
 

--- a/app/policies/acts_as_taggable_on/tag_policy.rb
+++ b/app/policies/acts_as_taggable_on/tag_policy.rb
@@ -1,26 +1,6 @@
 # frozen_string_literal: true
 
 class ActsAsTaggableOn::TagPolicy < ApplicationPolicy
-  def index?
-    true
-  end
-
-  def show?
-    true
-  end
-
-  def create?
-    true
-  end
-
-  def update?
-    true
-  end
-
-  def destroy?
-    true
-  end
-
   class Scope
     attr_reader :user, :scope
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -9,15 +9,15 @@ class ApplicationPolicy
   end
 
   def index?
-    user&.is_administrator?
+    user&.is_viewer?
   end
 
   def show?
-    user&.is_administrator?
+    user&.is_viewer?
   end
 
   def create?
-    user&.is_administrator?
+    user&.is_contributor?
   end
 
   def new?
@@ -25,7 +25,7 @@ class ApplicationPolicy
   end
 
   def update?
-    user&.is_administrator?
+    user&.is_editor?
   end
 
   def edit?
@@ -33,7 +33,12 @@ class ApplicationPolicy
   end
 
   def destroy?
-    user&.is_administrator?
+    all_of(
+      user&.is_editor?,
+      none_of(
+        Flipper.enabled?(:demo_mode)
+      )
+    )
   end
 
   class Scope

--- a/app/policies/delayed/backend/active_record/job_policy.rb
+++ b/app/policies/delayed/backend/active_record/job_policy.rb
@@ -2,23 +2,23 @@
 
 class Delayed::Backend::ActiveRecord::JobPolicy < ApplicationPolicy
   def index?
-    true
+    user&.is_administrator?
   end
 
   def show?
-    true
+    user&.is_administrator?
   end
 
   def create?
-    true
+    user&.is_administrator?
   end
 
   def update?
-    true
+    user&.is_administrator?
   end
 
   def destroy?
-    true
+    user&.is_administrator?
   end
 
   class Scope

--- a/app/policies/library_policy.rb
+++ b/app/policies/library_policy.rb
@@ -1,12 +1,4 @@
 class LibraryPolicy < ApplicationPolicy
-  def index?
-    true
-  end
-
-  def show?
-    true
-  end
-
   def create?
     !Flipper.enabled?(:demo_mode) && user&.is_administrator?
   end
@@ -20,7 +12,7 @@ class LibraryPolicy < ApplicationPolicy
   end
 
   def scan?
-    true
+    user&.is_contributor?
   end
 
   class Scope

--- a/app/policies/library_policy.rb
+++ b/app/policies/library_policy.rb
@@ -1,18 +1,27 @@
 class LibraryPolicy < ApplicationPolicy
   def create?
-    !Flipper.enabled?(:demo_mode) && user&.is_administrator?
+    all_of(
+      user&.is_administrator?,
+      none_of(
+        Flipper.enabled?(:demo_mode)
+      )
+    )
   end
 
   def update?
-    !Flipper.enabled?(:demo_mode) && user&.is_administrator?
+    create?
   end
 
   def destroy?
-    !Flipper.enabled?(:demo_mode) && user&.is_administrator?
+    create?
   end
 
   def scan?
     user&.is_contributor?
+  end
+
+  def scan_all?
+    scan?
   end
 
   class Scope

--- a/app/policies/link_policy.rb
+++ b/app/policies/link_policy.rb
@@ -1,24 +1,4 @@
 class LinkPolicy < ApplicationPolicy
-  def index?
-    true
-  end
-
-  def show?
-    true
-  end
-
-  def create?
-    true
-  end
-
-  def update?
-    true
-  end
-
-  def destroy?
-    true
-  end
-
   class Scope
     attr_reader :user, :scope
 

--- a/app/policies/model_file_policy.rb
+++ b/app/policies/model_file_policy.rb
@@ -1,17 +1,9 @@
 class ModelFilePolicy < ApplicationPolicy
-  def show?
-    true
-  end
-
-  def destroy?
-    !Flipper.enabled?(:demo_mode)
-  end
-
   def bulk_edit?
-    true
+    user&.is_editor?
   end
 
   def bulk_update?
-    true
+    user&.is_editor?
   end
 end

--- a/app/policies/model_policy.rb
+++ b/app/policies/model_policy.rb
@@ -5,19 +5,20 @@ class ModelPolicy < ApplicationPolicy
     end
   end
 
-  def show?
-    true
-  end
-
-  def update?
-    true
-  end
-
   def merge?
-    true
+    all_of(
+      user&.is_editor?,
+      none_of(
+        Flipper.enabled?(:demo_mode)
+      )
+    )
   end
 
-  def destroy?
-    !Flipper.enabled?(:demo_mode)
+  def bulk_edit?
+    user&.is_editor?
+  end
+
+  def bulk_update?
+    user&.is_editor?
   end
 end

--- a/app/policies/problem_policy.rb
+++ b/app/policies/problem_policy.rb
@@ -4,8 +4,4 @@ class ProblemPolicy < ApplicationPolicy
       scope.all
     end
   end
-
-  def update?
-    true
-  end
 end

--- a/app/policies/upload_policy.rb
+++ b/app/policies/upload_policy.rb
@@ -1,9 +1,14 @@
 class UploadPolicy < ApplicationPolicy
   def index?
-    !Flipper.enabled?(:demo_mode)
+    create?
   end
 
   def create?
-    !Flipper.enabled?(:demo_mode)
+    all_of(
+      user&.is_contributor?,
+      none_of(
+        Flipper.enabled?(:demo_mode)
+      )
+    )
   end
 end

--- a/spec/helpers/problems_helper_spec.rb
+++ b/spec/helpers/problems_helper_spec.rb
@@ -1,12 +1,8 @@
 require "rails_helper"
 
-RSpec.describe ProblemsHelper do
+RSpec.describe ProblemsHelper, :as_viewer do
   include Devise::Test::ControllerHelpers
   let(:model) { create(:model) }
-
-  before do
-    sign_in create(:user)
-  end
 
   it "converts a problem to a severity level" do
     expect(helper.problem_severity(

--- a/spec/requests/admin/collections_spec.rb
+++ b/spec/requests/admin/collections_spec.rb
@@ -1,17 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Collections" do
-  it "is inaccessible to normal user" do
-    sign_in create(:user)
+  it "is inaccessible to anything less than admin", :as_editor do
     get "/admin/collections"
     expect(response).to have_http_status(:unauthorized)
   end
 
-  context "with admin permission" do
-    before do
-      sign_in create(:admin)
-    end
-
+  context "with admin permission", :as_administrator do
     it "is accessible" do
       get "/admin/collections"
       expect(response).to have_http_status(:success)

--- a/spec/requests/admin/creators_spec.rb
+++ b/spec/requests/admin/creators_spec.rb
@@ -1,17 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Creators" do
-  it "is inaccessible to normal user" do
-    sign_in create(:user)
+  it "is inaccessible to anything less than admin", :as_editor do
     get "/admin/creators"
     expect(response).to have_http_status(:unauthorized)
   end
 
-  context "with admin permission" do
-    before do
-      sign_in create(:admin)
-    end
-
+  context "with admin permission", :as_administrator do
     it "is accessible" do
       get "/admin/creators"
       expect(response).to have_http_status(:success)

--- a/spec/requests/admin/dashboard_spec.rb
+++ b/spec/requests/admin/dashboard_spec.rb
@@ -1,17 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Dashboard" do
-  it "is inaccessible to normal user" do
-    sign_in create(:user)
+  it "is inaccessible to anything less than admin", :as_editor do
     get "/admin"
     expect(response).to have_http_status(:unauthorized)
   end
 
-  context "with admin permission" do
-    before do
-      sign_in create(:admin)
-    end
-
+  context "with admin permission", :as_administrator do
     it "is accessible" do
       get "/admin"
       expect(response).to have_http_status(:success)

--- a/spec/requests/admin/delayed_job_spec.rb
+++ b/spec/requests/admin/delayed_job_spec.rb
@@ -1,17 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Delayed_Job" do
-  it "is inaccessible to normal user" do
-    sign_in create(:user)
+  it "is inaccessible to anything less than admin", :as_editor do
     get "/admin/delayed_backend_active_record_jobs"
     expect(response).to have_http_status(:unauthorized)
   end
 
-  context "with admin permission" do
-    before do
-      sign_in create(:admin)
-    end
-
+  context "with admin permission", :as_administrator do
     it "is accessible" do
       get "/admin/delayed_backend_active_record_jobs"
       expect(response).to have_http_status(:success)

--- a/spec/requests/admin/link_spec.rb
+++ b/spec/requests/admin/link_spec.rb
@@ -1,17 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Links" do
-  it "is inaccessible to normal user" do
-    sign_in create(:user)
+  it "is inaccessible to anything less than admin", :as_editor do
     get "/admin/links"
     expect(response).to have_http_status(:unauthorized)
   end
 
-  context "with admin permission" do
-    before do
-      sign_in create(:admin)
-    end
-
+  context "with admin permission", :as_administrator do
     it "is accessible" do
       get "/admin/links"
       expect(response).to have_http_status(:success)

--- a/spec/requests/admin/log_spec.rb
+++ b/spec/requests/admin/log_spec.rb
@@ -1,17 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Log" do
-  it "is inaccessible to normal user" do
-    sign_in create(:user)
+  it "is inaccessible to anything less than admin", :as_editor do
     get "/admin/log"
     expect(response).to have_http_status(:unauthorized)
   end
 
-  context "with admin permission" do
-    before do
-      sign_in create(:admin)
-    end
-
+  context "with admin permission", :as_administrator do
     it "is accessible" do
       get "/admin/log"
       expect(response).to have_http_status(:success)

--- a/spec/requests/admin/model_files_spec.rb
+++ b/spec/requests/admin/model_files_spec.rb
@@ -1,17 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Model_Files" do
-  it "is inaccessible to normal user" do
-    sign_in create(:user)
+  it "is inaccessible to anything less than admin", :as_editor do
     get "/admin/model_files"
     expect(response).to have_http_status(:unauthorized)
   end
 
-  context "with admin permission" do
-    before do
-      sign_in create(:admin)
-    end
-
+  context "with admin permission", :as_administrator do
     it "is accessible" do
       get "/admin/model_files"
       expect(response).to have_http_status(:success)

--- a/spec/requests/admin/models_spec.rb
+++ b/spec/requests/admin/models_spec.rb
@@ -1,17 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Models" do
-  it "is inaccessible to normal user" do
-    sign_in create(:user)
+  it "is inaccessible to anything less than admin", :as_editor do
     get "/admin/models"
     expect(response).to have_http_status(:unauthorized)
   end
 
-  context "with admin permission" do
-    before do
-      sign_in create(:admin)
-    end
-
+  context "with admin permission", :as_administrator do
     it "is accessible" do
       get "/admin/models"
       expect(response).to have_http_status(:success)

--- a/spec/requests/admin/problem_spec.rb
+++ b/spec/requests/admin/problem_spec.rb
@@ -1,17 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Problems" do
-  it "is inaccessible to normal user" do
-    sign_in create(:user)
+  it "is inaccessible to anything less than admin", :as_editor do
     get "/admin/problems"
     expect(response).to have_http_status(:unauthorized)
   end
 
-  context "with admin permission" do
-    before do
-      sign_in create(:admin)
-    end
-
+  context "with admin permission", :as_administrator do
     it "is accessible" do
       get "/admin/problems"
       expect(response).to have_http_status(:success)

--- a/spec/requests/admin/tags_spec.rb
+++ b/spec/requests/admin/tags_spec.rb
@@ -1,17 +1,12 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Tags" do
-  it "is inaccessible to normal user" do
-    sign_in create(:user)
+  it "is inaccessible to anything less than admin", :as_editor do
     get "/admin/acts_as_taggable_on_tags"
     expect(response).to have_http_status(:unauthorized)
   end
 
-  context "with admin permission" do
-    before do
-      sign_in create(:admin)
-    end
-
+  context "with admin permission", :as_administrator do
     it "is accessible" do
       get "/admin/acts_as_taggable_on_tags"
       expect(response).to have_http_status(:success)

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -38,19 +38,31 @@ RSpec.describe "Collections" do
         post "/collections", params: {collection: {name: "newname"}}
         expect(response).to redirect_to("/collections")
       end
-    end
 
-    describe "GET /collections/new", :as_contributor do
-      it "Shows the new collection form" do
-        get "/collections/new"
-        expect(response).to have_http_status(:success)
+      it "denies viewer permission", :as_viewer do
+        expect { post "/collections", params: {collection: {name: "newname"}} }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
-    describe "GET /collections/:id/edit", :as_editor do
-      it "Shows the new collection form" do
+    describe "GET /collections/new" do
+      it "Shows the new collection form", :as_contributor do
+        get "/collections/new"
+        expect(response).to have_http_status(:success)
+      end
+
+      it "denies viewer permission", :as_viewer do
+        expect { get "/collections/new" }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    describe "GET /collections/:id/edit" do
+      it "Shows the new collection form", :as_editor do
         get "/collections/#{collection.id}/edit"
         expect(response).to have_http_status(:success)
+      end
+
+      it "is denied to non-editors", :as_contributor do
+        expect { get "/collections/#{collection.id}/edit" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
@@ -61,17 +73,25 @@ RSpec.describe "Collections" do
       end
     end
 
-    describe "PATCH /collections/:id", :as_editor do
-      it "saves details" do
+    describe "PATCH /collections/:id" do
+      it "saves details", :as_editor do
         patch "/collections/#{collection.id}", params: {collection: {name: "newname"}}
         expect(response).to redirect_to("/collections")
       end
+
+      it "is denied to non-editors", :as_contributor do
+        expect { patch "/collections/#{collection.id}", params: {collection: {name: "newname"}} }.to raise_error(Pundit::NotAuthorizedError)
+      end
     end
 
-    describe "DELETE /collections/:id", :as_editor do
-      it "removes collection" do
+    describe "DELETE /collections/:id" do
+      it "removes collection", :as_editor do
         delete "/collections/#{collection.id}"
         expect(response).to redirect_to("/collections")
+      end
+
+      it "is denied to non-editors", :as_contributor do
+        expect { delete "/collections/#{collection.id}" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
   end

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -10,7 +10,6 @@ require "rails_helper"
 #                  DELETE /collections/:id(.:format)                                              collections#destroy
 
 RSpec.describe "Collections" do
-  let(:admin) { create(:admin) }
   let(:collection) { create(:collection) }
 
   context "when signed out" do
@@ -19,7 +18,6 @@ RSpec.describe "Collections" do
 
   context "when signed in" do
     before do
-      sign_in admin
       build_list(:collection, 13) do |collection|
         collection.save! # See https://dev.to/hernamvel/the-optimal-way-to-create-a-set-of-records-with-factorybot-createlist-factorybot-buildlist-1j64
         create_list(:link, 1, linkable: collection)
@@ -28,7 +26,7 @@ RSpec.describe "Collections" do
     end
 
     describe "GET /collections" do
-      it "returns paginated collections" do # rubocop:todo RSpec/MultipleExpectations
+      it "returns paginated collections", :as_viewer do # rubocop:todo RSpec/MultipleExpectations
         get "/collections?page=2"
         expect(response).to have_http_status(:success)
         expect(response.body).to match(/pagination/)
@@ -36,41 +34,41 @@ RSpec.describe "Collections" do
     end
 
     describe "POST /collections" do
-      it "creates a new collection" do
+      it "creates a new collection", :as_contributor do
         post "/collections", params: {collection: {name: "newname"}}
         expect(response).to redirect_to("/collections")
       end
     end
 
-    describe "GET /collections/new" do
+    describe "GET /collections/new", :as_contributor do
       it "Shows the new collection form" do
         get "/collections/new"
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "GET /collections/:id/edit" do
+    describe "GET /collections/:id/edit", :as_editor do
       it "Shows the new collection form" do
         get "/collections/#{collection.id}/edit"
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "GET /collections/:id" do
+    describe "GET /collections/:id", :as_viewer do
       it "Redirects to a list of models with that collection" do
         get "/collections/#{collection.id}"
         expect(response).to redirect_to("/models?collection=#{collection.id}")
       end
     end
 
-    describe "PATCH /collections/:id" do
+    describe "PATCH /collections/:id", :as_editor do
       it "saves details" do
         patch "/collections/#{collection.id}", params: {collection: {name: "newname"}}
         expect(response).to redirect_to("/collections")
       end
     end
 
-    describe "DELETE /collections/:id" do
+    describe "DELETE /collections/:id", :as_editor do
       it "removes collection" do
         delete "/collections/#{collection.id}"
         expect(response).to redirect_to("/collections")

--- a/spec/requests/creators_spec.rb
+++ b/spec/requests/creators_spec.rb
@@ -10,7 +10,6 @@ require "rails_helper"
 #              DELETE /creators/:id(.:format)                                                 creators#destroy
 
 RSpec.describe "Creators" do
-  let(:admin) { create(:admin) }
   let(:creator) { create(:creator) }
 
   context "when signed out" do
@@ -19,7 +18,6 @@ RSpec.describe "Creators" do
 
   context "when signed in" do
     before do
-      sign_in admin
       build_list(:creator, 13) do |creator|
         creator.save! # See https://dev.to/hernamvel/the-optimal-way-to-create-a-set-of-records-with-factorybot-createlist-factorybot-buildlist-1j64
         create_list(:link, 1, linkable: creator)
@@ -28,7 +26,7 @@ RSpec.describe "Creators" do
     end
 
     describe "GET /creators" do
-      it "returns paginated creators" do # rubocop:todo RSpec/MultipleExpectations
+      it "returns paginated creators", :as_viewer do # rubocop:todo RSpec/MultipleExpectations
         get "/creators?page=2"
         expect(response).to have_http_status(:success)
         expect(response.body).to match(/pagination/)
@@ -36,41 +34,41 @@ RSpec.describe "Creators" do
     end
 
     describe "POST /creators" do
-      it "creates a new creator" do
+      it "creates a new creator", :as_contributor do
         post "/creators", params: {creator: {name: "newname"}}
         expect(response).to redirect_to("/creators")
       end
     end
 
-    describe "GET /creators/new" do
+    describe "GET /creators/new", :as_contributor do
       it "Shows the new creator form" do
         get "/creators/new"
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "GET /creators/:id/edit" do
+    describe "GET /creators/:id/edit", :as_editor do
       it "Shows the new creator form" do
         get "/creators/#{creator.id}/edit"
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "GET /creators/:id" do
+    describe "GET /creators/:id", :as_viewer do
       it "Redirects to a list of models with that creator" do
         get "/creators/#{creator.id}"
         expect(response).to redirect_to("/models?creator=#{creator.id}")
       end
     end
 
-    describe "PATCH /creators/:id" do
+    describe "PATCH /creators/:id", :as_editor do
       it "saves details" do
         patch "/creators/#{creator.id}", params: {creator: {name: "newname"}}
         expect(response).to redirect_to("/creators/#{creator.id}")
       end
     end
 
-    describe "DELETE /creators/:id" do
+    describe "DELETE /creators/:id", :as_editor do
       it "removes creator" do
         delete "/creators/#{creator.id}"
         expect(response).to redirect_to("/creators")

--- a/spec/requests/creators_spec.rb
+++ b/spec/requests/creators_spec.rb
@@ -38,19 +38,31 @@ RSpec.describe "Creators" do
         post "/creators", params: {creator: {name: "newname"}}
         expect(response).to redirect_to("/creators")
       end
-    end
 
-    describe "GET /creators/new", :as_contributor do
-      it "Shows the new creator form" do
-        get "/creators/new"
-        expect(response).to have_http_status(:success)
+      it "denies viewer permission", :as_viewer do
+        expect { post "/creators", params: {creator: {name: "newname"}} }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
-    describe "GET /creators/:id/edit", :as_editor do
-      it "Shows the new creator form" do
+    describe "GET /creators/new" do
+      it "Shows the new creator form", :as_contributor do
+        get "/creators/new"
+        expect(response).to have_http_status(:success)
+      end
+
+      it "denies viewer permission", :as_viewer do
+        expect { get "/creators/new" }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    describe "GET /creators/:id/edit" do
+      it "Shows the new creator form", :as_editor do
         get "/creators/#{creator.id}/edit"
         expect(response).to have_http_status(:success)
+      end
+
+      it "is denied to non-editors", :as_contributor do
+        expect { get "/creators/#{creator.id}/edit" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
@@ -61,17 +73,25 @@ RSpec.describe "Creators" do
       end
     end
 
-    describe "PATCH /creators/:id", :as_editor do
-      it "saves details" do
+    describe "PATCH /creators/:id" do
+      it "saves details", :as_editor do
         patch "/creators/#{creator.id}", params: {creator: {name: "newname"}}
         expect(response).to redirect_to("/creators/#{creator.id}")
       end
+
+      it "is denied to non-editors", :as_contributor do
+        expect { patch "/creators/#{creator.id}", params: {creator: {name: "newname"}} }.to raise_error(Pundit::NotAuthorizedError)
+      end
     end
 
-    describe "DELETE /creators/:id", :as_editor do
-      it "removes creator" do
+    describe "DELETE /creators/:id" do
+      it "removes creator", :as_editor do
         delete "/creators/#{creator.id}"
         expect(response).to redirect_to("/creators")
+      end
+
+      it "is denied to non-editors", :as_contributor do
+        expect { delete "/creators/#{creator.id}" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
   end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -8,17 +8,13 @@ RSpec.describe "Home" do
   end
 
   context "when signed in" do
-    before do
-      sign_in create(:user)
-    end
-
     describe "GET /" do
-      it "redirects to library creation if there isn't one already" do
+      it "redirects to library creation if there isn't one already", :as_viewer do
         get "/"
         expect(response).to redirect_to("/libraries/new")
       end
 
-      it "shows the homepage if a library has been created" do
+      it "shows the homepage if a library has been created", :as_viewer do
         create(:library)
         get "/"
         expect(response).to have_http_status(:success)

--- a/spec/requests/libraries_spec.rb
+++ b/spec/requests/libraries_spec.rb
@@ -28,12 +28,20 @@ RSpec.describe "Libraries" do
         expect { post "/libraries/#{library.id}/scan" }.to have_enqueued_job(Scan::DetectFilesystemChangesJob).exactly(:once)
         expect(response).to redirect_to("/libraries/#{library.id}")
       end
+
+      it "denies viewer permission", :as_viewer do
+        expect { post "/libraries/#{library.id}/scan" }.to raise_error(Pundit::NotAuthorizedError)
+      end
     end
 
-    describe "POST /libraries/scan", :as_contributor do
-      it "scans all libraries" do # rubocop:todo RSpec/MultipleExpectations
+    describe "POST /libraries/scan" do
+      it "scans all libraries", :as_contributor do # rubocop:todo RSpec/MultipleExpectations
         expect { post "/libraries/scan" }.to have_enqueued_job(Scan::DetectFilesystemChangesJob).exactly(:once)
         expect(response).to redirect_to("/models")
+      end
+
+      it "denies viewer permission", :as_viewer do
+        expect { post "/libraries/scan" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
@@ -44,45 +52,65 @@ RSpec.describe "Libraries" do
       end
     end
 
-    describe "POST /libraries/", :as_editor do
-      it "creates a new library" do
+    describe "POST /libraries/" do
+      it "creates a new library", :as_administrator do
         post "/libraries", params: {library: {name: "new"}}
         expect(response).to have_http_status(:success)
       end
+
+      it "is denied to non-admins", :as_editor do
+        expect { post "/libraries", params: {library: {name: "new"}} }.to raise_error(Pundit::NotAuthorizedError)
+      end
     end
 
-    describe "GET /libraries/new", :as_editor do
-      it "shows the new library form" do
+    describe "GET /libraries/new" do
+      it "shows the new library form", :as_administrator do
         get "/libraries/new"
         expect(response).to have_http_status(:success)
       end
-    end
 
-    describe "GET /libraries/:id/edit", :as_administrator do
-      it "shows the edit library form" do
-        get "/libraries/#{library.id}/edit"
-        expect(response).to have_http_status(:success)
+      it "is denied to non-admins", :as_editor do
+        expect { get "/libraries/new" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
-    describe "GET /libraries/:id", :as_viewer do
-      it "redirects to models index with library filter" do
+    describe "GET /libraries/:id/edit" do
+      it "shows the edit library form", :as_administrator do
+        get "/libraries/#{library.id}/edit"
+        expect(response).to have_http_status(:success)
+      end
+
+      it "is denied to non-administrators", :as_editor do
+        expect { get "/libraries/#{library.id}/edit" }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    describe "GET /libraries/:id" do
+      it "redirects to models index with library filter", :as_viewer do
         get "/libraries/#{library.id}"
         expect(response).to redirect_to("/models?library=#{library.id}")
       end
     end
 
-    describe "PATCH /libraries/:id", :as_administrator do
-      it "updates the library" do
+    describe "PATCH /libraries/:id" do
+      it "updates the library", :as_administrator do
         patch "/libraries/#{library.id}", params: {library: {name: "new"}}
         expect(response).to redirect_to("/models")
       end
+
+      it "is denied to non-administrators", :as_editor do
+        expect { patch "/libraries/#{library.id}", params: {library: {name: "new"}} }.to raise_error(Pundit::NotAuthorizedError)
+      end
     end
 
-    describe "DELETE /libraries/:id", :as_administrator do
-      it "removes the library" do
+    describe "DELETE /libraries/:id" do
+      it "removes the library", :as_administrator do
         delete "/libraries/#{library.id}"
         expect(response).to redirect_to("/libraries")
+      end
+
+      it "is denied to non-administrators", :as_editor do
+        expect { delete "/libraries/#{library.id}" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
   end

--- a/spec/requests/libraries_spec.rb
+++ b/spec/requests/libraries_spec.rb
@@ -12,8 +12,6 @@ require "rails_helper"
 #                DELETE /libraries/:id(.:format)                                                libraries#destroy
 
 RSpec.describe "Libraries" do
-  let(:admin) { create(:admin) }
-
   context "when signed out" do
     it "needs testing when multiuser is enabled"
   end
@@ -25,67 +23,63 @@ RSpec.describe "Libraries" do
       end
     end
 
-    before do
-      sign_in admin
-    end
-
     describe "POST /libraries/:id/scan" do
-      it "scans a single library" do # rubocop:todo RSpec/MultipleExpectations
+      it "scans a single library", :as_contributor do # rubocop:todo RSpec/MultipleExpectations
         expect { post "/libraries/#{library.id}/scan" }.to have_enqueued_job(Scan::DetectFilesystemChangesJob).exactly(:once)
         expect(response).to redirect_to("/libraries/#{library.id}")
       end
     end
 
-    describe "POST /libraries/scan" do
+    describe "POST /libraries/scan", :as_contributor do
       it "scans all libraries" do # rubocop:todo RSpec/MultipleExpectations
         expect { post "/libraries/scan" }.to have_enqueued_job(Scan::DetectFilesystemChangesJob).exactly(:once)
         expect(response).to redirect_to("/models")
       end
     end
 
-    describe "GET /libraries" do
+    describe "GET /libraries", :as_viewer do
       it "redirects to models index" do
         get "/libraries"
         expect(response).to redirect_to("/models")
       end
     end
 
-    describe "POST /libraries/" do
+    describe "POST /libraries/", :as_editor do
       it "creates a new library" do
         post "/libraries", params: {library: {name: "new"}}
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "GET /libraries/new" do
+    describe "GET /libraries/new", :as_editor do
       it "shows the new library form" do
         get "/libraries/new"
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "GET /libraries/:id/edit" do
+    describe "GET /libraries/:id/edit", :as_administrator do
       it "shows the edit library form" do
         get "/libraries/#{library.id}/edit"
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "GET /libraries/:id" do
+    describe "GET /libraries/:id", :as_viewer do
       it "redirects to models index with library filter" do
         get "/libraries/#{library.id}"
         expect(response).to redirect_to("/models?library=#{library.id}")
       end
     end
 
-    describe "PATCH /libraries/:id" do
+    describe "PATCH /libraries/:id", :as_administrator do
       it "updates the library" do
         patch "/libraries/#{library.id}", params: {library: {name: "new"}}
         expect(response).to redirect_to("/models")
       end
     end
 
-    describe "DELETE /libraries/:id" do
+    describe "DELETE /libraries/:id", :as_administrator do
       it "removes the library" do
         delete "/libraries/#{library.id}"
         expect(response).to redirect_to("/libraries")

--- a/spec/requests/model_files_spec.rb
+++ b/spec/requests/model_files_spec.rb
@@ -10,17 +10,11 @@ require "support/mock_directory"
 #                                DELETE /libraries/:library_id/models/:model_id/model_files/:id(.:format)       model_files#destroy
 
 RSpec.describe "Model Files" do
-  let(:admin) { create(:admin) }
-
   context "when signed out" do
     it "needs testing when multiuser is enabled"
   end
 
   context "when signed in" do
-    before do
-      sign_in admin
-    end
-
     let(:jpg_file) { create(:model_file, model: model, filename: "test.jpg") }
     let(:stl_file) { create(:model_file, model: model, filename: "test.stl") }
     let(:model) { create(:model, library: library, path: "model_one") }
@@ -36,28 +30,28 @@ RSpec.describe "Model Files" do
       end
     end
 
-    describe "GET /libraries/:library_id/models/:model_id/model_files/edit" do
+    describe "GET /libraries/:library_id/models/:model_id/model_files/edit", :as_editor do
       it "shows bulk update form" do
         get edit_library_model_model_files_path(library, model, stl_file)
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "PATCH /libraries/:library_id/models/:model_id/model_files/update" do
+    describe "PATCH /libraries/:library_id/models/:model_id/model_files/update", :as_editor do
       it "bulk updates the files" do
         patch library_model_model_file_path(library, model, stl_file), params: {model_file: {name: "name"}}
         expect(response).to redirect_to(library_model_model_file_path(library, model, stl_file))
       end
     end
 
-    describe "GET /libraries/:library_id/models/:model_id/model_files/:id/edit" do
+    describe "GET /libraries/:library_id/models/:model_id/model_files/:id/edit", :as_editor do
       it "shows edit page for file" do
         get edit_library_model_model_file_path(library, model, stl_file)
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "GET /libraries/:library_id/models/:model_id/model_files/:id" do
+    describe "GET /libraries/:library_id/models/:model_id/model_files/:id", :as_viewer do
       describe "GET a model file in its original file format" do
         before do
           get library_model_model_file_path(library, model, stl_file, format: :stl)
@@ -72,7 +66,7 @@ RSpec.describe "Model Files" do
         end
       end
 
-      describe "GET an image file in its original file format" do
+      describe "GET an image file in its original file format", :as_viewer do
         before do
           get library_model_model_file_path(library, model, jpg_file, format: :jpg)
         end
@@ -87,14 +81,14 @@ RSpec.describe "Model Files" do
       end
     end
 
-    describe "PATCH /libraries/:library_id/models/:model_id/model_files/:id" do
+    describe "PATCH /libraries/:library_id/models/:model_id/model_files/:id", :as_editor do
       it "updates the file" do
         patch library_model_model_file_path(library, model, stl_file), params: {model_file: {name: "name"}}
         expect(response).to redirect_to(library_model_model_file_path(library, model, stl_file))
       end
     end
 
-    describe "DELETE /libraries/:library_id/models/:model_id/model_files/:id" do
+    describe "DELETE /libraries/:library_id/models/:model_id/model_files/:id", :as_editor do
       it "removes the file" do
         delete library_model_model_file_path(library, model, stl_file)
         expect(response).to redirect_to(library_model_path(library, model))

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -11,17 +11,11 @@ require "rails_helper"
 # merge_library_model POST   /libraries/:library_id/models/:id/merge(.:format)                       models#merge
 
 RSpec.describe "Models" do
-  let(:admin) { create(:admin) }
-
   context "when signed out" do
     it "needs testing when multiuser is enabled"
   end
 
   context "when signed in" do
-    before do
-      sign_in admin
-    end
-
     let(:library) do
       l = create(:library)
       build_list(:model, 15, library: l) { |x| x.save! }
@@ -29,21 +23,21 @@ RSpec.describe "Models" do
     end
     let(:creator) { create(:creator) }
 
-    describe "GET /libraries/:library_id/models/:id" do
+    describe "GET /libraries/:library_id/models/:id", :as_viewer do
       it "returns http success" do
         get "/libraries/#{library.id}/models/#{library.models.first.id}"
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "GET /libraries/:library_id/models/:id/edit" do
+    describe "GET /libraries/:library_id/models/:id/edit", :as_editor do
       it "shows edit page for file" do
         get "/libraries/#{library.id}/models/#{library.models.first.id}/edit"
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "PUT /libraries/:library_id/models/:id" do
+    describe "PUT /libraries/:library_id/models/:id", :as_editor do
       it "adds tags to a model" do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
         put "/libraries/#{library.id}/models/#{library.models.first.id}", params: {model: {tag_list: ["a", "b", "c"]}}
         expect(response).to have_http_status(:redirect)
@@ -82,21 +76,21 @@ RSpec.describe "Models" do
       end
     end
 
-    describe "DELETE /libraries/:library_id/models/:id" do # rubocop:todo RSpec/RepeatedExampleGroupBody
+    describe "DELETE /libraries/:library_id/models/:id", :as_editor do # rubocop:todo RSpec/RepeatedExampleGroupBody
       it "redirects to model list after deletion" do
         delete "/libraries/#{library.id}/models/#{library.models.first.id}"
         expect(response).to redirect_to("/libraries/#{library.id}")
       end
     end
 
-    describe "GET /models/edit" do # rubocop:todo RSpec/RepeatedExampleGroupBody
+    describe "GET /models/edit", :as_editor do # rubocop:todo RSpec/RepeatedExampleGroupBody
       it "shows bulk edit page" do
         get "/models/edit"
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "PATCH /models/edit" do
+    describe "PATCH /models/edit", :as_editor do
       it "updates models creator" do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
         models = library.models.take(2)
         update = {}
@@ -142,7 +136,7 @@ RSpec.describe "Models" do
       end
     end
 
-    describe "GET /models" do
+    describe "GET /models", :as_viewer do
       it "returns paginated models" do # rubocop:todo RSpec/MultipleExpectations
         get "/models?library=#{library.id}&page=2"
         expect(response).to have_http_status(:success)
@@ -150,7 +144,7 @@ RSpec.describe "Models" do
       end
     end
 
-    describe "POST /libraries/:library_id/models/:id/merge" do
+    describe "POST /libraries/:library_id/models/:id/merge", :as_editor do
       it "gives a bad request response if no merge parameter is provided" do
         post "/libraries/#{library.id}/models/#{library.models.first.id}/merge"
         expect(response).to have_http_status(:bad_request)

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -30,15 +30,19 @@ RSpec.describe "Models" do
       end
     end
 
-    describe "GET /libraries/:library_id/models/:id/edit", :as_editor do
-      it "shows edit page for file" do
+    describe "GET /libraries/:library_id/models/:id/edit" do
+      it "shows edit page for file", :as_editor do
         get "/libraries/#{library.id}/models/#{library.models.first.id}/edit"
         expect(response).to have_http_status(:success)
       end
+
+      it "is denied to non-editors", :as_contributor do
+        expect { get "/libraries/#{library.id}/models/#{library.models.first.id}/edit" }.to raise_error(Pundit::NotAuthorizedError)
+      end
     end
 
-    describe "PUT /libraries/:library_id/models/:id", :as_editor do
-      it "adds tags to a model" do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
+    describe "PUT /libraries/:library_id/models/:id" do
+      it "adds tags to a model", :as_editor do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
         put "/libraries/#{library.id}/models/#{library.models.first.id}", params: {model: {tag_list: ["a", "b", "c"]}}
         expect(response).to have_http_status(:redirect)
         tags = library.models.first.tag_list
@@ -48,7 +52,7 @@ RSpec.describe "Models" do
         expect(tags[2]).to eq "c"
       end
 
-      it "removes tags from a model" do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
+      it "removes tags from a model", :as_editor do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
         first = library.models.first
         first.tag_list = "a, b, c"
         first.save
@@ -61,7 +65,7 @@ RSpec.describe "Models" do
         expect(tags[1]).to eq "b"
       end
 
-      it "both adds and removes tags from a model" do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
+      it "both adds and removes tags from a model", :as_editor do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
         first = library.models.first
         first.tag_list = "a, b, c"
         first.save
@@ -74,24 +78,36 @@ RSpec.describe "Models" do
         expect(tags[1]).to eq "b"
         expect(tags[2]).to eq "d"
       end
+
+      it "is denied to non-editors", :as_contributor do
+        expect { put "/libraries/#{library.id}/models/#{library.models.first.id}" }.to raise_error(Pundit::NotAuthorizedError)
+      end
     end
 
-    describe "DELETE /libraries/:library_id/models/:id", :as_editor do # rubocop:todo RSpec/RepeatedExampleGroupBody
-      it "redirects to model list after deletion" do
+    describe "DELETE /libraries/:library_id/models/:id" do # rubocop:todo RSpec/RepeatedExampleGroupBody
+      it "redirects to model list after deletion", :as_editor do
         delete "/libraries/#{library.id}/models/#{library.models.first.id}"
         expect(response).to redirect_to("/libraries/#{library.id}")
       end
-    end
 
-    describe "GET /models/edit", :as_editor do # rubocop:todo RSpec/RepeatedExampleGroupBody
-      it "shows bulk edit page" do
-        get "/models/edit"
-        expect(response).to have_http_status(:success)
+      it "is denied to non-editors", :as_contributor do
+        expect { delete "/libraries/#{library.id}/models/#{library.models.first.id}" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
-    describe "PATCH /models/edit", :as_editor do
-      it "updates models creator" do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
+    describe "GET /models/edit" do # rubocop:todo RSpec/RepeatedExampleGroupBody
+      it "shows bulk edit page", :as_editor do
+        get "/models/edit"
+        expect(response).to have_http_status(:success)
+      end
+
+      it "is denied to non-editors", :as_contributor do
+        expect { get "/models/edit" }.to raise_error(Pundit::NotAuthorizedError)
+      end
+    end
+
+    describe "PATCH /models/edit" do
+      it "updates models creator", :as_editor do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
         models = library.models.take(2)
         update = {}
         update[models[0].id] = 1
@@ -105,8 +121,8 @@ RSpec.describe "Models" do
         expect(models[1].creator_id).to eq creator.id
       end
 
-      update = {}
-      it "adds tags to models" do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
+      it "adds tags to models", :as_editor do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
+        update = {}
         library.models.take(2).each do |model|
           update[model.id] = 1
         end
@@ -119,7 +135,7 @@ RSpec.describe "Models" do
         end
       end
 
-      it "removes tags from models" do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
+      it "removes tags from models", :as_editor do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
         update = {}
         library.models.take(2).each do |model|
           model.tag_list = "a, b, c"
@@ -134,6 +150,11 @@ RSpec.describe "Models" do
           expect(model.tag_list).to eq ["c"]
         end
       end
+
+      it "is denied to non-editors", :as_contributor do
+        update = {}
+        expect { patch "/models/update", params: {models: update, remove_tags: ["a", "b"]} }.to raise_error(Pundit::NotAuthorizedError)
+      end
     end
 
     describe "GET /models", :as_viewer do
@@ -144,10 +165,14 @@ RSpec.describe "Models" do
       end
     end
 
-    describe "POST /libraries/:library_id/models/:id/merge", :as_editor do
-      it "gives a bad request response if no merge parameter is provided" do
+    describe "POST /libraries/:library_id/models/:id/merge" do
+      it "gives a bad request response if no merge parameter is provided", :as_editor do
         post "/libraries/#{library.id}/models/#{library.models.first.id}/merge"
         expect(response).to have_http_status(:bad_request)
+      end
+
+      it "is denied to non-editors", :as_contributor do
+        expect { post "/libraries/#{library.id}/models/#{library.models.first.id}/merge" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
   end

--- a/spec/requests/problems_spec.rb
+++ b/spec/requests/problems_spec.rb
@@ -83,12 +83,16 @@ RSpec.describe "Problems" do
       end
     end
 
-    describe "PATCH /problems/:id", :as_editor do
+    describe "PATCH /problems/:id" do
       let(:problem) { create(:problem) }
 
-      it "updates the problem and returns to list" do
+      it "updates the problem and returns to list", :as_editor do
         patch "/problems/#{problem.id}", params: {problem: {ignored: true}}
         expect(response).to redirect_to("/problems")
+      end
+
+      it "is denied to non-editors", :as_contributor do
+        expect { patch "/problems/#{problem.id}", params: {problem: {ignored: true}} }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
   end

--- a/spec/requests/problems_spec.rb
+++ b/spec/requests/problems_spec.rb
@@ -4,16 +4,12 @@ require "rails_helper"
 #  problem PATCH  /problems/:id(.:format)                                                 problems#update
 
 RSpec.describe "Problems" do
-  let(:admin) { create(:admin) }
-
   context "when signed out" do
     it "needs testing when multiuser is enabled"
   end
 
   context "when signed in" do
-    before { sign_in admin }
-
-    describe "GET /problems" do
+    describe "GET /problems", :as_viewer do
       before do
         create_list(:problem, 2, category: :inefficient)
         create_list(:problem_on_model, 3, category: :missing)
@@ -87,7 +83,7 @@ RSpec.describe "Problems" do
       end
     end
 
-    describe "PATCH /problems/:id" do
+    describe "PATCH /problems/:id", :as_editor do
       let(:problem) { create(:problem) }
 
       it "updates the problem and returns to list" do

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -5,35 +5,29 @@ require "rails_helper"
 #                PUT    /users/:user_id/settings(.:format)                                      settings#update
 
 RSpec.describe "Settings" do
-  let(:user) { create(:user) }
-
   context "when signed out" do
     it "needs testing when multiuser is enabled"
   end
 
   context "when signed in" do
-    before do
-      sign_in user
-    end
-
-    describe "GET /users/:user_id/settings" do
+    describe "GET /users/:user_id/settings", :as_viewer do
       it "returns http success" do
-        get "/users/#{user.username}/settings"
+        get "/users/#{User.first.username}/settings"
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "PATCH /users/:user_id/settings" do
+    describe "PATCH /users/:user_id/settings", :as_viewer do
       it "redirects back to settings on success" do
-        patch "/users/#{user.username}/settings"
-        expect(response).to redirect_to("/users/#{user.username}/settings")
+        patch "/users/#{User.first.username}/settings"
+        expect(response).to redirect_to("/users/#{User.first.username}/settings")
       end
     end
 
-    describe "PUT /users/:user_id/settings" do
+    describe "PUT /users/:user_id/settings", :as_viewer do
       it "redirects back to settings on success" do
-        put "/users/#{user.username}/settings"
-        expect(response).to redirect_to("/users/#{user.username}/settings")
+        put "/users/#{User.first.username}/settings"
+        expect(response).to redirect_to("/users/#{User.first.username}/settings")
       end
     end
   end

--- a/spec/requests/uploads_spec.rb
+++ b/spec/requests/uploads_spec.rb
@@ -4,7 +4,6 @@ require "rails_helper"
 #          POST   /uploads(.:format)                                                      uploads#create
 
 RSpec.describe "Uploads" do
-  let(:admin) { create(:admin) }
   let(:library) { create(:library) }
 
   context "when signed out" do
@@ -12,19 +11,25 @@ RSpec.describe "Uploads" do
   end
 
   context "when signed in" do
-    before { sign_in admin }
-
     describe "GET /uploads" do
-      it "shows upload form" do
+      it "shows upload form", :as_contributor do
         get "/uploads"
         expect(response).to have_http_status(:success)
       end
+
+      it "denies viewer permission", :as_viewer do
+        expect { get "/uploads" }.to raise_error(Pundit::NotAuthorizedError)
+      end
     end
 
-    describe "POST /uploads" do # rubocop:todo RSpec/RepeatedExampleGroupBody
-      it "redirect back to index after upload" do
+    describe "POST /uploads" do
+      it "redirect back to index after upload", :as_contributor do
         post "/uploads", params: {post: {library_pick: library.id, scan_after_upload: "1"}, upload: {datafiles: []}}
         expect(response).to redirect_to("/libraries")
+      end
+
+      it "denies viewer permission", :as_viewer do
+        expect { post "/uploads", params: {post: {library_pick: library.id, scan_after_upload: "1"}, upload: {datafiles: []}} }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
   end

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -29,11 +29,7 @@ RSpec.describe "Users::Sessions" do
       end
     end
 
-    context "when signed in" do
-      before { sign_in admin }
-
-      let(:admin) { create(:admin) }
-
+    context "when signed in", :as_viewer do
       describe "GET /users/sign_in" do
         it "redirects to root" do
           get "/users/sign_in"
@@ -67,11 +63,7 @@ RSpec.describe "Users::Sessions" do
       end
     end
 
-    context "when signed in" do
-      before { sign_in admin }
-
-      let(:admin) { create(:admin) }
-
+    context "when signed in", :as_viewer do
       describe "GET /users/sign_in" do
         it "redirects to root" do
           get "/users/sign_in"

--- a/spec/support/sign_in_role.rb
+++ b/spec/support/sign_in_role.rb
@@ -1,0 +1,17 @@
+RSpec.configure do |config|
+  config.before(:each, :as_administrator) do
+    sign_in create(:admin)
+  end
+
+  config.before(:each, :as_editor) do
+    sign_in create(:editor)
+  end
+
+  config.before(:each, :as_contributor) do
+    sign_in create(:contributor)
+  end
+
+  config.before(:each, :as_viewer) do
+    sign_in create(:user)
+  end
+end


### PR DESCRIPTION
In general, administrators can do everything, editors can edit and delete, contributors can create (and upload), and viewers can just view.

Part of #647 