### PR TITLE
Set 'lang' attribute on untranslated strings

### DIFF
--- a/app/components/model_component.html.erb
+++ b/app/components/model_component.html.erb
@@ -22,9 +22,9 @@
             <span style="float: right"><%= helpers.status_badges(@model) %></span>
           </div>
           <div class='mt-2'>
-            <%= link_to t(".open_button.text"), [@model.library, @model], {class: "btn btn-primary btn-sm", "aria-label": t(".open_button.label", name: @model.name)} if @can_show %>
-            <%= link_to helpers.icon("pencil-fill", t(".edit_button.text")), edit_library_model_path(@model.library, @model), {class: "btn btn-outline-secondary btn-sm", "aria-label": t(".edit_button.label", name: @model.name)} if @can_edit %>
-            <%= link_to helpers.icon("trash", t(".delete_button.text")), library_model_path(@model.library, @model), {method: :delete, class: "btn btn-outline-danger btn-sm", "aria-label": t(".delete_button.label", name: @model.name), data: {confirm: t("models.destroy.confirm")}} if @can_destroy %>
+            <%= link_to t(".open_button.text"), [@model.library, @model], {class: "btn btn-primary btn-sm", "aria-label": t_nowrap(".open_button.label", name: @model.name)} if @can_show %>
+            <%= link_to helpers.icon("pencil-fill", t(".edit_button.text")), edit_library_model_path(@model.library, @model), {class: "btn btn-outline-secondary btn-sm", "aria-label": t_nowrap(".edit_button.label", name: @model.name)} if @can_edit %>
+            <%= link_to helpers.icon("trash", t(".delete_button.text")), library_model_path(@model.library, @model), {method: :delete, class: "btn btn-outline-danger btn-sm", "aria-label": t_nowrap(".delete_button.label", name: @model.name), data: {confirm: t_nowrap("models.destroy.confirm")}} if @can_destroy %>
           </div>
         </div>
         <div class="col-auto">

--- a/app/components/model_component.html.erb
+++ b/app/components/model_component.html.erb
@@ -22,9 +22,9 @@
             <span style="float: right"><%= helpers.status_badges(@model) %></span>
           </div>
           <div class='mt-2'>
-            <%= link_to t(".open_button.text"), [@model.library, @model], {class: "btn btn-primary btn-sm", "aria-label": t_nowrap(".open_button.label", name: @model.name)} if @can_show %>
-            <%= link_to helpers.icon("pencil-fill", t(".edit_button.text")), edit_library_model_path(@model.library, @model), {class: "btn btn-outline-secondary btn-sm", "aria-label": t_nowrap(".edit_button.label", name: @model.name)} if @can_edit %>
-            <%= link_to helpers.icon("trash", t(".delete_button.text")), library_model_path(@model.library, @model), {method: :delete, class: "btn btn-outline-danger btn-sm", "aria-label": t_nowrap(".delete_button.label", name: @model.name), data: {confirm: t_nowrap("models.destroy.confirm")}} if @can_destroy %>
+            <%= link_to t(".open_button.text"), [@model.library, @model], {class: "btn btn-primary btn-sm", "aria-label": translate(".open_button.label", name: @model.name)} if @can_show %>
+            <%= link_to helpers.icon("pencil-fill", t(".edit_button.text")), edit_library_model_path(@model.library, @model), {class: "btn btn-outline-secondary btn-sm", "aria-label": translate(".edit_button.label", name: @model.name)} if @can_edit %>
+            <%= link_to helpers.icon("trash", t(".delete_button.text")), library_model_path(@model.library, @model), {method: :delete, class: "btn btn-outline-danger btn-sm", "aria-label": translate(".delete_button.label", name: @model.name), data: {confirm: translate("models.destroy.confirm")}} if @can_destroy %>
           </div>
         </div>
         <div class="col-auto">

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -34,7 +34,7 @@ class ProblemsController < ApplicationController
     notice = t(
       (@problem.ignored ? ".ignored" : ".unignored"),
       name: @problem.problematic.name,
-      message: t("problems.%{type}_%{category}.title" % {type: @problem.problematic_type.underscore, category: @problem.category})
+      message: t_nowrap("problems.%{type}_%{category}.title" % {type: @problem.problematic_type.underscore, category: @problem.category})
     )
     redirect_back_or_to problems_path, notice: notice
   end

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -34,7 +34,7 @@ class ProblemsController < ApplicationController
     notice = t(
       (@problem.ignored ? ".ignored" : ".unignored"),
       name: @problem.problematic.name,
-      message: t_nowrap("problems.%{type}_%{category}.title" % {type: @problem.problematic_type.underscore, category: @problem.category})
+      message: translate("problems.%{type}_%{category}.title" % {type: @problem.problematic_type.underscore, category: @problem.category})
     )
     redirect_back_or_to problems_path, notice: notice
   end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -134,6 +134,5 @@ module ApplicationHelper
       str&.locale ? content_tag(:span, lang: str.locale) { sanitize str } : str
     end
   end
-  alias :t :translate_with_locale_wrapper
-
+  alias_method :t, :translate_with_locale_wrapper
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -128,4 +128,12 @@ module ApplicationHelper
       link_to text, "##{target}", class: "text-reset"
     end
   end
+
+  def translate_with_locale_wrapper(key, **options)
+    translate(key, **options) do |str, _key|
+      str.locale ? content_tag(:span, lang: str.locale) { sanitize str } : str
+    end
+  end
+  alias :t :translate_with_locale_wrapper
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -135,5 +135,6 @@ module ApplicationHelper
     end
   end
   alias :t :translate_with_locale_wrapper
+  alias :t_nowrap :translate
 
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -131,7 +131,7 @@ module ApplicationHelper
 
   def translate_with_locale_wrapper(key, **options)
     translate(key, **options) do |str, _key|
-      str.locale ? content_tag(:span, lang: str.locale) { sanitize str } : str
+      str&.locale ? content_tag(:span, lang: str.locale) { sanitize str } : str
     end
   end
   alias :t :translate_with_locale_wrapper

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -135,6 +135,5 @@ module ApplicationHelper
     end
   end
   alias :t :translate_with_locale_wrapper
-  alias :t_nowrap :translate
 
 end

--- a/app/lib/locale_awareness.rb
+++ b/app/lib/locale_awareness.rb
@@ -1,0 +1,8 @@
+module LocaleAwareness
+  def locale=(l)
+    @locale = l
+  end
+  def locale
+    @locale
+  end
+end

--- a/app/lib/locale_awareness.rb
+++ b/app/lib/locale_awareness.rb
@@ -2,6 +2,7 @@ module LocaleAwareness
   def locale=(l)
     @locale = l
   end
+
   def locale
     @locale
   end

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-lg-3 me-auto">
       <span class="d-inline-flex align-items-center mb-2">
