### PR TITLE
Allow for modular setting of database connection string

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -4,6 +4,30 @@ if [ -f tmp/pids/server.pid ]; then
   rm tmp/pids/server.pid
 fi
 
+# List of required variables to be set for modular database string generation
+MODULAR_STRING_COMPONENTS=(
+	"DATABASE_HOST"
+#	"DATABASE_PORT"
+	"DATABASE_USER"
+	"DATABASE_PASSWORD"
+	"DATABASE_NAME"
+)
+
+# Check if the required vars are set, if they are, generate the URL string, else exit with error code 1
+echo "Executing database url substitution hack"
+env
+if [ -z ${DATABASE_URL} ]; then
+	echo "DATABASE_URL appears to be empty, proceeding with modular string generation"
+	for VAR in ${MODULAR_STRING_COMPONENTS}; do	
+		if [ -z "${VAR}" ]; then 
+			echo "${VAR} = ${!VAR}"
+			echo "${VAR} is unset" && exit 1
+		fi
+	done
+	echo "Required variables check passed"
+	DATABASE_URL="postgresql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}?pool=5"
+fi
+
 echo "Preparing database..."
 bundle exec rails db:prepare:with_data
 

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -8,14 +8,14 @@ services:
     volumes:
       - /path/to/your/libraries:/libraries
     environment:
-      DATABASE_URL: postgresql://manyfold:password@db/manyfold?pool=5
       SECRET_KEY_BASE: a_nice_long_random_string
       REDIS_URL: redis://redis:6379/1
+      DATABASE_URL: postgresql://manyfold:password@db/manyfold?pool=5
 #		or
-      DATABASE_HOST: db
-      DATABASE_USER: manyfold
-      DATABASE_PASSWORD: password
-      DATABASE_NAME: manyfold
+#      DATABASE_HOST: db
+#      DATABASE_USER: manyfold
+#      DATABASE_PASSWORD: password
+#      DATABASE_NAME: manyfold
 
       # For details of other optional environment variables, including features such
       # as multiuser mode, visit https://manyfold.app/sysadmin/configuration.html

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -11,6 +11,12 @@ services:
       DATABASE_URL: postgresql://manyfold:password@db/manyfold?pool=5
       SECRET_KEY_BASE: a_nice_long_random_string
       REDIS_URL: redis://redis:6379/1
+#		or
+      DATABASE_HOST: db
+      DATABASE_USER: manyfold
+      DATABASE_PASSWORD: password
+      DATABASE_NAME: manyfold
+
       # For details of other optional environment variables, including features such
       # as multiuser mode, visit https://manyfold.app/sysadmin/configuration.html
     depends_on:


### PR DESCRIPTION
This change introduces a mechanism to build the database connection url by individual components, HOST, USERNAME, PASSWORD and DATABASE. This will make it considerably nicer to run in Kubernetes.

## Linked issues

## Description of changes

Add a handful of loops in the docker-entrypoint to generate the databse string. Existing configurations should be completley unaffected.
