### PR TITLE
Anonymous OPT-IN usage tracking

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -132,3 +132,5 @@ gem "i18n_data", "~> 0.17.1"
 gem "bullet", "~> 7.1", group: :development
 
 gem "logstash-event", "~> 1.2"
+
+gem "climate_control", "~> 1.2", group: :test

--- a/Gemfile
+++ b/Gemfile
@@ -134,3 +134,5 @@ gem "bullet", "~> 7.1", group: :development
 gem "logstash-event", "~> 1.2"
 
 gem "climate_control", "~> 1.2", group: :test
+
+gem "sidekiq-scheduler", "~> 5.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,7 @@ GEM
     byebug (11.1.3)
     childprocess (5.0.0)
     chunky_png (1.4.0)
+    climate_control (1.2.0)
     cocoon (1.2.15)
     coderay (1.1.3)
     concurrent-ruby (1.2.3)
@@ -567,6 +568,7 @@ DEPENDENCIES
   brakeman (~> 6.1)
   bullet (~> 7.1)
   byebug
+  climate_control (~> 1.2)
   cocoon (~> 1.2)
   cssbundling-rails (~> 1.4)
   data_migrate!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,8 @@ GEM
       rubocop
       smart_properties
     erubi (1.12.0)
+    et-orbi (1.2.11)
+      tzinfo
     factory_bot (6.4.6)
       activesupport (>= 5.0.0)
     faker (3.3.1)
@@ -187,6 +189,9 @@ GEM
       actionpack (>= 6.0.0)
     formtastic_i18n (0.7.0)
     forwardable (1.3.3)
+    fugit (1.11.0)
+      et-orbi (~> 1, >= 1.2.11)
+      raabro (~> 1.4)
     gettext (3.4.9)
       erubi
       locale (>= 2.0.5)
@@ -334,6 +339,7 @@ GEM
       nio4r (~> 2.0)
     pundit (2.3.2)
       activesupport (>= 3.0.0)
+    raabro (1.4.0)
     racc (1.7.3)
     rack (2.2.9)
     rack-contrib (2.4.0)
@@ -457,6 +463,8 @@ GEM
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
+    rufus-scheduler (3.9.1)
+      fugit (~> 1.1, >= 1.1.6)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
     sassc (2.4.0)
@@ -477,6 +485,10 @@ GEM
       redis-client (>= 0.19.0)
     sidekiq-failures (1.0.4)
       sidekiq (>= 4.0.0)
+    sidekiq-scheduler (5.0.3)
+      rufus-scheduler (~> 3.2)
+      sidekiq (>= 6, < 8)
+      tilt (>= 1.4.0)
     simple_po_parser (1.1.6)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -617,6 +629,7 @@ DEPENDENCIES
   scout_apm
   sidekiq (~> 7.2)
   sidekiq-failures (~> 1.0)
+  sidekiq-scheduler (~> 5.0)
   simplecov (~> 0.22.0)
   spdx (~> 4.1)
   spring

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -24,6 +24,7 @@ class SettingsController < ApplicationController
       update_folder_settings(params[:folders])
       update_tagging_settings(params[:model_tags])
       update_analysis_settings(params[:analysis])
+      update_usage_settings(params[:usage])
     end
     redirect_to user_settings_path(@user), notice: t(".success")
   end
@@ -101,6 +102,15 @@ class SettingsController < ApplicationController
   def update_analysis_settings(settings)
     return unless settings
     SiteSettings.analyse_manifold = settings[:manifold] == "1"
+  end
+
+  def update_usage_settings(settings)
+    return unless settings
+    if settings[:report] == "1"
+      SiteSettings.anonymous_usage_id ||= SecureRandom.uuid
+    else
+      SiteSettings.anonymous_usage_id = nil
+    end
   end
 
   def get_user

--- a/app/jobs/usage_reporting_job.rb
+++ b/app/jobs/usage_reporting_job.rb
@@ -1,5 +1,4 @@
 class UsageReportingJob < ApplicationJob
-
   def perform
     # If there's no ID, don't send
     return unless SiteSettings.anonymous_usage_id