-        <%= image_tag "logo.png", width: 48, height: 48, class: "me-2", alt: t(".logo") %>
+        <%= image_tag "logo.png", width: 48, height: 48, class: "me-2", alt: t_nowrap(".logo") %>
         <span class="fs-5"><%= t "application.title" %></span>
       </span>
       <ul class="list-unstyled small text-muted">

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -2,7 +2,7 @@
   <div class="row">
     <div class="col-lg-3 me-auto">
       <span class="d-inline-flex align-items-center mb-2">
-        <%= image_tag "logo.png", width: 48, height: 48, class: "me-2", alt: t_nowrap(".logo") %>
+        <%= image_tag "logo.png", width: 48, height: 48, class: "me-2", alt: translate(".logo") %>
         <span class="fs-5"><%= t "application.title" %></span>
       </span>
       <ul class="list-unstyled small text-muted">

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -1,10 +1,10 @@
 <nav class="navbar navbar-expand-lg bg-body-tertiary">
   <div class='container-fluid'>
-    <a class="navbar-brand ms-2" href="<%= root_path %>" aria-label="<%= t ".home" %>">
+    <a class="navbar-brand ms-2" href="<%= root_path %>" aria-label="<%= translate ".home" %>">
       <%= image_tag "logo.png", alt: translate("application.title"), height: "40px", class: "me-2" %>
       <span class="d-lg-none"><%= t "application.title" %></span>
     </a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="<%= t ".navbar.toggler.label" %>">
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="<%= translate ".navbar.toggler.label" %>">
       <span class="navbar-toggler-icon"></span>
     </button>
     <div class="collapse navbar-collapse row" id="navbar">

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-lg bg-body-tertiary">
   <div class='container-fluid'>
     <a class="navbar-brand ms-2" href="<%= root_path %>" aria-label="<%= t ".home" %>">
-      <%= image_tag "logo.png", alt: t("application.title"), height: "40px", class: "me-2" %>
+      <%= image_tag "logo.png", alt: t_nowrap("application.title"), height: "40px", class: "me-2" %>
       <span class="d-lg-none"><%= t "application.title" %></span>
     </a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="<%= t ".navbar.toggler.label" %>">
@@ -61,7 +61,7 @@
               <%= nav_link problem_icon(severity),
                     Problem.model_name.human(count: 100),
                     problems_path,
-                    title: t("problems.severities.#{severity}"), # rubocop:todo I18n/RailsI18n/DecorateStringFormattingUsingInterpolation
+                    title: t_nowrap("problems.severities.#{severity}"), # rubocop:todo I18n/RailsI18n/DecorateStringFormattingUsingInterpolation
                     icon_style: "link-#{severity}",
                     text_style: "d-lg-none",
                     aria_label: Problem.model_name.human(count: 100) %>
@@ -78,7 +78,7 @@
         <% end %>
         <li class="nav-item">
           <%= form_with url: models_path, method: :get, role: "search" do |f| %>
-            <%= f.search_field :q, class: "form-control ms-1 me-3", placeholder: t(".search"), aria_label: t(".search"), aria_describedby: "button-search", value: params[:q] %>
+            <%= f.search_field :q, class: "form-control ms-1 me-3", placeholder: t_nowrap(".search"), aria_label: t_nowrap(".search"), aria_describedby: "button-search", value: params[:q] %>
           <% end %>
         </li>
         <%- if Flipper.enabled? :multiuser %>
@@ -89,9 +89,9 @@
           <% end %>
           <li class="nav-item">
             <%- if current_user %>
-              <%= nav_link "box-arrow-right", t(".log_out"), destroy_user_session_path, method: :delete, title: t(".log_out"), text_style: "d-lg-none" %>
+              <%= nav_link "box-arrow-right", t(".log_out"), destroy_user_session_path, method: :delete, title: t_nowrap(".log_out"), text_style: "d-lg-none" %>
             <% else %>
-              <%= nav_link "box-arrow-in-right", "", new_user_session_path, title: t(".log_in") %>
+              <%= nav_link "box-arrow-in-right", "", new_user_session_path, title: t_nowrap(".log_in") %>
             <% end %>
           </li>
         <%- end %>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -1,7 +1,7 @@
 <nav class="navbar navbar-expand-lg bg-body-tertiary">
   <div class='container-fluid'>
     <a class="navbar-brand ms-2" href="<%= root_path %>" aria-label="<%= t ".home" %>">
-      <%= image_tag "logo.png", alt: t_nowrap("application.title"), height: "40px", class: "me-2" %>
+      <%= image_tag "logo.png", alt: translate("application.title"), height: "40px", class: "me-2" %>
       <span class="d-lg-none"><%= t "application.title" %></span>
     </a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="<%= t ".navbar.toggler.label" %>">
@@ -61,7 +61,7 @@
               <%= nav_link problem_icon(severity),
                     Problem.model_name.human(count: 100),
                     problems_path,
-                    title: t_nowrap("problems.severities.#{severity}"), # rubocop:todo I18n/RailsI18n/DecorateStringFormattingUsingInterpolation
+                    title: translate("problems.severities.#{severity}"), # rubocop:todo I18n/RailsI18n/DecorateStringFormattingUsingInterpolation
                     icon_style: "link-#{severity}",
                     text_style: "d-lg-none",
                     aria_label: Problem.model_name.human(count: 100) %>
@@ -78,7 +78,7 @@
         <% end %>
         <li class="nav-item">
           <%= form_with url: models_path, method: :get, role: "search" do |f| %>
-            <%= f.search_field :q, class: "form-control ms-1 me-3", placeholder: t_nowrap(".search"), aria_label: t_nowrap(".search"), aria_describedby: "button-search", value: params[:q] %>
+            <%= f.search_field :q, class: "form-control ms-1 me-3", placeholder: translate(".search"), aria_label: translate(".search"), aria_describedby: "button-search", value: params[:q] %>
           <% end %>
         </li>
         <%- if Flipper.enabled? :multiuser %>
@@ -89,9 +89,9 @@
           <% end %>
           <li class="nav-item">
             <%- if current_user %>
-              <%= nav_link "box-arrow-right", t(".log_out"), destroy_user_session_path, method: :delete, title: t_nowrap(".log_out"), text_style: "d-lg-none" %>
+              <%= nav_link "box-arrow-right", t(".log_out"), destroy_user_session_path, method: :delete, title: translate(".log_out"), text_style: "d-lg-none" %>
             <% else %>
-              <%= nav_link "box-arrow-in-right", "", new_user_session_path, title: t_nowrap(".log_in") %>
+              <%= nav_link "box-arrow-in-right", "", new_user_session_path, title: translate(".log_in") %>
             <% end %>
           </li>
         <%- end %>

--- a/app/views/collections/_collection.html.erb
+++ b/app/views/collections/_collection.html.erb
@@ -34,9 +34,9 @@
         </ul>
       </div>
       <div>
