### PR TITLE
Explicitly setting for interface language

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -131,3 +131,5 @@ gem "sidekiq-failures", "~> 1.0"
 gem "activejob-status", "~> 1.0"
 
 gem "brakeman", "~> 6.1"
+
+gem "i18n_data", "~> 0.17.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -225,6 +225,8 @@ GEM
       rails-i18n
       rainbow (>= 2.2.2, < 4.0)
       terminal-table (>= 1.5.1)
+    i18n_data (0.17.1)
+      simple_po_parser (~> 1.1)
     inherited_resources (1.14.0)
       actionpack (>= 6.0)
       has_scope (>= 0.6)
@@ -471,6 +473,7 @@ GEM
       redis-client (>= 0.19.0)
     sidekiq-failures (1.0.4)
       sidekiq (>= 4.0.0)
+    simple_po_parser (1.1.6)
     simplecov (0.22.0)
       docile (~> 1.1)
       simplecov-html (~> 0.11)
@@ -578,6 +581,7 @@ DEPENDENCIES
   guard-rspec (~> 4.7)
   i18n-js (~> 4.2)
   i18n-tasks (~> 1.0)
+  i18n_data (~> 0.17.1)
   jbuilder (~> 2.11)
   jsbundling-rails
   kaminari (~> 1.2)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,7 @@ class ApplicationController < ActionController::Base
   after_action :verify_policy_scoped, only: :index, unless: :active_admin_controller?
 
   before_action :authenticate_user!
+  around_action :switch_locale
   before_action :check_for_first_use
   before_action :check_scan_status
   before_action :remember_ordering
@@ -33,4 +34,12 @@ class ApplicationController < ActionController::Base
   def active_admin_controller?
     is_a?(ActiveAdmin::BaseController)
   end
+
+  private
+
+  def switch_locale(&action)
+    locale = current_user&.interface_language || request.env['rack.locale']
+    I18n.with_locale(locale, &action)
+  end
+
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,8 +38,7 @@ class ApplicationController < ActionController::Base
   private
 
   def switch_locale(&action)
-    locale = current_user&.interface_language || request.env['rack.locale']
+    locale = current_user&.interface_language || request.env["rack.locale"]
     I18n.with_locale(locale, &action)
   end
-
 end

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,4 +1,4 @@
-require 'i18n_data'
+require "i18n_data"
 
 class SettingsController < ApplicationController
   before_action :get_user
@@ -6,8 +6,8 @@ class SettingsController < ApplicationController
 
   def show
     @languages = [[t("settings.general_settings.interface_language.autodetect"), nil]].concat(
-        I18n.available_locales.map { |locale| [I18nData.languages(locale)[locale.upcase.to_s]&.capitalize, locale] }
-      )
+      I18n.available_locales.map { |locale| [I18nData.languages(locale)[locale.upcase.to_s]&.capitalize, locale] }
+    )
   end
 
   def update

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,12 +1,18 @@
+require 'i18n_data'
+
 class SettingsController < ApplicationController
   before_action :get_user
   before_action :check_owner_permission
 
   def show
+    @languages = [[t("settings.general_settings.interface_language.autodetect"), nil]].concat(
+        I18n.available_locales.map { |locale| [I18nData.languages(locale)[locale.upcase.to_s]&.capitalize, locale] }
+      )
   end
 
   def update
     # Save personal settings
+    update_general_settings(params[:general])
     update_pagination_settings(params[:pagination])
     update_renderer_settings(params[:renderer])
     update_tag_cloud_settings(params[:tag_cloud])
@@ -23,6 +29,11 @@ class SettingsController < ApplicationController
   end
 
   private
+
+  def update_general_settings(settings)
+    return unless settings
+    @user.interface_language = settings[:interface_language].presence
+  end
 
   def update_pagination_settings(settings)
     return unless settings

--- a/app/views/settings/_general_settings.html.erb
+++ b/app/views/settings/_general_settings.html.erb
@@ -1,0 +1,17 @@
+<div class="card mb-2">
+  <h3 class="card-header"><%= t(".heading") %></h3>
+  <div class="card-body">
+
+    <div class="row">
+      <%= form.label t(".interface_language.label"), for: "general[interface_language]", class: "col col-form-label" %>
+      <div class="col">
+        <%= form.select "general[interface_language]",
+              @languages,
+              {selected: @user.interface_language},
+              {class: "form-select"} %>
+        <small class="form-text"><%= t ".interface_language.help" %></small>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -3,6 +3,7 @@
 <%= form_with url: user_settings_path(user: @user), method: :patch do |form| %>
   <div class="row mb-4">
     <div class="col">