@@ -11,10 +10,9 @@ class UsageReportingJob < ApplicationJob
     Rails.logger.info("Sending anonymous usage report to #{uri}: #{data}")
     # Send
     headers = {
-      'Content-Type': 'application/json',
-      'User-Agent': 'Manyfold::UsageReportingJob'
+      "Content-Type": "application/json",
+      "User-Agent": "Manyfold::UsageReportingJob"
     }
     Net::HTTP.post(uri, data, headers)
   end
-
 end

--- a/app/jobs/usage_reporting_job.rb
+++ b/app/jobs/usage_reporting_job.rb
@@ -1,0 +1,20 @@
+class UsageReportingJob < ApplicationJob
+
+  def perform
+    # If there's no ID, don't send
+    return unless SiteSettings.anonymous_usage_id
+    # Get the endpoint
+    uri = URI.parse(UsageReport.endpoint)
+    # Prepare the report
+    data = UsageReport.generate
+    # Tell the user what we're doing
+    Rails.logger.info("Sending anonymous usage report to #{uri}: #{data}")
+    # Send
+    headers = {
+      'Content-Type': 'application/json',
+      'User-Agent': 'Manyfold::UsageReportingJob'
+    }
+    Net::HTTP.post(uri, data, headers)
+  end
+
+end

--- a/app/lib/usage_report.rb
+++ b/app/lib/usage_report.rb
@@ -1,0 +1,15 @@
+module UsageReport
+  def self.endpoint
+    ENV.fetch("USAGE_TRACKING_URL", "https://tracking.manyfold.app")
+  end
+
+  def self.generate
+    Jbuilder.encode do |report|
+      report.id SiteSettings.anonymous_usage_id
+      report.version do |version|
+        version.app ENV.fetch("APP_VERSION", "unknown").split(":")[-1]
+        version.sha ENV.fetch("GIT_SHA", "unknown")
+      end
+    end
+  end
+end

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -11,6 +11,7 @@ class SiteSettings < RailsSettings::Base
   field :parse_metadata_from_path, type: :boolean, default: true
   field :safe_folder_names, type: :boolean, default: true
   field :analyse_manifold, type: :boolean, default: false
+  field :anonymous_usage_id, type: :string, default: nil
 
   def self.registration_enabled
     ENV.fetch("REGISTRATION", false) == "enabled"

--- a/app/views/settings/_usage_settings.html.erb
+++ b/app/views/settings/_usage_settings.html.erb
@@ -2,7 +2,7 @@
   <h3 class="card-header"><%= t(".heading") %></h3>
   <div class="card-body">
     <p class="lead"><%= t(".summary") %></p>
-    <p><%= t(".description_html", endpoint: UsageReport.endpoint ) %></p>
+    <p><%= t(".description_html", endpoint: UsageReport.endpoint) %></p>
     <div class='alert alert-info'>
       <code><%= UsageReport.generate %></code>
     </div>

--- a/app/views/settings/_usage_settings.html.erb
+++ b/app/views/settings/_usage_settings.html.erb
@@ -1,0 +1,18 @@
+<div class="card mb-2">
+  <h3 class="card-header"><%= t(".heading") %></h3>
+  <div class="card-body">
+    <p class="lead"><%= t(".summary") %></p>
+    <p><%= t(".description_html", endpoint: UsageReport.endpoint ) %></p>
+    <div class='alert alert-info'>
+      <code><%= UsageReport.generate %></code>
+    </div>
+    <p><%= t(".use_of_data") %></p>
+    <p><%= t(".verification_html") %></p>
+    <div class="row">
+      <%= form.label nil, t(".report_usage.label"), for: "usage[report]", class: "col col-form-label" %>
+      <div class="col form-check form-switch">
+        <%= form.check_box "usage[report]", checked: SiteSettings.anonymous_usage_id.present?, class: "form-check-input" %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/settings/show.html.erb
+++ b/app/views/settings/show.html.erb
@@ -18,12 +18,13 @@
 
     <div class="row mb-4">
       <div class="col">
