### PR TITLE
Check for non-manifold mesh errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -97,7 +97,7 @@ gem "acts_as_favoritor", "~> 6.0"
 
 gem "sqlite3_ar_regexp", "~> 2.2"
 
-gem "mittsu", github: "danini-the-panini/mittsu", ref: "7f44c46"
+gem "mittsu", github: "manyfold3d/mittsu", ref: "manyfold"
 
 gem "view_component", "~> 3.11"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,14 +8,16 @@ GIT
       railties (>= 6.0)
 
 GIT
-  remote: https://github.com/danini-the-panini/mittsu.git
-  revision: 7f44c468f9d6d8b5548ca933dea2d1a873ac496d
-  ref: 7f44c46
+  remote: https://github.com/manyfold3d/mittsu.git
+  revision: 412b188b3e9ae701e00322eef18c114c76e4a9b7
+  ref: manyfold
   specs:
     mittsu (0.4.0)
+      builder
       chunky_png
       ffi
       opengl-bindings
+      rubyzip
 
 GEM
   remote: https://rubygems.org/
@@ -298,7 +300,7 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    opengl-bindings (1.6.13)
+    opengl-bindings (1.6.14)
     orm_adapter (0.5.0)
     parallel (1.24.0)
     parser (3.3.0.5)
@@ -442,6 +444,7 @@ GEM
       rubocop (~> 1.40)
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
+    rubyzip (2.3.2)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: https://github.com/manyfold3d/mittsu.git
-  revision: 412b188b3e9ae701e00322eef18c114c76e4a9b7
+  revision: cd538af53493c09b0a2497c51569be6c1c6fc1d6
   ref: manyfold
   specs:
     mittsu (0.4.0)
@@ -166,7 +166,6 @@ GEM
     faker (3.3.0)
       i18n (>= 1.8.11, < 2)
     ffi (1.16.3)
-    ffi (1.16.3-x64-mingw-ucrt)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     flipper (1.2.2)

--- a/app/jobs/scan/analyse_model_file_job.rb
+++ b/app/jobs/scan/analyse_model_file_job.rb
@@ -1,7 +1,7 @@
 require "string/similarity"
 
 class Scan::AnalyseModelFileJob < ApplicationJob
-  queue_as :scan
+  queue_as :analysis
 
   def perform(file_id)
     file = ModelFile.find(file_id)

--- a/app/jobs/scan/analyse_model_file_job.rb
+++ b/app/jobs/scan/analyse_model_file_job.rb
@@ -9,13 +9,15 @@ class Scan::AnalyseModelFileJob < ApplicationJob
     # Don't run analysis if the file is missing
     # The Problem is raised elsewhere.
     return if !File.exist?(file.pathname)
-    # Update stored file metadata to detect file changes
-    file.digest = file.calculate_digest
-    file.size = File.size(file.pathname)
-    # If the digest has changed, queue up detailed geometric mesh analysis
-    Scan::GeometricAnalysisJob.perform_later(file_id) if file.digest_changed?
-    # Store updated file metadata
-    file.save!
+    # If the file is modified, or we're lacking metadata
+    if File.mtime(file.pathname) > file.updated_at || file.digest.nil? || file.size.nil?
+      file.digest = file.calculate_digest
+      file.size = File.size(file.pathname)
+      # If the digest has changed, queue up detailed geometric mesh analysis
+      Scan::GeometricAnalysisJob.perform_later(file_id) if file.digest_changed?
+      # Store updated file metadata
+      file.save!
+    end
     # Match supported files
     match_with_supported_file(file)
     # Detect inefficient file formats

--- a/app/jobs/scan/geometric_analysis_job.rb
+++ b/app/jobs/scan/geometric_analysis_job.rb
@@ -9,25 +9,18 @@ class Scan::GeometricAnalysisJob < ApplicationJob
     mesh = file.mesh
     if mesh
       # Check for manifold mesh
