### PR TITLE
Adds .well-known URI for password change

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,8 @@
 require "sidekiq/web"
 
 Rails.application.routes.draw do
+  get ".well-known/change-password", to: redirect("/users/edit")
+
   get "problems/index"
   devise_for :users, controllers: {
     passwords: "users/passwords",

--- a/spec/requests/users/passwords_spec.rb
+++ b/spec/requests/users/passwords_spec.rb
@@ -1,10 +1,11 @@
 require "rails_helper"
 
-#  new_user_password GET    /users/password/new(.:format)
-# edit_user_password GET    /users/password/edit(.:format)
-#      user_password PATCH  /users/password(.:format)
-#                    PUT    /users/password(.:format)
-#                    POST   /users/password(.:format)
+# .well-known/change-password GET    /.well-known/change-password
+#  new_user_password          GET    /users/password/new(.:format)
+# edit_user_password          GET    /users/password/edit(.:format)
+#      user_password          PATCH  /users/password(.:format)
+#                             PUT    /users/password(.:format)
+#                             POST   /users/password(.:format)
 
 RSpec.describe "Users::Passwords" do
   let(:new_password) { Faker::Internet.password min_length: 6, mix_case: true, special_characters: true }
@@ -27,6 +28,15 @@ RSpec.describe "Users::Passwords" do
       }
     }
   }
+
+  context "when signed out" do
+    describe "GET /.well-known/change-password" do
+      it "redirects to password change" do
+        get "/.well-known/change-password"
+        expect(response).to redirect_to("/users/edit")
+      end
+    end
+  end
 
   context "when in single user mode" do
     context "when signed out" do


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [x] Check that the tests and code linter both pass.
- [ ] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

This adds the Well-known URI for a password reset.

## Linked issues

<!--
Does this PR resolve an issue? If so, please state "resolves #{number}" here.
Mention any other linked issues or PRs as well, even if this PR doesn't resolve them completely.
-->

## Description of changes

This change adds a Well-known URI for a password reset and a simple spec. One drawback is that this would let a user go to their password reset in single-user mode -- not ideal but possible. It also allows password managers to quickly access the link in multi-user mode which is ideal.

I wrote the spec in the context of `"when signed out"` but it also works if the user is signed in. I'm not certain the best way to describe the context, so I left it as is.