+      <%= render "general_settings", form: form %>
       <%= render "pagination_settings", form: form %>
       <%= render "tag_cloud_settings", form: form %>
       <%= render "file_list_settings", form: form %>

--- a/config/locales/settings/de.yml
+++ b/config/locales/settings/de.yml
@@ -30,6 +30,12 @@ de:
         model_id: Ein eindeutiger numerischer Bezeichner für das Modell. Wir empfehlen dringend, diese Kennung immer am Ende der Vorlage anzugeben, um Namenskonflikte auf der Festplatte zu vermeiden.
         model_name: Eine dateisystemsichere Version des Modellnamens.
         tags_html:
+    general_settings:
+      heading:
+      interface_language:
+        autodetect:
+        help:
+        label:
     library_settings:
       caption:
         help: Bewegen Sie den Mauszeiger über die Bibliothek in der Kopfzeile, um die Bildunterschrift zu sehen.

--- a/config/locales/settings/en.yml
+++ b/config/locales/settings/en.yml
@@ -33,9 +33,9 @@ en:
     general_settings:
       heading: General
       interface_language:
-        help: "Note: some untranslated text may still show in English."
-        label: Interface language
         autodetect: Use browser settings
+        help: 'Note: some untranslated text may still show in English.'
+        label: Interface language
     library_settings:
       caption:
         help: Hover over library in header to see caption.

--- a/config/locales/settings/en.yml
+++ b/config/locales/settings/en.yml
@@ -30,6 +30,12 @@ en:
         model_id: A unique numerical identifier for the model. We strongly recommend always including this at the end of your template to avoid name conflicts on disk.
         model_name: A filesystem-safe version of the model name.
         tags_html: 'a series of nested folders, one for each tag, arranged in order of tag popularity. For example: <code>fantasy/human/wizard</code>'
+    general_settings:
+      heading: General
+      interface_language:
+        help: "Note: some untranslated text may still show in English."
+        label: Interface language
+        autodetect: Use browser settings
     library_settings:
       caption:
         help: Hover over library in header to see caption.

--- a/config/locales/settings/fr.yml
+++ b/config/locales/settings/fr.yml
@@ -30,6 +30,12 @@ fr:
         model_id: Un identifiant numérique unique pour le modèle. Nous vous recommandons fortement de toujours l'inclure à la fin de votre modèle afin d'éviter les conflits de noms sur le disque.
         model_name: Une version sécurisée du nom du modèle pour le système de fichiers.
         tags_html: 'une série de dossiers imbriqués, un pour chaque étiquette, classés par ordre de popularité de l''étiquette. Par exemple : <code>fantasy/humain/sorcier</code>'
+    general_settings:
+      heading:
+      interface_language:
+        autodetect:
+        help:
+        label:
     library_settings:
       caption:
         help: Survolez la bibliothèque dans l'en-tête pour voir la légende.

--- a/config/locales/settings/pl.yml
+++ b/config/locales/settings/pl.yml
@@ -30,6 +30,12 @@ pl:
         model_id: Unikalny numeryczny identyfikator modelu. Zdecydowanie polecamy podawanie go zawsze na końcu szablonu, aby uniknąć konfliktów nazw na dysku.
         model_name: Bezpieczna dla systemu plików wersja nazwy modelu.
         tags_html: 'seria zagnieżdżonych folderów, po jednym dla każdego z tagów, ułożonych w kolejności popularności tagów. Na przykład: <code>fantasy/człowiek/czarodziej</code>'
+    general_settings:
+      heading:
+      interface_language:
+        autodetect:
+        help:
+        label:
     library_settings:
       caption:
         help: Najedź kursorem na bibliotekę w nagłówku, aby zobaczyć napis.

--- a/db/migrate/20240423102250_add_interface_language_to_users.rb
+++ b/db/migrate/20240423102250_add_interface_language_to_users.rb
@@ -1,0 +1,5 @@
+class AddInterfaceLanguageToUsers < ActiveRecord::Migration[7.0]
+  def change
+    add_column :users, :interface_language, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_04_18_112821) do
+ActiveRecord::Schema[7.0].define(version: 2024_04_23_102250) do
   create_table "collections", force: :cascade do |t|
     t.string "name"
     t.text "notes"
@@ -204,6 +204,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_04_18_112821) do
     t.string "reset_password_token"
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
+    t.string "interface_language"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true


### PR DESCRIPTION
Resolves #1941. The default is still to use the browser preference, but the user can override that on the settings page if they like.