-      manifold = true
-      mesh.traverse do |object|
-        manifold &&= object.manifold?
-      end
+      manifold = mesh.manifold?
       Problem.create_or_clear(
         file,
         :non_manifold,
         !manifold
       )
       # If the mesh is manifold, we can check if it's inside out
-      solid = true
-      mesh.traverse do |object|
-        solid &&= object.solid?
-      end
       if manifold
         Problem.create_or_clear(
           file,
           :inside_out,
-          !solid
+          !mesh.solid?
         )
       end
     end

--- a/app/jobs/scan/geometric_analysis_job.rb
+++ b/app/jobs/scan/geometric_analysis_job.rb
@@ -2,5 +2,27 @@ class Scan::GeometricAnalysisJob < ApplicationJob
   queue_as :scan
 
   def perform(file_id)
+    # Get model
+    file = ModelFile.find(file_id)
+    return if file.nil?
+    # Get mesh
+    mesh = file.mesh
+    if mesh
+      # Check for manifold mesh
+      manifold = mesh.manifold?
+      Problem.create_or_clear(
+        file,
+        :non_manifold,
+        !manifold
+      )
+      # If the mesh is manifold, we can check if it's inside out
+      if manifold
+        Problem.create_or_clear(
+          file,
+          :inside_out,
+          !mesh.solid?
+        )
+      end
+    end
   end
 end

--- a/app/jobs/scan/geometric_analysis_job.rb
+++ b/app/jobs/scan/geometric_analysis_job.rb
@@ -1,0 +1,6 @@
+class Scan::GeometricAnalysisJob < ApplicationJob
+  queue_as :scan
+
+  def perform(file_id)
+  end
+end

--- a/app/jobs/scan/geometric_analysis_job.rb
+++ b/app/jobs/scan/geometric_analysis_job.rb
@@ -9,18 +9,25 @@ class Scan::GeometricAnalysisJob < ApplicationJob
     mesh = file.mesh
     if mesh
       # Check for manifold mesh
-      manifold = mesh.manifold?
+      manifold = true
+      mesh.traverse do |object|
+        manifold &&= object.manifold?
+      end
       Problem.create_or_clear(
         file,
         :non_manifold,
         !manifold
       )
       # If the mesh is manifold, we can check if it's inside out
+      solid = true
+      mesh.traverse do |object|
+        solid &&= object.solid?
+      end
       if manifold
         Problem.create_or_clear(
           file,
           :inside_out,
-          !mesh.solid?
+          !solid
         )
       end
     end

--- a/app/jobs/scan/geometric_analysis_job.rb
+++ b/app/jobs/scan/geometric_analysis_job.rb
@@ -1,5 +1,5 @@
 class Scan::GeometricAnalysisJob < ApplicationJob
-  queue_as :scan
+  queue_as :analysis
 
   def perform(file_id)
     # Get model

--- a/app/lib/mesh_analysis.rb
+++ b/app/lib/mesh_analysis.rb
@@ -1,5 +1,7 @@
 module MeshAnalysis
   def solid?
+    # Shortcut if there is no geometry
+    return true if geometry.nil?
     # Make sure material is double sided
     prev_side = material.side
     material.side = Mittsu::DoubleSide
@@ -14,9 +16,11 @@ module MeshAnalysis
   end
 
   def manifold?
+    # Shortcut if there is no geometry
+    return true if geometry.nil?
     edges = {}
     # For each face, record its edges in the edge hash
-    geometry.faces.each do |face|
+    geometry&.faces&.each do |face|
       update_edge_hash face.a, face.b, edges
       update_edge_hash face.b, face.c, edges
       update_edge_hash face.c, face.a, edges

--- a/app/lib/mesh_analysis.rb
+++ b/app/lib/mesh_analysis.rb
@@ -1,6 +1,5 @@
 module Mittsu
   class Object3D
-
     def solid?
       # Make sure material is double sided
       prev_side = material.side