-        <%= link_to "#{collection.models.count} #{Model.model_name.human count: collection.models.count}", {controller: "models", collection: collection.id}, class: "btn btn-primary", "aria-label": t_nowrap(".models_button.label", name: collection.name) if policy(collection).show? %>
-        <%= link_to "#{collection.collections.count} #{Collection.model_name.human count: collection.collections.count}", (@filters || {}).merge(controller: "collections", collection: collection.id), class: "btn btn-primary", "aria-label": t_nowrap(".collections_button.label", name: collection.name) if collection.collections.count > 0 && policy(collection).show? %>
-        <%= link_to icon("pencil-fill", t(".edit_button.text")), edit_collection_path(collection), {class: "btn btn-outline-secondary", "aria-label": t_nowrap(".edit_button.label", name: collection.name)} if policy(collection).edit? %>
+        <%= link_to "#{collection.models.count} #{Model.model_name.human count: collection.models.count}", {controller: "models", collection: collection.id}, class: "btn btn-primary", "aria-label": translate(".models_button.label", name: collection.name) if policy(collection).show? %>
+        <%= link_to "#{collection.collections.count} #{Collection.model_name.human count: collection.collections.count}", (@filters || {}).merge(controller: "collections", collection: collection.id), class: "btn btn-primary", "aria-label": translate(".collections_button.label", name: collection.name) if collection.collections.count > 0 && policy(collection).show? %>
+        <%= link_to icon("pencil-fill", t(".edit_button.text")), edit_collection_path(collection), {class: "btn btn-outline-secondary", "aria-label": translate(".edit_button.label", name: collection.name)} if policy(collection).edit? %>
       </div>
     </div>
   </div>

--- a/app/views/collections/_collection.html.erb
+++ b/app/views/collections/_collection.html.erb
@@ -34,9 +34,9 @@
         </ul>
       </div>
       <div>
-        <%= link_to "#{collection.models.count} #{Model.model_name.human count: collection.models.count}", {controller: "models", collection: collection.id}, class: "btn btn-primary", "aria-label": t(".models_button.label", name: collection.name) if policy(collection).show? %>
-        <%= link_to "#{collection.collections.count} #{Collection.model_name.human count: collection.collections.count}", (@filters || {}).merge(controller: "collections", collection: collection.id), class: "btn btn-primary", "aria-label": t(".collections_button.label", name: collection.name) if collection.collections.count > 0 && policy(collection).show? %>
-        <%= link_to icon("pencil-fill", t(".edit_button.text")), edit_collection_path(collection), {class: "btn btn-outline-secondary", "aria-label": t(".edit_button.label", name: collection.name)} if policy(collection).edit? %>
+        <%= link_to "#{collection.models.count} #{Model.model_name.human count: collection.models.count}", {controller: "models", collection: collection.id}, class: "btn btn-primary", "aria-label": t_nowrap(".models_button.label", name: collection.name) if policy(collection).show? %>
+        <%= link_to "#{collection.collections.count} #{Collection.model_name.human count: collection.collections.count}", (@filters || {}).merge(controller: "collections", collection: collection.id), class: "btn btn-primary", "aria-label": t_nowrap(".collections_button.label", name: collection.name) if collection.collections.count > 0 && policy(collection).show? %>
+        <%= link_to icon("pencil-fill", t(".edit_button.text")), edit_collection_path(collection), {class: "btn btn-outline-secondary", "aria-label": t_nowrap(".edit_button.label", name: collection.name)} if policy(collection).edit? %>
       </div>
     </div>
   </div>

--- a/app/views/creators/_creator.html.erb
+++ b/app/views/creators/_creator.html.erb
@@ -13,8 +13,8 @@
           <li><%= link_to t("sites.%{site}" % {site: link.site}), link.url %></li>
         <% end %>
       </ul>
-      <%= link_to "#{creator.models.count} #{Model.model_name.human count: creator.models.count}", models_path(creator: creator.id), {class: "btn btn-primary", "aria-label": t(".models_button.label", name: creator.name)} if policy(creator).show? %>
-      <%= link_to icon("pencil-fill", t(".edit_button.text")), edit_creator_path(creator), {class: "btn btn-outline-secondary", "aria-label": t(".edit_button.label", name: creator.name)} if policy(creator).edit? %>
+      <%= link_to "#{creator.models.count} #{Model.model_name.human count: creator.models.count}", models_path(creator: creator.id), {class: "btn btn-primary", "aria-label": t_nowrap(".models_button.label", name: creator.name)} if policy(creator).show? %>
+      <%= link_to icon("pencil-fill", t(".edit_button.text")), edit_creator_path(creator), {class: "btn btn-outline-secondary", "aria-label": t_nowrap(".edit_button.label", name: creator.name)} if policy(creator).edit? %>
     </div>
   </div>
 </div>

--- a/app/views/creators/_creator.html.erb
+++ b/app/views/creators/_creator.html.erb
@@ -13,8 +13,8 @@
           <li><%= link_to t("sites.%{site}" % {site: link.site}), link.url %></li>
         <% end %>
       </ul>
-      <%= link_to "#{creator.models.count} #{Model.model_name.human count: creator.models.count}", models_path(creator: creator.id), {class: "btn btn-primary", "aria-label": t_nowrap(".models_button.label", name: creator.name)} if policy(creator).show? %>
-      <%= link_to icon("pencil-fill", t(".edit_button.text")), edit_creator_path(creator), {class: "btn btn-outline-secondary", "aria-label": t_nowrap(".edit_button.label", name: creator.name)} if policy(creator).edit? %>
+      <%= link_to "#{creator.models.count} #{Model.model_name.human count: creator.models.count}", models_path(creator: creator.id), {class: "btn btn-primary", "aria-label": translate(".models_button.label", name: creator.name)} if policy(creator).show? %>
+      <%= link_to icon("pencil-fill", t(".edit_button.text")), edit_creator_path(creator), {class: "btn btn-outline-secondary", "aria-label": translate(".edit_button.label", name: creator.name)} if policy(creator).edit? %>
     </div>
   </div>
 </div>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -29,7 +29,7 @@
           <p class="card-text">
             <%= link_to t(".cancel_my_account"),
                   registration_path(resource_name),
-                  data: {confirm: t_nowrap(".confirm_deletion"), turbo_confirm: t_nowrap(".confirm_deletion")},
+                  data: {confirm: translate(".confirm_deletion"), turbo_confirm: translate(".confirm_deletion")},
                   method: :delete,
                   class: "btn btn-danger" %>
           </p>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -29,7 +29,7 @@
           <p class="card-text">
             <%= link_to t(".cancel_my_account"),
                   registration_path(resource_name),
-                  data: {confirm: t(".confirm_deletion"), turbo_confirm: t(".confirm_deletion")},
+                  data: {confirm: t_nowrap(".confirm_deletion"), turbo_confirm: t_nowrap(".confirm_deletion")},
                   method: :delete,
                   class: "btn btn-danger" %>
           </p>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -6,5 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <%= link_to_unless current_page.first?, t("views.pagination.first"), url, remote: remote, class: "page-link", "aria-label": t_nowrap(".label") %>
