### PR TITLE
Fix tab ordering by moving sidebar later in DOM

### DIFF
--- a/app/views/layouts/card_list_page.html.erb
+++ b/app/views/layouts/card_list_page.html.erb
@@ -1,11 +1,11 @@
 <%= yield :page_header %>
 
 <div class="row row-cols-md-2">
-  <div class="col-md-3 row-cols-md-1" id="sidebar">
-    <%= yield :sidebar %>
-  </div>
-  <div class="col-md-9 order-md-first" id="item_list">
+  <div class="col-md-9" id="item_list">
     <%= yield :items %>
+  </div>
+  <div class="col-md-3" id="sidebar">
+    <%= yield :sidebar %>
   </div>
 </div>
 


### PR DESCRIPTION
Ideally it would be first for the mobile pop-to-top thing, but there's no way around it really. Accessible pages need visual order to follow the DOM, so we can't really have the sidebar up top on small screens.

Resolves #2097