--- a/app/lib/mesh_analysis.rb
+++ b/app/lib/mesh_analysis.rb
@@ -24,4 +24,12 @@ module Mittsu
       edges["#{v1}->#{v2}"] = true
     end
   end
+
+  class Face3
+    def flip!
+      tmp = @a
+      @a = @c
+      @c = tmp
+    end
+  end
 end

--- a/app/lib/mesh_analysis.rb
+++ b/app/lib/mesh_analysis.rb
@@ -1,23 +1,32 @@
 module MeshAnalysis
   def solid?
-    # Shortcut if there is no geometry
-    return true if geometry.nil?
-    # Make sure material is double sided
-    prev_side = material.side
-    material.side = Mittsu::DoubleSide
-    # Make a raycaster from a vertex and the face normal
-    face = geometry.faces.first
-    r = Mittsu::Raycaster.new(geometry.vertices[face.b], face.normal, 1e-9)
-    intersections = r.intersect_object(self, true)
-    # Restore material
-    material.side = prev_side
-    # We want an even number of intersections
-    intersections.length % 2 == 0
+    # Shortcut if there is nothing here
+    return true if geometry.nil? && children.empty?
+    # Recurse children to see if they are solid
+    children_are_solid = children.map { |x| x.solid? }.all?
+    solid = true
+    if geometry
+      # Make sure material is double sided
+      prev_side = material.side
+      material.side = Mittsu::DoubleSide
+      # Make a raycaster from a vertex and the face normal
+      face = geometry.faces.first
+      r = Mittsu::Raycaster.new(geometry.vertices[face.b], face.normal, 1e-9)
+      intersections = r.intersect_object(self, true)
+      # Restore material
+      material.side = prev_side
+      # We want an even number of intersections
+      solid = (intersections.length % 2 == 0)
+    end
+    solid && children_are_solid
   end
 
   def manifold?
-    # Shortcut if there is no geometry
-    return true if geometry.nil?
+    # Shortcut if there is nothing here
+    return true if geometry.nil? && children.empty?
+    # Recurse children to see if they are manifold
+    children_are_manifold = children.map { |x| x.manifold? }.all?
+    # Detect manifold geometry in this object
     edges = {}
     # For each face, record its edges in the edge hash
     geometry&.faces&.each do |face|
@@ -27,7 +36,7 @@ module MeshAnalysis
     end
     # If there's anything left in the edge hash, then either
     # we have holes, or we have badly oriented faces
-    edges.empty?
+    edges.empty? && children_are_manifold
   end
 
   private

--- a/app/lib/mesh_analysis.rb
+++ b/app/lib/mesh_analysis.rb
@@ -1,0 +1,13 @@
+module Mittsu
+  class Geometry
+    def manifold?
+      false
+    end
+  end
+
+  class BufferGeometry
+    def manifold?
+      false
+    end
+  end
+end

--- a/app/lib/mesh_analysis.rb
+++ b/app/lib/mesh_analysis.rb
@@ -1,5 +1,20 @@
 module Mittsu
   class Object3D
+
+    def solid?
+      # Make sure material is double sided
+      prev_side = material.side
+      material.side = Mittsu::DoubleSide
+      # Make a raycaster from a vertex and the face normal
+      face = geometry.faces.first
+      r = Mittsu::Raycaster.new(geometry.vertices[face.b], face.normal, 1e-9)
+      intersections = r.intersect_object(self, true)
+      # Restore material
+      material.side = prev_side
+      # We want an even number of intersections
+      intersections.length % 2 == 0
+    end
+
     def manifold?
       edges = {}
       # For each face, record its edges in the edge hash

--- a/app/lib/mesh_analysis.rb
+++ b/app/lib/mesh_analysis.rb
@@ -1,9 +1,9 @@
 module Mittsu
-  class Geometry
+  class Object3D
     def manifold?
       edges = {}
       # For each face, record its edges in the edge hash