-        <%= render "folder_settings", form: form %>
+        <%= render "usage_settings", form: form %>
+        <%= render "multiuser_settings", form: form %>
         <%= render "analysis_settings", form: form %>
       </div>
       <div class="col">
+        <%= render "folder_settings", form: form %>
         <%= render "tag_settings", form: form %>
-        <%= render "multiuser_settings", form: form %>
       </div>
     </div>
 

--- a/config/initializers/usage_reports.rb
+++ b/config/initializers/usage_reports.rb
@@ -1,0 +1,1 @@
+require "usage_report"

--- a/config/locales/settings/en.yml
+++ b/config/locales/settings/en.yml
@@ -141,3 +141,11 @@ en:
         label: Create tags from model directory name
     update:
       success: Settings saved.
+    usage_settings:
+      description_html: If you enable usage tracking, the following information will be sent once a day to <code>%{endpoint}</code>. The <code>id</code> is randomly generated when you enable tracking.
+      heading: Anonymous Usage Tracking
+      report_usage:
+        label: Enable anonymous usage tracking
+      summary: Let the devs know you're running Manyfold.
+      use_of_data: No other information is sent or stored, and the devs will never use the information for any purpose other than measuring how many instances of Manyfold are running, and what version they are.
+      verification_html: If you want to verify what we send, you can change the <code>USAGE_REPORTING_URL</code> environment variable and send the data somewhere you can inspect it. You can also see exactly what is sent in the log.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,5 @@
 require "sidekiq/web"
+require 'sidekiq-scheduler/web'
 
 Rails.application.routes.draw do
   get ".well-known/change-password", to: redirect("/users/edit")

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 require "sidekiq/web"
-require 'sidekiq-scheduler/web'
+require "sidekiq-scheduler/web"
 
 Rails.application.routes.draw do
   get ".well-known/change-password", to: redirect("/users/edit")

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -3,3 +3,8 @@
   - scan
   - default
   - analysis
+:scheduler:
+  :schedule:
+    usage:
+      every: '1d'
+      class: UsageReportingJob

--- a/spec/lib/usage_report_spec.rb
+++ b/spec/lib/usage_report_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+RSpec.describe UsageReport do
+  around do |example|
+    vars = {
+      APP_VERSION: "test",
+      GIT_SHA: "deadbeef"
+    }
+    ClimateControl.modify vars do
+      example.run
+    end
+  end
+
+  context "when generating a usage report" do
+    before do
+      allow(SiteSettings).to receive(:anonymous_usage_id).and_return("guid-goes-here")
+    end
+
+    let(:report) { described_class.generate }
+    let(:parsed) { JSON.parse(report) }
+
+    it "produces valid JSON" do
+      expect(parsed).not_to be_nil
+    end
+
+    it "includes application ID" do
+      expect(parsed["id"]).to eq "guid-goes-here"
+    end
+
+    it "includes application version" do
+      expect(parsed["version"]["app"]).to eq "test"
+    end
+
+    it "includes git SHA" do
+      expect(parsed["version"]["sha"]).to eq "deadbeef"
+    end
+  end
+
+  it "specifies a default endpoint" do
+    ClimateControl.modify USAGE_TRACKING_URL: nil do
+      expect(described_class.endpoint).to eq "https://tracking.manyfold.app"
+    end
+  end
+
+  it "allows custom endpoint in ENV" do
+    ClimateControl.modify USAGE_TRACKING_URL: "http://example.com" do
+      expect(described_class.endpoint).to eq "http://example.com"
+    end
+  end
+end


### PR DESCRIPTION
This PR introduces anonymous, opt-in usage tracking. Off by default, if enabled the code will send an extremely minimal report to a tracking API endpoint. The only information is an random UUID for the server, which is reset when the settings is disabled/enabled, the git SHA and the app version, as reported in the footer.

<img width="594" alt="Screenshot 2024-05-16 at 13 43 05" src="https://github.com/manyfold3d/manyfold/assets/3565/ad40b8f5-d6fc-4e17-949a-2d493989ff37">

I've gone overboard on the text for the setting, probably, but I'd rather be 100% clear about what's happening rather than cause anyone any concern.

Resolves #2045 