+  <%= link_to_unless current_page.first?, t("views.pagination.first"), url, remote: remote, class: "page-link", "aria-label": translate(".label") %>
 </li>

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -6,5 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <%= link_to_unless current_page.first?, t("views.pagination.first"), url, remote: remote, class: "page-link", "aria-label": t(".label") %>
+  <%= link_to_unless current_page.first?, t("views.pagination.first"), url, remote: remote, class: "page-link", "aria-label": t_nowrap(".label") %>
 </li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -6,5 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <%= link_to_unless current_page.last?, t("views.pagination.last"), url, remote: remote, class: "page-link", "aria-label": t_nowrap(".label") %>
+  <%= link_to_unless current_page.last?, t("views.pagination.last"), url, remote: remote, class: "page-link", "aria-label": translate(".label") %>
 </li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -6,5 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <%= link_to_unless current_page.last?, t("views.pagination.last"), url, remote: remote, class: "page-link", "aria-label": t(".label") %>
+  <%= link_to_unless current_page.last?, t("views.pagination.last"), url, remote: remote, class: "page-link", "aria-label": t_nowrap(".label") %>
 </li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -6,5 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <%= link_to_unless current_page.last?, t("views.pagination.next"), url, rel: "next", remote: remote, class: "page-link", "aria-label": t(".label") %>
+  <%= link_to_unless current_page.last?, t("views.pagination.next"), url, rel: "next", remote: remote, class: "page-link", "aria-label": t_nowrap(".label") %>
 </li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -6,5 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <%= link_to_unless current_page.last?, t("views.pagination.next"), url, rel: "next", remote: remote, class: "page-link", "aria-label": t_nowrap(".label") %>
+  <%= link_to_unless current_page.last?, t("views.pagination.next"), url, rel: "next", remote: remote, class: "page-link", "aria-label": translate(".label") %>
 </li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -7,7 +7,7 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item <%= " active" if page.current? %>">
-  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "page-link", "aria-label": t_nowrap(".label", page: page)} do |name|
-        content_tag(:span, name, class: "page-link", "aria-label": t_nowrap(".current_page"))
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "page-link", "aria-label": translate(".label", page: page)} do |name|
+        content_tag(:span, name, class: "page-link", "aria-label": translate(".current_page"))
       end %>
 </li>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -7,7 +7,7 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item <%= " active" if page.current? %>">
-  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "page-link", "aria-label": t(".label", page: page)} do |name|
-        content_tag(:span, name, class: "page-link", "aria-label": t(".current_page"))
+  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel, class: "page-link", "aria-label": t_nowrap(".label", page: page)} do |name|
+        content_tag(:span, name, class: "page-link", "aria-label": t_nowrap(".current_page"))
       end %>
 </li>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -6,5 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <%= link_to_unless current_page.first?, t("views.pagination.previous"), url, rel: "prev", remote: remote, class: "page-link", "aria-label": t_nowrap(".label") %>
+  <%= link_to_unless current_page.first?, t("views.pagination.previous"), url, rel: "prev", remote: remote, class: "page-link", "aria-label": translate(".label") %>
 </span>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -6,5 +6,5 @@
     per_page:      number of items to fetch per page
     remote:        data-remote -%>
 <li class="page-item">
-  <%= link_to_unless current_page.first?, t("views.pagination.previous"), url, rel: "prev", remote: remote, class: "page-link", "aria-label": t(".label") %>
+  <%= link_to_unless current_page.first?, t("views.pagination.previous"), url, rel: "prev", remote: remote, class: "page-link", "aria-label": t_nowrap(".label") %>
 </span>

--- a/app/views/model_files/bulk_edit.html.erb
+++ b/app/views/model_files/bulk_edit.html.erb
@@ -16,7 +16,7 @@
     </tr>
     <% @files.each do |file| %>
       <tr>
-        <td><%= form.check_box "model_files[#{file.id}]", data: {bulk_item: file.id.to_s}, "aria-label": t(".select", name: file.name) %></td>
+        <td><%= form.check_box "model_files[#{file.id}]", data: {bulk_item: file.id.to_s}, "aria-label": t_nowrap(".select", name: file.name) %></td>
         <td><%= link_to file.name, [@library, @model, file], title: file.filename %></td>
         <td><code><%= file.filename %></code></td>
         <td><%= icon "check-circle-fill", ModelFile.human_attribute_name(:printed) if current_user.printed?(file) %></td>

--- a/app/views/model_files/bulk_edit.html.erb
+++ b/app/views/model_files/bulk_edit.html.erb
@@ -7,7 +7,7 @@
 
   <table class="table table-striped" data-bulk-edit>
     <tr>
-      <th><input type="checkbox" aria-label="<%= t ".select_all" %>" value="0" name="bulk-select-all"></th>
+      <th><input type="checkbox" aria-label="<%= translate ".select_all" %>" value="0" name="bulk-select-all"></th>
       <th><%= ModelFile.human_attribute_name(:name) %></th>
       <th><%= ModelFile.human_attribute_name(:filename) %></th>
       <th><%= ModelFile.human_attribute_name(:printed) %></th>

--- a/app/views/model_files/bulk_edit.html.erb
+++ b/app/views/model_files/bulk_edit.html.erb
@@ -16,7 +16,7 @@
     </tr>
     <% @files.each do |file| %>
       <tr>
-        <td><%= form.check_box "model_files[#{file.id}]", data: {bulk_item: file.id.to_s}, "aria-label": t_nowrap(".select", name: file.name) %></td>
+        <td><%= form.check_box "model_files[#{file.id}]", data: {bulk_item: file.id.to_s}, "aria-label": translate(".select", name: file.name) %></td>
         <td><%= link_to file.name, [@library, @model, file], title: file.filename %></td>
         <td><code><%= file.filename %></code></td>
         <td><%= icon "check-circle-fill", ModelFile.human_attribute_name(:printed) if current_user.printed?(file) %></td>

--- a/app/views/model_files/show.html.erb
+++ b/app/views/model_files/show.html.erb
@@ -56,7 +56,7 @@
         </p>
       <% end %>
       <%= link_to safe_join([icon("pencil", t("general.edit")), t("general.edit")], " "), edit_library_model_model_file_path(@library, @model, @file), class: "btn btn-primary" if policy(@file).edit? %>
-      <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "), library_model_model_file_path(@library, @model, @file), {method: "delete", data: {confirm: t_nowrap("model_files.destroy.confirm")}, class: "btn btn-outline-danger"} if policy(@file).destroy? %>
+      <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "), library_model_model_file_path(@library, @model, @file), {method: "delete", data: {confirm: translate("model_files.destroy.confirm")}, class: "btn btn-outline-danger"} if policy(@file).destroy? %>
     <% end %>
 
     <%= render partial: "problem", collection: @file.problems.visible(current_user.problem_settings) %>

--- a/app/views/model_files/show.html.erb
+++ b/app/views/model_files/show.html.erb
@@ -56,7 +56,7 @@
         </p>
       <% end %>
       <%= link_to safe_join([icon("pencil", t("general.edit")), t("general.edit")], " "), edit_library_model_model_file_path(@library, @model, @file), class: "btn btn-primary" if policy(@file).edit? %>