-      @faces.each do |face|
+      geometry.faces.each do |face|
         update_edge_hash face.a, face.b, edges
         update_edge_hash face.b, face.c, edges
         update_edge_hash face.c, face.a, edges

--- a/app/lib/mesh_analysis.rb
+++ b/app/lib/mesh_analysis.rb
@@ -1,13 +1,33 @@
 module Mittsu
   class Geometry
     def manifold?
-      false
+      edges = {}
+      # For each face, record its edges in the edge hash
+      @faces.each do |face|
+        update_edge_hash face.a, face.b, edges
+        update_edge_hash face.b, face.c, edges
+        update_edge_hash face.c, face.a, edges
+      end
+      # If there's anything left in the edge hash, then either
+      # we have holes, or we have badly oriented faces
+      edges.empty?
+    end
+
+    private
+
+    # Updates edge hash with the passed vertex indexes
+    # First, the reverse edge is searched for in the hash
+    # If found, it's removed as we've got a match
+    # If not, we record this edge in the hash
+    def update_edge_hash(v1, v2, edges)
+      return if edges.delete "#{v2}->#{v1}"
+      edges["#{v1}->#{v2}"] = true
     end
   end
 
   class BufferGeometry
     def manifold?
-      false
+      true
     end
   end
 end

--- a/app/lib/mesh_analysis.rb
+++ b/app/lib/mesh_analysis.rb
@@ -1,42 +1,46 @@
+module MeshAnalysis
+  def solid?
+    # Make sure material is double sided
+    prev_side = material.side
+    material.side = Mittsu::DoubleSide
+    # Make a raycaster from a vertex and the face normal
+    face = geometry.faces.first
+    r = Mittsu::Raycaster.new(geometry.vertices[face.b], face.normal, 1e-9)
+    intersections = r.intersect_object(self, true)
+    # Restore material
+    material.side = prev_side
+    # We want an even number of intersections
+    intersections.length % 2 == 0
+  end
+
+  def manifold?
+    edges = {}
+    # For each face, record its edges in the edge hash
+    geometry.faces.each do |face|
+      update_edge_hash face.a, face.b, edges
+      update_edge_hash face.b, face.c, edges
+      update_edge_hash face.c, face.a, edges
+    end
+    # If there's anything left in the edge hash, then either
+    # we have holes, or we have badly oriented faces
+    edges.empty?
+  end
+
+  private
+
+  # Updates edge hash with the passed vertex indexes
+  # First, the reverse edge is searched for in the hash
+  # If found, it's removed as we've got a match
+  # If not, we record this edge in the hash
+  def update_edge_hash(v1, v2, edges)
+    return if edges.delete "#{v2}->#{v1}"
+    edges["#{v1}->#{v2}"] = true
+  end
+end
+
 module Mittsu
   class Object3D
-    def solid?
-      # Make sure material is double sided
-      prev_side = material.side
-      material.side = Mittsu::DoubleSide
-      # Make a raycaster from a vertex and the face normal
-      face = geometry.faces.first
-      r = Mittsu::Raycaster.new(geometry.vertices[face.b], face.normal, 1e-9)
-      intersections = r.intersect_object(self, true)
-      # Restore material
-      material.side = prev_side
-      # We want an even number of intersections
-      intersections.length % 2 == 0
-    end
-
-    def manifold?
-      edges = {}
-      # For each face, record its edges in the edge hash
-      geometry.faces.each do |face|
-        update_edge_hash face.a, face.b, edges
-        update_edge_hash face.b, face.c, edges
-        update_edge_hash face.c, face.a, edges
-      end
-      # If there's anything left in the edge hash, then either
-      # we have holes, or we have badly oriented faces
-      edges.empty?
-    end
-
-    private
-
-    # Updates edge hash with the passed vertex indexes
-    # First, the reverse edge is searched for in the hash
-    # If found, it's removed as we've got a match
-    # If not, we record this edge in the hash
-    def update_edge_hash(v1, v2, edges)
-      return if edges.delete "#{v2}->#{v1}"
-      edges["#{v1}->#{v2}"] = true
-    end
+    include MeshAnalysis
   end
 
   class Face3

