### PR TITLE
Convert STL and OBJ files to 3MF

### DIFF
--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -3,7 +3,7 @@ class ModelFilesController < ApplicationController
 
   before_action :get_library
   before_action :get_model
-  before_action :get_file, except: [:bulk_edit, :bulk_update]
+  before_action :get_file, except: [:create, :bulk_edit, :bulk_update]
 
   skip_after_action :verify_authorized, only: [:bulk_edit, :bulk_update]
   after_action :verify_policy_scoped, only: [:bulk_edit, :bulk_update]
@@ -21,6 +21,16 @@ class ModelFilesController < ApplicationController
           send_file_content
         end
       end
+    end
+  end
+
+  def create
+    if params[:convert]
+      file = ModelFile.find(params[:convert][:id].to_i)
+      Analysis::FileConversionJob.perform_later(file.id, params[:convert][:to].to_sym)
+      redirect_to [@library, @model, file], notice: t(".conversion_started")
+    else
+      head :unprocessable_entity
     end
   end
 

--- a/app/jobs/analysis/file_conversion_job.rb
+++ b/app/jobs/analysis/file_conversion_job.rb
@@ -1,0 +1,41 @@
+require "string/similarity"
+
+class Analysis::FileConversionJob < ApplicationJob
+  queue_as :analysis
+
+  def perform(file_id, output_format)
+    # Can we output this format?
+    return unless SupportedMimeTypes.can_export?(output_format)
+    # Get model
+    begin
+      file = ModelFile.find(file_id)
+    rescue ActiveRecord::RecordNotFound
+      return
+    end
+    exporter = nil
+    extension = nil
+    case output_format
+    when :threemf
+      return unless file.mesh.manifold?
+      extension = "3mf"
+      exporter = Mittsu::ThreeMFExporter.new
+    end
+    if exporter
+      new_file = ModelFile.new(
+        model: file.model,
+        filename: file.filename.gsub(".#{file.extension}", ".#{extension}")
+      )
+      dedup = 0
+      while File.exist?(new_file.pathname)
+        dedup += 1
+        new_file.filename = file.filename.gsub(".#{file.extension}", "-#{dedup}.#{extension}")
+      end
+      # Save the actual file in new format
+      exporter.export(file.mesh, new_file.pathname)
+      # Store record in database
+      new_file.save
+      # Queue up file scan
+      Analysis::AnalyseModelFileJob.perform_later(new_file.id)
+    end
+  end
+end

--- a/app/lib/supported_mime_types.rb
+++ b/app/lib/supported_mime_types.rb
@@ -15,6 +15,10 @@ module SupportedMimeTypes
     Mime::EXTENSION_LOOKUP.filter { |k, v| is_model_mime_type?(v) }.keys
   end
 
+  def self.can_export?(type)
+    [:threemf].include? type
+  end
+
   class << self
     private
 

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -43,8 +43,12 @@ class ModelFile < ApplicationRecord
     Mime::Type.lookup_by_extension(extension)
   end
 
+  def basename
+    File.basename(filename, ".*")
+  end
+
   def name
-    File.basename(filename, ".*").humanize.titleize
+    basename.humanize.titleize
   end
 
   def pathname

--- a/app/views/model_files/show.html.erb
+++ b/app/views/model_files/show.html.erb
@@ -63,6 +63,9 @@
 
     <%= card :secondary, t(".actions_heading") do %>
       <%= link_to safe_join([icon("cloud-download", t("general.download")), t("general.download")], " "), library_model_model_file_path(@library, @model, @file, @file.extension.to_sym), {class: "btn btn-secondary"} %>
+      <% if policy(:model_file).create? && ["stl", "obj"].include?(@file.extension) %>
+        <%= link_to safe_join([icon("arrow-left-right", t(".convert")), t(".convert")], " "), library_model_model_files_path(@library, @model, convert: {id: @file.id, to: "threemf"}), method: :post, class: "btn btn-warning" %>
+      <% end %>
     <% end %>
 
   </div>

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -98,7 +98,7 @@
         <li><a href="#<%= group.parameterize %>"><%= group %></a></li>
       <% end %>
     </ul>
-    <%= link_to t(".files_card.bulk_edit"), edit_library_model_model_files_path(@library, @model), class: "btn btn-secondary" if policy(@model).edit? %>
+    <%= link_to t(".files_card.bulk_edit"), bulk_edit_library_model_model_files_path(@library, @model), class: "btn btn-secondary" if policy(@model).edit? %>
     <%= link_to t(".rescan"), scan_library_model_path(@library, @model), class: "btn btn-warning", method: :post if policy(@model).scan? %>
   <% end %>
 