-      <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "), library_model_model_file_path(@library, @model, @file), {method: "delete", data: {confirm: t("model_files.destroy.confirm")}, class: "btn btn-outline-danger"} if policy(@file).destroy? %>
+      <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "), library_model_model_file_path(@library, @model, @file), {method: "delete", data: {confirm: t_nowrap("model_files.destroy.confirm")}, class: "btn btn-outline-danger"} if policy(@file).destroy? %>
     <% end %>
 
     <%= render partial: "problem", collection: @file.problems.visible(current_user.problem_settings) %>

--- a/app/views/models/_file.html.erb
+++ b/app/views/models/_file.html.erb
@@ -17,7 +17,7 @@
       <% end %>
       <div class="row">
         <div class="col">
-          <%= link_to t(".open_button.text"), library_model_model_file_path(@model.library, @model, file), {class: "btn btn-primary", "aria-label": t(".open_button.label", name: file.name)} %>
+          <%= link_to t(".open_button.text"), library_model_model_file_path(@model.library, @model, file), {class: "btn btn-primary", "aria-label": t_nowrap(".open_button.label", name: file.name)} %>
           <%= link_to icon("cloud-download", t("general.download")), library_model_model_file_path(@model.library, @model, file, file.extension.to_sym), {class: "btn btn-outline-secondary"} %>
           <% if policy(@model).edit? %>
             <%= form_with model: [@model.library, @model], class: "d-inline" do |form| %>

--- a/app/views/models/_file.html.erb
+++ b/app/views/models/_file.html.erb
@@ -17,7 +17,7 @@
       <% end %>
       <div class="row">
         <div class="col">
-          <%= link_to t(".open_button.text"), library_model_model_file_path(@model.library, @model, file), {class: "btn btn-primary", "aria-label": t_nowrap(".open_button.label", name: file.name)} %>
+          <%= link_to t(".open_button.text"), library_model_model_file_path(@model.library, @model, file), {class: "btn btn-primary", "aria-label": translate(".open_button.label", name: file.name)} %>
           <%= link_to icon("cloud-download", t("general.download")), library_model_model_file_path(@model.library, @model, file, file.extension.to_sym), {class: "btn btn-outline-secondary"} %>
           <% if policy(@model).edit? %>
             <%= form_with model: [@model.library, @model], class: "d-inline" do |form| %>

--- a/app/views/models/_form.html.erb
+++ b/app/views/models/_form.html.erb
@@ -20,7 +20,7 @@
     <%= form.collection_select :library_id, Library.all, :id, :name, {include_blank: false}, {class: "form-control col-auto form-select", disabled: @model.contains_other_models?} %>
   </div>
 
-  <%= render "tags_edit", form: form, name: "model[tag_list]", value: (@model.tags.map { |tag| tag.name }).join(","), label: t(".tags"), tags: @model.library.all_tags %>
+  <%= render "tags_edit", form: form, name: "model[tag_list]", value: (@model.tags.map { |tag| tag.name }).join(","), label: t_nowrap(".tags"), tags: @model.library.all_tags %>
 
   <div class="row mb-3 input-group">
     <%= form.label :collection_id, class: "col-sm-2 col-form-label" %>

--- a/app/views/models/_form.html.erb
+++ b/app/views/models/_form.html.erb
@@ -20,7 +20,7 @@
     <%= form.collection_select :library_id, Library.all, :id, :name, {include_blank: false}, {class: "form-control col-auto form-select", disabled: @model.contains_other_models?} %>
   </div>
 
-  <%= render "tags_edit", form: form, name: "model[tag_list]", value: (@model.tags.map { |tag| tag.name }).join(","), label: t_nowrap(".tags"), tags: @model.library.all_tags %>
+  <%= render "tags_edit", form: form, name: "model[tag_list]", value: (@model.tags.map { |tag| tag.name }).join(","), label: translate(".tags"), tags: @model.library.all_tags %>
 
   <div class="row mb-3 input-group">
     <%= form.label :collection_id, class: "col-sm-2 col-form-label" %>

--- a/app/views/models/_image_carousel.html.erb
+++ b/app/views/models/_image_carousel.html.erb
@@ -4,11 +4,11 @@
       <button id="rotationControl" class="carousel-control-play btn btn-secondary m-2">
         <%= icon "pause", t(".play_pause"), id: "rotationControlIcon" %>
       </button>
-      <div class="carousel-indicators" role="group" aria-label="<%= t ".select_slide" %>">
+      <div class="carousel-indicators" role="group" aria-label="<%= translate ".select_slide" %>">
         <% images.each_with_index do |image, index| %>
           <button type="button" data-bs-target="#imageCarousel" data-bs-slide-to="<%= index %>"
             <%= "class=active aria-current=true aria-disabled=true" if index == 0 %>
-            aria-label="<%= t ".slide_label", index: (index + 1), count: images.count, name: image.name %>">
+            aria-label="<%= translate ".slide_label", index: (index + 1), count: images.count, name: image.name %>">
             <%= index %>
           </button>
         <% end %>
@@ -16,7 +16,7 @@
     <% end %>
     <div id="imageCarouselInner" class="carousel-inner" aria-atomic="false" aria-live="off">
       <% images.each_with_index do |image, index| %>
-        <div class="carousel-item <%= "active" if index == 0 %>" role="group" aria-roledescription="slide" aria-label="<%= t ".slide_label", index: (index + 1), count: images.count, name: image.name %>">
+        <div class="carousel-item <%= "active" if index == 0 %>" role="group" aria-roledescription="slide" aria-label="<%= translate ".slide_label", index: (index + 1), count: images.count, name: image.name %>">
           <%= image_tag library_model_model_file_path(@model.library, @model, image, format: image.extension), alt: image.name, class: "d-block w-100 carousel" %>
           <% if @model.preview_file != image && policy(image).edit? %>
             <div class="carousel-caption d-none d-md-block">

--- a/app/views/models/bulk_edit.html.erb
+++ b/app/views/models/bulk_edit.html.erb
@@ -15,7 +15,7 @@
     </tr>
     <% @models.each do |model| %>
       <tr>
-        <td><%= form.check_box "models[#{model.id}]", data: {bulk_item: model.id.to_s}, "aria-label": t(".select", name: model.name) %></td>
+        <td><%= form.check_box "models[#{model.id}]", data: {bulk_item: model.id.to_s}, "aria-label": t_nowrap(".select", name: model.name) %></td>
         <td><%= link_to model.name, [model.library, model], title: model.path %></td>
         <td><%= link_to model.collection.name, model.collection if model.collection %></td>
         <td><%= render partial: "tag",
@@ -54,8 +54,8 @@
     </div>
   </div>
 