--- a/app/lib/mesh_analysis.rb
+++ b/app/lib/mesh_analysis.rb
@@ -24,10 +24,4 @@ module Mittsu
       edges["#{v1}->#{v2}"] = true
     end
   end
-
-  class BufferGeometry
-    def manifold?
-      true
-    end
-  end
 end

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -102,6 +102,11 @@ class ModelFile < ApplicationRecord
     ["favorited", "model", "problems"]
   end
 
+  def mesh
+    loader&.new&.load(pathname)
+  end
+  memoize :mesh
+
   private
 
   def presupported_files_cannot_have_presupported_version
@@ -115,11 +120,6 @@ class ModelFile < ApplicationRecord
       errors.add(:presupported_version, :not_supported)
     end
   end
-
-  def mesh
-    loader&.new&.load(pathname)
-  end
-  memoize :mesh
 
   def loader
     case extension

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -123,6 +123,8 @@ class ModelFile < ApplicationRecord
 
   def loader
     case extension
+    when "stl"
+      Mittsu::STLLoader
     when "obj"
       Mittsu::OBJLoader
     end

--- a/app/models/problem.rb
+++ b/app/models/problem.rb
@@ -18,7 +18,9 @@ class Problem < ApplicationRecord
     :inefficient,
     :duplicate,
     :no_image,
-    :no_3d_model
+    :no_3d_model,
+    :non_manifold,
+    :inside_out
   ]
   enum :category, CATEGORIES
 
@@ -36,7 +38,9 @@ class Problem < ApplicationRecord
     inefficient: :info,
     duplicate: :warning,
     no_image: :silent,
-    no_3d_model: :silent
+    no_3d_model: :silent,
+    non_manifold: :warning,
+    inside_out: :warning
   }
 
   def self.create_or_clear(problematic, cat, present, options = {})

--- a/app/views/model_files/_problem.html.erb
+++ b/app/views/model_files/_problem.html.erb
@@ -1,7 +1,7 @@
 <%= card(problem_severity(problem), t("problems.model_file.%{cat}.title" % {cat: problem.category})) do %>
   <%= t(("problems.model_file.%{cat}.description" % {cat: problem.category}), note: problem.note) %>
 
-  <% unless @duplicates.empty? %>
+  <% if problem.category == "duplicate" && !@duplicates.empty? %>
     <ul>
       <% @duplicates.each do |file| %>
         <li><%= link_to "#{file.model.name}/#{file.filename}", [file.model.library, file.model, file] %></li>

--- a/app/views/problems/model_file/_inside_out.html.erb
+++ b/app/views/problems/model_file/_inside_out.html.erb
@@ -1,0 +1,4 @@
+<td><%= icon("files", t(".title")) %></td>
+<td><%= link_to problem.problematic.name, [problem.problematic.model.library, problem.problematic.model, problem.problematic] %></td>
+<td><%= t ".title" %></td>
+<td><%= link_to "Open", [problem.problematic.model.library, problem.problematic.model, problem.problematic], class: "btn btn-primary" %></td>

--- a/app/views/problems/model_file/_non_manifold.html.erb
+++ b/app/views/problems/model_file/_non_manifold.html.erb
@@ -1,0 +1,4 @@
+<td><%= icon("files", t(".title")) %></td>
+<td><%= link_to problem.problematic.name, [problem.problematic.model.library, problem.problematic.model, problem.problematic] %></td>
+<td><%= t ".title" %></td>
+<td><%= link_to "Open", [problem.problematic.model.library, problem.problematic.model, problem.problematic], class: "btn btn-primary" %></td>

--- a/config/initializers/delayed_job_extensions.rb
+++ b/config/initializers/delayed_job_extensions.rb
@@ -3,3 +3,9 @@ class Delayed::Backend::ActiveRecord::Job
     ["attempts", "created_at", "failed_at", "handler", "id", "last_error", "locked_at", "locked_by", "priority", "queue", "run_at", "updated_at"]
   end
 end
