### PR TITLE
Add plural forms for models in english

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -94,14 +94,30 @@ en:
               already_presupported: cannot be set on a presupported file
               not_supported: is not a presupported file
     models:
-      acts_as_taggable_on/tag: Tag
-      collection: Collection
-      creator: Creator
-      library: Library
-      link: Link
-      model: Model
-      model_file: File
-      problem: Problem
+      acts_as_taggable_on/tag:
+        one: Tag
+        other: Tags
+      collection:
+        one: Collection
+        other: Collections
+      creator:
+        one: Creator
+        other: Creators
+      library:
+        one: Library
+        other: Libraries
+      link:
+        one: Link
+        other: Links
+      model:
+        one: Model
+        other: Models
+      model_file:
+        one: File
+        other: Files
+      problem:
+        one: Problem
+        other: Problems
       user:
         one: User
         other: Users


### PR DESCRIPTION
Apparently we can't leave them out even though they work by default
