### PR TITLE
Don't schedule background usage reporting job if not enabled

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -135,4 +135,4 @@ gem "logstash-event", "~> 1.2"
 
 gem "climate_control", "~> 1.2", group: :test
 
-gem "sidekiq-scheduler", "~> 5.0"
+gem "sidekiq-scheduler", github: "manyfold3d/sidekiq-scheduler", branch: "fix-dynamic-schedule-load-on-boot"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,6 +19,16 @@ GIT
       opengl-bindings
       rubyzip
 
+GIT
+  remote: https://github.com/manyfold3d/sidekiq-scheduler.git
+  revision: 8eb248143c89fae273d66a57b41b474b7006f2bd
+  branch: fix-dynamic-schedule-load-on-boot
+  specs:
+    sidekiq-scheduler (5.0.3)
+      rufus-scheduler (~> 3.2)
+      sidekiq (>= 6, < 8)
+      tilt (>= 1.4.0, < 3)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -485,10 +495,6 @@ GEM
       redis-client (>= 0.19.0)
     sidekiq-failures (1.0.4)
       sidekiq (>= 4.0.0)
-    sidekiq-scheduler (5.0.3)
-      rufus-scheduler (~> 3.2)
-      sidekiq (>= 6, < 8)
-      tilt (>= 1.4.0)
     simple_po_parser (1.1.6)
     simplecov (0.22.0)
       docile (~> 1.1)
@@ -629,7 +635,7 @@ DEPENDENCIES
   scout_apm
   sidekiq (~> 7.2)
   sidekiq-failures (~> 1.0)
-  sidekiq-scheduler (~> 5.0)
+  sidekiq-scheduler!
   simplecov (~> 0.22.0)
   spdx (~> 4.1)
   spring

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -106,11 +106,7 @@ class SettingsController < ApplicationController
 
   def update_usage_settings(settings)
     return unless settings
-    if settings[:report] == "1"
-      SiteSettings.anonymous_usage_id ||= SecureRandom.uuid
-    else
-      SiteSettings.anonymous_usage_id = nil
-    end
+    (settings[:report] == "1") ? UsageReport.enable! : UsageReport.disable!
   end
 
   def get_user

--- a/app/jobs/usage_reporting_job.rb
+++ b/app/jobs/usage_reporting_job.rb
@@ -1,3 +1,5 @@
+require "net/http"
+
 class UsageReportingJob < ApplicationJob
   def perform
     # If there's no ID, don't send

--- a/app/lib/usage_report.rb
+++ b/app/lib/usage_report.rb
@@ -12,4 +12,14 @@ module UsageReport
       end
     end
   end
+
+  def self.enable!
+    SiteSettings.anonymous_usage_id ||= SecureRandom.uuid
+    Sidekiq.set_schedule("usage", {every: "1d", class: "UsageReportingJob"})
+  end
+
+  def self.disable!
+    SiteSettings.anonymous_usage_id = nil
+    Sidekiq.remove_schedule("usage")
+  end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -4,7 +4,5 @@
   - default
   - analysis
 :scheduler:
-  :schedule:
-    usage:
-      every: '1d'
-      class: UsageReportingJob
+  :dynamic: true
+  :dynamic_every: 15s


### PR DESCRIPTION
It quit immediately when it checked the config, but it's better if it doesn't run at all.