### PR TITLE
Fix right-click behaviour

### DIFF
--- a/app/assets/stylesheets/application.bootstrap.scss
+++ b/app/assets/stylesheets/application.bootstrap.scss
@@ -29,4 +29,5 @@ p.alert:empty, p.notice:empty {
   height: 100vh;
   display: block;
   z-index: -1;
+  pointer-events: none;
 }


### PR DESCRIPTION
WebGL canvas ignores normal pointer events, but 3d controls still get captured. Resolves #1578

I did NOT expect it to be that easy.