### PR TITLE
Temporarily disable inside-out check while we debug

### DIFF
--- a/app/jobs/analysis/geometric_analysis_job.rb
+++ b/app/jobs/analysis/geometric_analysis_job.rb
@@ -15,14 +15,15 @@ class Analysis::GeometricAnalysisJob < ApplicationJob
         :non_manifold,
         !manifold
       )
-      # If the mesh is manifold, we can check if it's inside out
-      if manifold
-        Problem.create_or_clear(
-          file,
-          :inside_out,
-          !mesh.solid?
-        )
-      end
+      # Temporarily disabled for release
+      # # If the mesh is manifold, we can check if it's inside out
+      # if manifold
+      #   Problem.create_or_clear(
+      #     file,
+      #     :inside_out,
+      #     !mesh.solid?
+      #   )
+      # end
     end
   end
 end

--- a/spec/jobs/analysis/geometric_analysis_job_spec.rb
+++ b/spec/jobs/analysis/geometric_analysis_job_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe Analysis::GeometricAnalysisJob do
   end
 
   it "creates a Problem for an inside-out mesh" do # rubocop:todo RSpec/MultipleExpectations
+    pending "not currently working reliably"
     allow(mesh).to receive(:solid?).and_return(false)
     allow(file).to receive(:mesh).and_return(mesh)
     expect { described_class.perform_now(file.id) }.to change(Problem, :count).from(0).to(1)
@@ -40,6 +41,7 @@ RSpec.describe Analysis::GeometricAnalysisJob do
   end
 
   it "removes an inside-out problem if the mesh is OK" do
+    pending "not currently working reliably"
     allow(file).to receive(:mesh).and_return(mesh)
     create(:problem, problematic: file, category: :inside_out)
     expect { described_class.perform_now(file.id) }.to change(Problem, :count).from(1).to(0)


### PR DESCRIPTION
Inside-out checks aren't reliable, and seem to fail in specific cases. So that we don't hold up release, we'll temporarily disable that test.