--- a/app/views/problems/model_file/_inefficient.html.erb
+++ b/app/views/problems/model_file/_inefficient.html.erb
@@ -1,4 +1,6 @@
 <td><%= icon("fire", t(".title")) %></td>
 <td><%= link_to problem.problematic.name, [problem.problematic.model.library, problem.problematic.model, problem.problematic] %></td>
 <td><%= t ".title" %>: <%= problem.note %></td>
-<td><%= link_to "Open", [problem.problematic.model.library, problem.problematic.model, problem.problematic], class: "btn btn-primary" %></td>
+<td>
+  <%= link_to t("model_files.show.convert"), library_model_model_files_path(problem.problematic.model.library, problem.problematic.model, convert: {id: problem.problematic.id, to: "threemf"}), method: :post, class: "btn btn-warning" %>
+</td>

--- a/config/locales/model_files/en.yml
+++ b/config/locales/model_files/en.yml
@@ -3,6 +3,8 @@ en:
   model_files:
     bulk_update:
       success: Files updated successfully.
+    create:
+      conversion_started: File conversion started. The converted file should be available shortly.
     destroy:
       confirm: Are you sure you want to remove this file from your filesystem?
       success: File deleted!

--- a/config/locales/model_files/en.yml
+++ b/config/locales/model_files/en.yml
@@ -14,6 +14,7 @@ en:
       actions_heading: Actions
       details_heading: Details
       notes_heading: Notes
+      convert: Convert to 3MF
     update:
       failure: An error occurred and file details could not be saved.
       success: File details saved.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,8 +29,8 @@ Rails.application.routes.draw do
       end
       resources :model_files, except: [:index, :new, :create] do
         collection do
-          get "edit", action: "bulk_edit"
-          patch "update", action: "bulk_update"
+          get "bulk_edit"
+          patch "bulk_update"
         end
       end
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -27,7 +27,7 @@ Rails.application.routes.draw do
         post "merge"
         post "scan"
       end
-      resources :model_files, except: [:index, :new, :create] do
+      resources :model_files, except: [:index, :new] do
         collection do
           get "bulk_edit"
           patch "bulk_update"

--- a/spec/jobs/analysis/file_conversion_job_spec.rb
+++ b/spec/jobs/analysis/file_conversion_job_spec.rb
@@ -1,0 +1,83 @@
+require "rails_helper"
+require "support/mock_directory"
+
+RSpec.describe Analysis::FileConversionJob do
+  around do |ex|
+    MockDirectory.create([
+      "model_one/files/awesome.stl"
+    ]) do |path|
+      @library_path = path
+      ex.run
+    end
+  end
+
+  let(:library) { create(:library, path: @library_path) } # rubocop:todo RSpec/InstanceVariable
+  let(:model) { create(:model, path: "model_one", library: library) }
+  let(:file) { create(:model_file, model: model, filename: "files/awesome.stl") }
+  let(:mesh) do
+    m = Mittsu::Mesh.new(Mittsu::SphereGeometry.new(2.0, 32, 16))
+    m.geometry.merge_vertices
+    m
+  end
+
+  before do
+    ActiveJob::Base.queue_adapter = :test
+    allow(file).to receive(:mesh).and_return(mesh)
+    allow(ModelFile).to receive(:find).with(file.id).and_return(file)
+  end
+
+  context "when converting to 3MF" do
+    it "creates a new file" do
+      expect { described_class.perform_now(file.id, :threemf) }.to change(ModelFile, :count).from(1).to(2)
+    end
+
+    it "creates a file with 3mf extension" do
+      described_class.perform_now(file.id, :threemf)
+      expect(ModelFile.where.not(id: file.id).first.extension).to eq "3mf"
+    end
+
+    it "creates a file with the same basename as the original" do
+      described_class.perform_now(file.id, :threemf)
+      expect(ModelFile.where.not(id: file.id).first.filename).to eq "files/awesome.3mf"
+    end
+
+    it "avoids filenames that already exist" do
+      allow(File).to receive(:exist?).with(file.pathname.gsub(".stl", ".3mf")).and_return(true).once
+      allow(File).to receive(:exist?).with(file.pathname.gsub(".stl", "-1.3mf")).and_return(true).once
+      allow(File).to receive(:exist?).with(file.pathname.gsub(".stl", "-2.3mf")).and_return(false).once
+      described_class.perform_now(file.id, :threemf)
+      expect(ModelFile.where.not(id: file.id).first.filename).to eq "files/awesome-2.3mf"
+    end
+
+    it "creates an actual 3MF file on disk" do
+      described_class.perform_now(file.id, :threemf)
+      pathname = ModelFile.where.not(id: file.id).first.pathname
+      expect(File.exist?(pathname)).to be true
+    end
+
+    it "does not remove the original file" do
+      described_class.perform_now(file.id, :threemf)
+      expect { ModelFile.find(file.id) }.not_to raise_error
+    end
+
+    it "should create a file equivalence with the original file"
+
+    it "does not convert non-manifold meshes" do
+      allow(mesh).to receive(:manifold?).and_return(false)
+      expect { described_class.perform_now(file.id, :threemf) }.not_to change(ModelFile, :count)
+    end
+
+    it "queues up analysis job for new file" do
+      expect { described_class.perform_now(file.id, :threemf) }.to have_enqueued_job(Analysis::AnalyseModelFileJob)
+    end
+  end
+
+  it "does nothing with an invalid file ID" do
+    allow(ModelFile).to receive(:find).with(nil).and_raise(ActiveRecord::RecordNotFound)
+    expect { described_class.perform_now(nil, :threemf) }.not_to raise_error
+  end
+
+  it "does nothing with an invalid output format" do
+    expect { described_class.perform_now(file.id, :ply) }.not_to raise_error
+  end
+end