+
+Delayed::Worker.queue_attributes = {
+  default: { priority: 0 },
+  scan: { priority: 0 },
+  analysis: { priority: 10 }
+}

--- a/config/initializers/delayed_job_extensions.rb
+++ b/config/initializers/delayed_job_extensions.rb
@@ -5,7 +5,7 @@ class Delayed::Backend::ActiveRecord::Job
 end
 
 Delayed::Worker.queue_attributes = {
-  default: { priority: 0 },
-  scan: { priority: 0 },
-  analysis: { priority: 10 }
+  default: {priority: 0},
+  scan: {priority: 0},
+  analysis: {priority: 10}
 }

--- a/config/initializers/mittsu.rb
+++ b/config/initializers/mittsu.rb
@@ -1,0 +1,2 @@
+# Load mittsu extensions
+require Rails.root.join("app/lib/mesh_analysis")

--- a/config/locales/problems/en.yml
+++ b/config/locales/problems/en.yml
@@ -9,6 +9,8 @@ en:
       nesting: Model contains other models
       no_3d_model: Model has no 3D files
       no_image: Model has no image files
+      non_manifold: Mesh has holes or backwards faces
+      inside_out: Mesh is inside-out
     filters:
       apply_filters: Apply
       clear_filters: Clear
@@ -48,6 +50,12 @@ en:
       missing:
         description: This file is missing on disk; either delete it, or find where it went!
         title: File not found
+      non_manifold:
+        description: The mesh in this file is non-manifold, meaning it has holes or has some faces backwards, and may cause errors when printed. Repair it in a 3d modeling tool.
+        title: Mesh errors detected
+      inside_out:
+        description: The faces on this mesh look like they're pointed the wrong way, which will cause print errors. Repair it in a 3d modeling tool.
+        title: Mesh errors detected
     severities:
       danger: Danger
       info: Info

--- a/config/locales/problems/en.yml
+++ b/config/locales/problems/en.yml
@@ -9,7 +9,7 @@ en:
       nesting: Model contains other models
       no_3d_model: Model has no 3D files
       no_image: Model has no image files
-      non_manifold: Mesh has holes or backwards faces
+      non_manifold: Mesh is non-manifold
       inside_out: Mesh is inside-out
     filters:
       apply_filters: Apply
@@ -51,11 +51,11 @@ en:
         description: This file is missing on disk; either delete it, or find where it went!
         title: File not found
       non_manifold:
-        description: The mesh in this file is non-manifold, meaning it has holes or has some faces backwards, and may cause errors when printed. Repair it in a 3d modeling tool.
-        title: Mesh errors detected
+        description: This mesh appears to be non-manifold, meaning it has holes or has some faces backwards, and may cause errors when printed. Repair it in a 3d modeling tool such as MeshLab or 3D Builder.
+        title: Non-manifold mesh
       inside_out:
-        description: The faces on this mesh look like they're pointed the wrong way, which will cause print errors. Repair it in a 3d modeling tool.
-        title: Mesh errors detected
+        description: This mesh looks like its faces might be pointed the wrong way, which could cause print errors. Repair it in a 3d modeling tool such as MeshLab or 3D Builder.
+        title: Inside-out mesh
     severities:
       danger: Danger
       info: Info

--- a/spec/jobs/scan/analyse_model_file_job_spec.rb
+++ b/spec/jobs/scan/analyse_model_file_job_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Scan::AnalyseModelFileJob do
       ActiveJob::Base.queue_adapter = :test
       allow(ModelFile).to receive(:find).with(file.id).and_return(file)
       allow(File).to receive(:exist?).and_return(true)
+      allow(File).to receive(:mtime).once.and_return(1.day.ago)
       allow(file).to receive(:calculate_digest).once.and_return("deadbeef")
       allow(File).to receive(:size).once.and_return(1234)
     end