-  <%= render "tags_edit", form: form, name: :add_tags, value: "", label: t(".add_tags"), tags: @addtags || [] %>
-  <%= render "tags_edit", form: form, name: :remove_tags, value: "", label: t(".remove_tags"), tags: @models.includes(:tags).map(&:tags).flatten.uniq.sort_by(&:name) %>
+  <%= render "tags_edit", form: form, name: :add_tags, value: "", label: t_nowrap(".add_tags"), tags: @addtags || [] %>
+  <%= render "tags_edit", form: form, name: :remove_tags, value: "", label: t_nowrap(".remove_tags"), tags: @models.includes(:tags).map(&:tags).flatten.uniq.sort_by(&:name) %>
 
   <div class="row mb-3">
     <%= form.label :collection_id, class: "col-sm-2 col-form-label" %>

--- a/app/views/models/bulk_edit.html.erb
+++ b/app/views/models/bulk_edit.html.erb
@@ -6,7 +6,7 @@
 
   <table class="table table-striped" data-bulk-edit>
     <tr>
-      <th><input type="checkbox" aria-label="<%= t ".select_all" %>" value="0" name="bulk-select-all"></th>
+      <th><input type="checkbox" aria-label="<%= translate ".select_all" %>" value="0" name="bulk-select-all"></th>
       <th><%= Model.human_attribute_name(:name) %></th>
       <th><%= Model.human_attribute_name(:collection) %></th>
       <th><%= Model.human_attribute_name(:tags) %></th>

--- a/app/views/models/bulk_edit.html.erb
+++ b/app/views/models/bulk_edit.html.erb
@@ -15,7 +15,7 @@
     </tr>
     <% @models.each do |model| %>
       <tr>
-        <td><%= form.check_box "models[#{model.id}]", data: {bulk_item: model.id.to_s}, "aria-label": t_nowrap(".select", name: model.name) %></td>
+        <td><%= form.check_box "models[#{model.id}]", data: {bulk_item: model.id.to_s}, "aria-label": translate(".select", name: model.name) %></td>
         <td><%= link_to model.name, [model.library, model], title: model.path %></td>
         <td><%= link_to model.collection.name, model.collection if model.collection %></td>
         <td><%= render partial: "tag",
@@ -54,8 +54,8 @@
     </div>
   </div>
 
-  <%= render "tags_edit", form: form, name: :add_tags, value: "", label: t_nowrap(".add_tags"), tags: @addtags || [] %>
-  <%= render "tags_edit", form: form, name: :remove_tags, value: "", label: t_nowrap(".remove_tags"), tags: @models.includes(:tags).map(&:tags).flatten.uniq.sort_by(&:name) %>
+  <%= render "tags_edit", form: form, name: :add_tags, value: "", label: translate(".add_tags"), tags: @addtags || [] %>
+  <%= render "tags_edit", form: form, name: :remove_tags, value: "", label: translate(".remove_tags"), tags: @models.includes(:tags).map(&:tags).flatten.uniq.sort_by(&:name) %>
 
   <div class="row mb-3">
     <%= form.label :collection_id, class: "col-sm-2 col-form-label" %>

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -70,7 +70,7 @@
       </tr>
     </table>
     <%= link_to safe_join([icon("pencil", t("general.edit")), t("general.edit")], " "), edit_library_model_path(@model.library, @model), class: "btn btn-primary" if policy(@model).edit? %>
-    <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "), library_model_path(@model.library, @model), {method: :delete, class: "float-end btn btn-outline-danger", data: {confirm: t_nowrap("models.destroy.confirm")}} if policy(@model).destroy? %>
+    <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "), library_model_path(@model.library, @model), {method: :delete, class: "float-end btn btn-outline-danger", data: {confirm: translate("models.destroy.confirm")}} if policy(@model).destroy? %>
   <% end %>
 
   <% if !@model.parents.empty? && policy(@model).merge? %>

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -70,7 +70,7 @@
       </tr>
     </table>
     <%= link_to safe_join([icon("pencil", t("general.edit")), t("general.edit")], " "), edit_library_model_path(@model.library, @model), class: "btn btn-primary" if policy(@model).edit? %>
-    <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "), library_model_path(@model.library, @model), {method: :delete, class: "float-end btn btn-outline-danger", data: {confirm: t("models.destroy.confirm")}} if policy(@model).destroy? %>
+    <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "), library_model_path(@model.library, @model), {method: :delete, class: "float-end btn btn-outline-danger", data: {confirm: t_nowrap("models.destroy.confirm")}} if policy(@model).destroy? %>
   <% end %>
 
   <% if !@model.parents.empty? && policy(@model).merge? %>

--- a/app/views/settings/_analysis_settings.html.erb
+++ b/app/views/settings/_analysis_settings.html.erb
@@ -5,7 +5,7 @@
       <%= t(".description") %>
     </p>
     <div class="row mb-2">
-      <%= form.label t(".manifold.label"), for: "analysis[manifold]", class: "col-sm-4 col-form-label" %>
+      <%= form.label nil, t(".manifold.label"), for: "analysis[manifold]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8 form-check form-switch">
         <%= form.check_box "analysis[manifold]", checked: SiteSettings.analyse_manifold, class: "form-check-input" %>
         <small><%= t(".manifold.help") %></small>

--- a/app/views/settings/_file_list_settings.html.erb
+++ b/app/views/settings/_file_list_settings.html.erb
@@ -3,7 +3,7 @@
   <div class="card-body">
     <p class="lead"><%= t(".summary") %></p>
     <div class="row">
-      <%= form.label t(".hide_presupported_versions.label"), for: "file_list[hide_presupported_versions]", class: "col col-form-label" %>
+      <%= form.label nil, t(".hide_presupported_versions.label"), for: "file_list[hide_presupported_versions]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
         <%= form.check_box "file_list[hide_presupported_versions]", checked: @user.file_list_settings["hide_presupported_versions"], class: "form-check-input" %>
       </div>

--- a/app/views/settings/_folder_settings.html.erb
+++ b/app/views/settings/_folder_settings.html.erb
@@ -25,20 +25,20 @@
       </li>
     </ul>
     <div class="row mb-2">
-      <%= form.label t(".model_path_template.label"), for: "folders[model_path_template]", class: "col-sm-4 col-form-label" %>
+      <%= form.label nil, t(".model_path_template.label"), for: "folders[model_path_template]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8 form-check form-switch">
         <%= form.text_field "folders[model_path_template]", value: SiteSettings.model_path_template, class: "form-control" %>
       </div>
     </div>
     <div class="row mb-2">
-      <%= form.label t(".parse_metadata_from_path.label"), for: "folders[parse_metadata_from_path]", class: "col-sm-4 col-form-label" %>
+      <%= form.label nil, t(".parse_metadata_from_path.label"), for: "folders[parse_metadata_from_path]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8 form-check form-switch">
         <%= form.check_box "folders[parse_metadata_from_path]", checked: SiteSettings.parse_metadata_from_path, class: "form-check-input" %>
         <small><%= t ".parse_metadata_from_path.help" %></small>
       </div>
     </div>
     <div class="row mb-2">
-      <%= form.label t(".safe_folder_names.label"), for: "folders[safe_folder_names]", class: "col-sm-4 col-form-label" %>
+      <%= form.label nil, t(".safe_folder_names.label"), for: "folders[safe_folder_names]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8 form-check form-switch">
         <%= form.check_box "folders[safe_folder_names]", checked: SiteSettings.safe_folder_names, class: "form-check-input" %>
         <small><%= t(".safe_folder_names.help_html") %></small>

