### PR TITLE
Remove job clearing in Docker start - not needed any more

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -25,8 +25,5 @@ fi
 echo "Preparing database..."
 bundle exec rails db:prepare:with_data
 
-echo "Clearing up old jobs..."
-bundle exec rake jobs:clear
-
 echo "Launching application..."
 exec "$@"


### PR DESCRIPTION
no need any more with fail-safe jobs