--- a/spec/requests/model_files_spec.rb
+++ b/spec/requests/model_files_spec.rb
@@ -3,6 +3,7 @@ require "support/mock_directory"
 
 # edit_library_model_model_files GET    /libraries/:library_id/models/:model_id/model_files/edit(.:format)      model_files#bulk_edit
 #      library_model_model_files PATCH  /libraries/:library_id/models/:model_id/model_files/update(.:format)    model_files#bulk_update
+#                                POST   /libraries/:library_id/models/:model_id/model_files(.:format)           model_files#create
 #  edit_library_model_model_file GET    /libraries/:library_id/models/:model_id/model_files/:id/edit(.:format)  model_files#edit
 #       library_model_model_file GET    /libraries/:library_id/models/:model_id/model_files/:id(.:format)       model_files#show
 #                                PATCH  /libraries/:library_id/models/:model_id/model_files/:id(.:format)       model_files#update
@@ -78,6 +79,32 @@ RSpec.describe "Model Files" do
         it "has correct MIME type" do
           expect(response.media_type).to eq("image/jpeg")
         end
+      end
+    end
+
+    describe "POST /libraries/:library_id/models/:model_id/model_files", :as_editor do
+      context "when requesting a conversion" do
+        let(:params) { {convert: {id: stl_file.id, to: "threemf"}} }
+
+        it "queues a conversion job" do
+          expect { post library_model_model_files_path(library, model, params: params) }.to have_enqueued_job(Analysis::FileConversionJob).with(stl_file.id, :threemf)
+        end
+
+        it "redirects back to file list" do
+          post library_model_model_files_path(library, model, params: params)
+          expect(response).to redirect_to library_model_model_file_path(library, model, stl_file)
+        end
+
+        it "shows success message if conversion job was queued" do
+          post library_model_model_files_path(library, model, params: params)
+          follow_redirect!
+          expect(response.body).to include "alert-info"
+        end
+      end
+
+      it "shows an error with missing parameters" do
+        post library_model_model_files_path(library, model, params: {})
+        expect(response).to have_http_status(:unprocessable_entity)
       end
     end
 

--- a/spec/requests/model_files_spec.rb
+++ b/spec/requests/model_files_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe "Model Files" do
 
     describe "GET /libraries/:library_id/models/:model_id/model_files/edit", :as_editor do
       it "shows bulk update form" do
-        get edit_library_model_model_files_path(library, model, stl_file)
+        get bulk_edit_library_model_model_files_path(library, model, stl_file)
         expect(response).to have_http_status(:success)
       end
     end


### PR DESCRIPTION
STL and OBJ are pretty inefficient - 3MF is better. This PR adds a "convert" button which will create a 3MF version of an STL or OBJ file, and also wires it into the Problem line. Future extension for this would be to allow the user to choose output format, but we only have 3MF export coded at the moment, and I'm OK with Manyfold being opinionated about what the "best" format is. At least for now.

Resolves #457.