--- a/app/views/settings/_general_settings.html.erb
+++ b/app/views/settings/_general_settings.html.erb
@@ -3,7 +3,7 @@
   <div class="card-body">
 
     <div class="row">
-      <%= form.label t(".interface_language.label"), for: "general[interface_language]", class: "col col-form-label" %>
+      <%= form.label nil, t(".interface_language.label"), for: "general[interface_language]", class: "col col-form-label" %>
       <div class="col">
         <%= form.select "general[interface_language]",
               @languages,

--- a/app/views/settings/_pagination_settings.html.erb
+++ b/app/views/settings/_pagination_settings.html.erb
@@ -7,25 +7,25 @@
     </p>
 
     <div class="row">
-      <%= form.label t(".models.label"), for: "pagination[models]", class: "col col-form-label" %>
+      <%= form.label nil, t(".models.label"), for: "pagination[models]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
         <%= form.check_box "pagination[models]", checked: @user.pagination_settings["models"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
-      <%= form.label t(".creators.label"), for: "pagination[creators]", class: "col col-form-label" %>
+      <%= form.label nil, t(".creators.label"), for: "pagination[creators]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
         <%= form.check_box "pagination[creators]", checked: @user.pagination_settings["creators"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
-      <%= form.label t(".collections.label"), for: "pagination[collections]", class: "col col-form-label" %>
+      <%= form.label nil, t(".collections.label"), for: "pagination[collections]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
         <%= form.check_box "pagination[collections]", checked: @user.pagination_settings["collections"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
-      <%= form.label t(".per_page.label"), for: "pagination[per_page]", class: "col col-form-label" %>
+      <%= form.label nil, t(".per_page.label"), for: "pagination[per_page]", class: "col col-form-label" %>
       <div class="col">
         <%= form.number_field "pagination[per_page]", value: @user.pagination_settings["per_page"], in: 1..100, class: "form-control" %>
       </div>

--- a/app/views/settings/_problem_settings.html.erb
+++ b/app/views/settings/_problem_settings.html.erb
@@ -7,7 +7,7 @@
     <% Problem::CATEGORIES.each do |category| %>
       <% next if Problem::DEFAULT_SEVERITIES[category].nil? # Skip deprecated categories; they don't appear in the defaults list %>
       <div class="row">
-        <%= form.label t("problems.categories.%{c}" % {c: category}),
+        <%= form.label nil, t("problems.categories.%{c}" % {c: category}),
               for: "problems[#{category}]",
               class: "col col-form-label" %>
         <div class="col">

--- a/app/views/settings/_renderer_settings.html.erb
+++ b/app/views/settings/_renderer_settings.html.erb
@@ -5,7 +5,7 @@
       <%= t(".description") %>
     </p>
     <div class="row">
-      <%= form.label t(".auto_load_max_size.label"), for: "renderer[auto_load_max_size]", class: "col col-form-label" %>
+      <%= form.label nil, t(".auto_load_max_size.label"), for: "renderer[auto_load_max_size]", class: "col col-form-label" %>
       <div class="col">
         <%= form.select "renderer[auto_load_max_size]",
               [
@@ -27,37 +27,37 @@
       </div>
     </div>
     <div class="row">
-      <%= form.label t(".show_grid.label"), for: "renderer[show_grid]", class: "col col-form-label" %>
+      <%= form.label nil, t(".show_grid.label"), for: "renderer[show_grid]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
         <%= form.check_box "renderer[show_grid]", checked: @user.renderer_settings["show_grid"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
-      <%= form.label t(".grid_width.label"), for: "renderer[grid_width]", class: "col col-form-label" %>
+      <%= form.label nil, t(".grid_width.label"), for: "renderer[grid_width]", class: "col col-form-label" %>
       <div class="col">
         <%= form.number_field "renderer[grid_width]", value: @user.renderer_settings["grid_width"], class: "form-control" %>
       </div>
     </div>
     <div class="row">
-      <%= form.label t(".enable_pan_zoom.label"), for: "renderer[enable_pan_zoom]", class: "col col-form-label" %>
+      <%= form.label nil, t(".enable_pan_zoom.label"), for: "renderer[enable_pan_zoom]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
         <%= form.check_box "renderer[enable_pan_zoom]", checked: @user.renderer_settings["enable_pan_zoom"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
-      <%= form.label t(".background_colour.label"), for: "renderer[background_colour]", class: "col col-form-label" %>
+      <%= form.label nil, t(".background_colour.label"), for: "renderer[background_colour]", class: "col col-form-label" %>
       <div class="col">
         <%= form.color_field "renderer[background_colour]", value: @user.renderer_settings["background_colour"], class: "form-control" %>
       </div>
     </div>
     <div class="row">
-      <%= form.label t(".render_style.label"), for: "renderer[render_style]", class: "col col-form-label" %>
+      <%= form.label nil, t(".render_style.label"), for: "renderer[render_style]", class: "col col-form-label" %>
       <div class="col">
         <%= form.select "renderer[render_style]", [[t(".render_style.normals"), "normals"], [t(".render_style.lambert"), "lambert"]], {selected: @user.renderer_settings["render_style"]}, {class: "form-select"} %>
       </div>
     </div>
     <div class="row">
-      <%= form.label t(".object_colour.label"), for: "renderer[object_colour]", class: "col col-form-label" %>
+      <%= form.label nil, t(".object_colour.label"), for: "renderer[object_colour]", class: "col col-form-label" %>
       <div class="col">
         <%= form.color_field "renderer[object_colour]", value: @user.renderer_settings["object_colour"], class: "form-control" %>
       </div>

--- a/app/views/settings/_tag_cloud_settings.html.erb
+++ b/app/views/settings/_tag_cloud_settings.html.erb
@@ -2,25 +2,25 @@
   <h3 class="card-header"><%= t(".heading") %></h3>
   <div class="card-body">
     <div class="row">
-      <%= form.label t(".threshold.label"), for: "tag_cloud[threshold]", class: "col col-form-label" %>
+      <%= form.label nil, t(".threshold.label"), for: "tag_cloud[threshold]", class: "col col-form-label" %>
       <div class="col">
         <%= form.text_field "tag_cloud[threshold]", value: @user.tag_cloud_settings["threshold"], class: "form-control" %>
       </div>
     </div>
     <div class="row">
-      <%= form.label t(".heatmap.label"), for: "tag_cloud[heatmap]", class: "col col-form-label" %>
+      <%= form.label nil, t(".heatmap.label"), for: "tag_cloud[heatmap]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
         <%= form.check_box "tag_cloud[heatmap]", checked: @user.tag_cloud_settings["heatmap"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
-      <%= form.label t(".hide_unrelated.label"), for: "tag_cloud[hide_unrelated]", class: "col col-form-label" %>
+      <%= form.label nil, t(".hide_unrelated.label"), for: "tag_cloud[hide_unrelated]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
         <%= form.check_box "tag_cloud[hide_unrelated]", checked: @user.tag_cloud_settings["hide_unrelated"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
-      <%= form.label t(".sorting.label"), for: "tag_cloud[sorting]", class: "col col-form-label" %>
+      <%= form.label nil, t(".sorting.label"), for: "tag_cloud[sorting]", class: "col col-form-label" %>
       <div class="col">
         <%= form.select "tag_cloud[sorting]", ["frequency", "alphabetical"],
               {selected: @user.tag_cloud_settings["sorting"]},
@@ -28,7 +28,7 @@
       </div>
     </div>
     <div class="row mb-2">
-      <%= form.label t(".keypair.label"), for: "tag_cloud[keypair]", class: "col col-form-label" %>
+      <%= form.label nil, t(".keypair.label"), for: "tag_cloud[keypair]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
         <%= form.check_box "tag_cloud[keypair]", checked: @user.tag_cloud_settings["keypair"], class: "form-check-input" %>
       </div>

--- a/app/views/settings/_tag_settings.html.erb
+++ b/app/views/settings/_tag_settings.html.erb
@@ -5,32 +5,32 @@
       <%= t(".description") %>
     </p>
     <div class="row mb-2">
-      <%= form.label t(".auto_tag_new.label"), for: "model_tags[auto_tag_new]", class: "col-sm-4 col-form-label" %>
+      <%= form.label nil, t(".auto_tag_new.label"), for: "model_tags[auto_tag_new]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8">
         <%= form.text_field "model_tags[auto_tag_new]", value: SiteSettings.model_tags_auto_tag_new, class: "form-control" %>
       </div>
     </div>
     <div class="row mb-2">
-      <%= form.label t(".tag_model_directory_name.label"), for: "model_tags[tag_model_directory_name]", class: "col-sm-4 col-form-label" %>
+      <%= form.label nil, t(".tag_model_directory_name.label"), for: "model_tags[tag_model_directory_name]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8 form-check form-switch">
         <%= form.check_box "model_tags[tag_model_directory_name]", checked: SiteSettings.model_tags_tag_model_directory_name, class: "form-check-input" %>
         <small><%= t(".tag_model_directory_name.help") %></small>
       </div>
     </div>
     <div class="row mb-2">
-      <%= form.label t(".filter_stop_words.label"), for: "model_tags[filter_stop_words]", class: "col-sm-4 col-form-label" %>
+      <%= form.label nil, t(".filter_stop_words.label"), for: "model_tags[filter_stop_words]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8 form-check form-switch">
         <%= form.check_box "model_tags[filter_stop_words]", checked: SiteSettings.model_tags_filter_stop_words, class: "form-check-input" %>
       </div>
     </div>
     <div class="row mb-2">
-      <%= form.label t(".stop_words_locale.label"), for: "model_tags[stop_words_locale]", class: "col-sm-4 col-form-label" %>
+      <%= form.label nil, t(".stop_words_locale.label"), for: "model_tags[stop_words_locale]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8">
         <%= form.text_field "model_tags[stop_words_locale]", value: SiteSettings.model_tags_stop_words_locale, class: "form-control" %>
       </div>
     </div>
     <div class="row mb-2">
-      <%= form.label t(".custom_stop_words.label"), for: "model_tags[custom_stop_words]", class: "col-sm-4 col-form-label" %>
+      <%= form.label nil, t(".custom_stop_words.label"), for: "model_tags[custom_stop_words]", class: "col-sm-4 col-form-label" %>
       <div class="col-sm-8">
         <%= form.text_field "model_tags[custom_stop_words]", value: SiteSettings.model_tags_custom_stop_words, class: "form-control" %>
       </div>

--- a/config/initializers/core_extensions.rb
+++ b/config/initializers/core_extensions.rb
@@ -1,6 +1,8 @@
 # Mixing in some extensions to core classes
 require "trim_path_separators"
+require "locale_awareness"
 
 class String
   include TrimPathSeparators
+  include LocaleAwareness
 end

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -1,0 +1,29 @@
+# Monkeypatch fallbacks to add locale to returned strings
+module I18n::Backend::Fallbacks
+  def translate(locale, key, options = EMPTY_HASH)
+    return super unless options.fetch(:fallback, true)
+    return super if options[:fallback_in_progress]
+    default = extract_non_symbol_default!(options) if options[:default]
+
+    fallback_options = options.merge(:fallback_in_progress => true, fallback_original_locale: locale)
+    I18n.fallbacks[locale].each do |fallback|
+      begin
+        catch(:exception) do
+          result = super(fallback, key, fallback_options)
+          result.locale = fallback if locale.to_s != fallback.to_s
+          unless result.nil?
+            on_fallback(locale, fallback, key, options) if locale.to_s != fallback.to_s
+            return result
+          end
+        end
+      rescue I18n::InvalidLocale
+        # we do nothing when the locale is invalid, as this is a fallback anyways.
+      end
+    end
+
+    return if options.key?(:default) && options[:default].nil?
+
+    return super(locale, nil, options.merge(:default => default)) if default
+    throw(:exception, I18n::MissingTranslation.new(locale, key, options))
+  end
+end

--- a/config/initializers/i18n.rb
+++ b/config/initializers/i18n.rb
@@ -5,25 +5,23 @@ module I18n::Backend::Fallbacks
     return super if options[:fallback_in_progress]
     default = extract_non_symbol_default!(options) if options[:default]
 
-    fallback_options = options.merge(:fallback_in_progress => true, fallback_original_locale: locale)
+    fallback_options = options.merge(fallback_in_progress: true, fallback_original_locale: locale)
     I18n.fallbacks[locale].each do |fallback|
-      begin
-        catch(:exception) do
-          result = super(fallback, key, fallback_options)
-          result.locale = fallback if locale.to_s != fallback.to_s
-          unless result.nil?
-            on_fallback(locale, fallback, key, options) if locale.to_s != fallback.to_s
-            return result
-          end
+      catch(:exception) do
+        result = super(fallback, key, fallback_options)
+        result.locale = fallback if locale.to_s != fallback.to_s
+        unless result.nil?
+          on_fallback(locale, fallback, key, options) if locale.to_s != fallback.to_s
+          return result
         end
-      rescue I18n::InvalidLocale
-        # we do nothing when the locale is invalid, as this is a fallback anyways.
       end
+    rescue I18n::InvalidLocale
+      # we do nothing when the locale is invalid, as this is a fallback anyways.
     end
 
     return if options.key?(:default) && options[:default].nil?
 
-    return super(locale, nil, options.merge(:default => default)) if default
+    return super(locale, nil, options.merge(default: default)) if default
     throw(:exception, I18n::MissingTranslation.new(locale, key, options))
   end
 end


### PR DESCRIPTION
We do this by:

1. Adding a locale property to String
2. Overwriting I18n::Fallbacks to set the locale property when a fallback is used
3. Override default translate helper `t` to add a wrapper span tag if a locale is set.

Resolves #2096 