--- a/spec/jobs/scan/geometric_analysis_job_spec.rb
+++ b/spec/jobs/scan/geometric_analysis_job_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+require "support/mock_directory"
+
+RSpec.describe Scan::GeometricAnalysisJob do
+  let(:file) { create(:model_file, filename: "test.stl") }
+  let(:mesh) do
+    m = Mittsu::Mesh.new(Mittsu::SphereGeometry.new(2.0, 32, 16))
+    m.geometry.merge_vertices
+    m
+  end
+
+  before do
+    allow(file).to receive(:mesh).and_return(mesh)
+    allow(ModelFile).to receive(:find).with(file.id).and_return(file)
+  end
+
+  it "does not create Problems for a good mesh" do
+    allow(file).to receive(:mesh).and_return(mesh)
+    expect { described_class.perform_now(file.id) }.not_to change(Problem, :count)
+  end
+
+  it "creates a Problem for a non-manifold mesh" do # rubocop:todo RSpec/MultipleExpectations
+    allow(mesh).to receive(:manifold?).and_return(false)
+    allow(file).to receive(:mesh).and_return(mesh)
+    expect { described_class.perform_now(file.id) }.to change(Problem, :count).from(0).to(1)
+    expect(Problem.first.category).to eq "non_manifold"
+  end
+
+  it "removes a manifold problem if the mesh is OK" do
+    allow(file).to receive(:mesh).and_return(mesh)
+    create(:problem, problematic: file, category: :non_manifold)
+    expect { described_class.perform_now(file.id) }.to change(Problem, :count).from(1).to(0)
+  end
+
+  it "creates a Problem for an inside-out mesh" do # rubocop:todo RSpec/MultipleExpectations
+    allow(mesh).to receive(:solid?).and_return(false)
+    allow(file).to receive(:mesh).and_return(mesh)
+    expect { described_class.perform_now(file.id) }.to change(Problem, :count).from(0).to(1)
+    expect(Problem.first.category).to eq "inside_out"
+  end
+
+  it "removes an inside-out problem if the mesh is OK" do
+    allow(file).to receive(:mesh).and_return(mesh)
+    create(:problem, problematic: file, category: :inside_out)
+    expect { described_class.perform_now(file.id) }.to change(Problem, :count).from(1).to(0)
+  end
+end

--- a/spec/lib/mesh_analysis_spec.rb
+++ b/spec/lib/mesh_analysis_spec.rb
@@ -12,11 +12,4 @@ RSpec.describe "MeshAnalysis" do
     geometry.merge_vertices
     expect(geometry.manifold?).to be false
   end
-
-  it "detects buffergeometry meshes that are non-manifold" do
-    geometry = Mittsu::PlaneBufferGeometry.new(1.0, 1.0)
-    geometry.merge_vertices
-    expect(geometry.manifold?).to be false
-  end
-
 end

--- a/spec/lib/mesh_analysis_spec.rb
+++ b/spec/lib/mesh_analysis_spec.rb
@@ -3,11 +3,20 @@ require "rails_helper"
 RSpec.describe "MeshAnalysis" do
   it "verifies that meshes are manifold (i.e. do not have holes)" do
     geometry = Mittsu::SphereGeometry.new(2.0, 32, 16)
+    geometry.merge_vertices
     expect(geometry.manifold?).to be true
   end
 
   it "detects meshes that are non-manifold (i.e. do have holes)" do
-    geometry = Mittsu::PlaneBufferGeometry.new(1.0, 1.0)
+    geometry = Mittsu::PlaneGeometry.new(1.0, 1.0)
+    geometry.merge_vertices
     expect(geometry.manifold?).to be false
   end
+
+  it "detects buffergeometry meshes that are non-manifold" do
+    geometry = Mittsu::PlaneBufferGeometry.new(1.0, 1.0)
+    geometry.merge_vertices
+    expect(geometry.manifold?).to be false
+  end
+
 end

--- a/spec/lib/mesh_analysis_spec.rb
+++ b/spec/lib/mesh_analysis_spec.rb
@@ -1,7 +1,6 @@
 require "rails_helper"
 
 RSpec.describe "MeshAnalysis" do
-
   it "verifies that meshes are manifold (i.e. do not have holes)" do
     geometry = Mittsu::SphereGeometry.new(2.0, 32, 16)
     expect(geometry.manifold?).to be true
@@ -11,5 +10,4 @@ RSpec.describe "MeshAnalysis" do
     geometry = Mittsu::PlaneBufferGeometry.new(1.0, 1.0)
     expect(geometry.manifold?).to be false
   end
-
 end

--- a/spec/lib/mesh_analysis_spec.rb
+++ b/spec/lib/mesh_analysis_spec.rb
@@ -22,5 +22,15 @@ RSpec.describe "MeshAnalysis" do
     mesh.geometry.faces.pop
     expect(mesh.manifold?).to be false
   end
+
+  it "verifies that meshes are solid when normals are pointing outwards" do
+    expect(mesh.solid?).to be true
+  end
+
+  it "detects that meshes where the normals point inwards are not solid" do
+    # Flip all the faces on our test object and recalculate normals
+    mesh.geometry.faces.each { |f| f.flip! }
+    mesh.geometry.compute_face_normals
+    expect(mesh.solid?).to be false
   end
 end

--- a/spec/lib/mesh_analysis_spec.rb
+++ b/spec/lib/mesh_analysis_spec.rb
@@ -1,15 +1,26 @@
 require "rails_helper"
 
 RSpec.describe "MeshAnalysis" do
-  it "verifies that meshes are manifold (i.e. do not have holes)" do
-    geometry = Mittsu::SphereGeometry.new(2.0, 32, 16)
-    geometry.merge_vertices
-    expect(geometry.manifold?).to be true
+  let(:mesh) do
+    m = Mittsu::Mesh.new(Mittsu::SphereGeometry.new(2.0, 32, 16))
+    m.geometry.merge_vertices
+    m
   end
 
-  it "detects meshes that are non-manifold (i.e. do have holes)" do
-    geometry = Mittsu::PlaneGeometry.new(1.0, 1.0)
-    geometry.merge_vertices
-    expect(geometry.manifold?).to be false
+  it "verifies that good meshes are manifold" do
+    expect(mesh.manifold?).to be true
+  end
+
+  it "detects that meshes with flipped faces are non-manifold" do
+    # Flip a single face
+    mesh.geometry.faces.first.flip!
+    expect(mesh.manifold?).to be false
+  end
+
+  it "detects that meshes with holes are non-manifold" do
+    # Remove a face
+    mesh.geometry.faces.pop
+    expect(mesh.manifold?).to be false
+  end
   end
 end

--- a/spec/lib/mesh_analysis_spec.rb
+++ b/spec/lib/mesh_analysis_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "MeshAnalysis" do
+
+  it "verifies that meshes are manifold (i.e. do not have holes)" do
+    geometry = Mittsu::SphereGeometry.new(2.0, 32, 16)
+    expect(geometry.manifold?).to be true
+  end
+
+  it "detects meshes that are non-manifold (i.e. do have holes)" do
+    geometry = Mittsu::PlaneBufferGeometry.new(1.0, 1.0)
+    expect(geometry.manifold?).to be false
+  end
+
+end


### PR DESCRIPTION
Adds checking meshes for manifold connectivity. We do this by following the [3MF conditions](https://github.com/3MFConsortium/spec_core/blob/master/3MF%20Core%20Specification.md#41-meshes):

* [x] Each edge must be used by two faces; no more, no less.
* [x] Faces must be consistently oriented; we can detect this my making sure that a shared edge is in the opposite order on each face.
* [x] Faces must be oriented so that their normal points away from the interior of the object.

If these fail, a Problem will be raised.

Resolves #593 