### PR TITLE
Add Shrine storage engine

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -139,3 +139,4 @@ gem "climate_control", "~> 1.2", group: :test
 gem "sidekiq-scheduler", github: "manyfold3d/sidekiq-scheduler", branch: "fix-dynamic-schedule-load-on-boot"
 
 gem "sys-filesystem", "~> 1.5"
+gem "shrine", "~> 3.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -210,7 +210,10 @@ GEM
       activesupport (>= 5.0.0)
     faker (3.4.1)
       i18n (>= 1.8.11, < 2)
+    ffi (1.17.0)
+    ffi (1.17.0-x64-mingw-ucrt)
     ffi (1.17.0-x86_64-darwin)
+    ffi (1.17.0-x86_64-linux-gnu)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     flipper (1.3.0)
@@ -330,6 +333,7 @@ GEM
     memoist (0.16.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
+    mini_portile2 (2.8.7)
     minitest (5.24.0)
     msgpack (1.7.2)
     mutex_m (0.2.0)
@@ -344,7 +348,14 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
+    nokogiri (1.16.6)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.16.6-x64-mingw-ucrt)
+      racc (~> 1.4)
     nokogiri (1.16.6-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -545,7 +556,11 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.7.3)
+      mini_portile2 (~> 2.8.0)
+    sqlite3 (1.7.3-x64-mingw-ucrt)
     sqlite3 (1.7.3-x86_64-darwin)
+    sqlite3 (1.7.3-x86_64-linux)
     standard (1.39.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -576,6 +591,8 @@ GEM
       polyglot (~> 0.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
+    tzinfo-data (1.2024.1)
+      tzinfo (>= 1.0.0)
     unicode-display_width (2.5.0)
     uniform_notifier (1.16.0)
     view_component (3.12.1)
@@ -596,7 +613,10 @@ GEM
     zeitwerk (2.6.16)
 
 PLATFORMS
+  ruby
+  x64-mingw-ucrt
   x86_64-darwin-22
+  x86_64-linux
 
 DEPENDENCIES
   activeadmin (~> 3.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -167,6 +167,7 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
+    content_disposition (1.0.0)
     crass (1.0.6)
     cssbundling-rails (1.4.0)
       railties (>= 6.0.0)
@@ -192,6 +193,8 @@ GEM
     dotenv-rails (3.1.2)
       dotenv (= 3.1.2)
       railties (>= 6.1)
+    down (5.4.2)
+      addressable (~> 2.8)
     drb (2.2.1)
     erb_lint (0.5.0)
       activesupport
@@ -207,10 +210,7 @@ GEM
       activesupport (>= 5.0.0)
     faker (3.4.1)
       i18n (>= 1.8.11, < 2)
-    ffi (1.17.0)
-    ffi (1.17.0-x64-mingw-ucrt)
     ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
     ffi-libarchive (1.1.14)
       ffi (~> 1.0)
     flipper (1.3.0)
@@ -330,7 +330,6 @@ GEM
     memoist (0.16.2)
     method_source (1.1.0)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.7)
     minitest (5.24.0)
     msgpack (1.7.2)
     mutex_m (0.2.0)
@@ -345,14 +344,7 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
-    nokogiri (1.16.6)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
-    nokogiri (1.16.6-x64-mingw-ucrt)
-      racc (~> 1.4)
     nokogiri (1.16.6-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
@@ -364,7 +356,6 @@ GEM
       ast (~> 2.4.1)
       racc
     pg (1.5.6)
-    pg (1.5.6-x64-mingw-ucrt)
     polyglot (0.3.5)
     prime (0.1.2)
       forwardable
@@ -525,6 +516,9 @@ GEM
     scout_apm (5.3.8)
       parser
     shellany (0.0.1)
+    shrine (3.6.0)
+      content_disposition (~> 1.0)
+      down (~> 5.1)
     sidekiq (7.2.4)
       concurrent-ruby (< 2)
       connection_pool (>= 2.3.0)
@@ -551,11 +545,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sqlite3 (1.7.3)
-      mini_portile2 (~> 2.8.0)
-    sqlite3 (1.7.3-x64-mingw-ucrt)
     sqlite3 (1.7.3-x86_64-darwin)
-    sqlite3 (1.7.3-x86_64-linux)
     standard (1.39.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -586,8 +576,6 @@ GEM
       polyglot (~> 0.3)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    tzinfo-data (1.2023.2)
-      tzinfo (>= 1.0.0)
     unicode-display_width (2.5.0)
     uniform_notifier (1.16.0)
     view_component (3.12.1)
@@ -608,10 +596,7 @@ GEM
     zeitwerk (2.6.16)
 
 PLATFORMS
-  ruby
-  x64-mingw-ucrt
-  x86_64-darwin-19
-  x86_64-linux
+  x86_64-darwin-22
 
 DEPENDENCIES
   activeadmin (~> 3.2)
@@ -672,6 +657,7 @@ DEPENDENCIES
   rubocop-rspec_rails
   sass-rails (>= 6)
   scout_apm
+  shrine (~> 3.6)
   sidekiq (~> 7.2)
   sidekiq-failures (~> 1.0)
   sidekiq-scheduler!

--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -75,9 +75,8 @@ class ModelFilesController < ApplicationController
   private
 
   def send_file_content(disposition: :attachment)
-    filename = File.join(@library.path, @model.path, @file.filename)
-    response.headers["Content-Length"] = File.size(filename).to_s
-    send_file filename, disposition: disposition, type: @file.extension.to_sym
+    response.headers["Content-Length"] = @file.size
+    send_file @file.pathname, disposition: disposition, type: @file.mime_type
   rescue Errno::ENOENT
     head :internal_server_error
   end

--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -75,8 +75,10 @@ class ModelFilesController < ApplicationController
   private
 
   def send_file_content(disposition: :attachment)
-    response.headers["Content-Length"] = @file.size
-    send_file @file.absolute_path, disposition: disposition, type: @file.mime_type
+    status, headers, body = @file.attachment.to_rack_response(disposition: disposition)
+    self.status = status
+    self.headers.merge!(headers)
+    self.response_body = body
   rescue Errno::ENOENT
     head :internal_server_error
   end

--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -76,7 +76,7 @@ class ModelFilesController < ApplicationController
 
   def send_file_content(disposition: :attachment)
     response.headers["Content-Length"] = @file.size
-    send_file @file.pathname, disposition: disposition, type: @file.mime_type
+    send_file @file.absolute_path, disposition: disposition, type: @file.mime_type
   rescue Errno::ENOENT
     head :internal_server_error
   end

--- a/app/jobs/analysis/analyse_model_file_job.rb
+++ b/app/jobs/analysis/analyse_model_file_job.rb
@@ -10,7 +10,7 @@ class Analysis::AnalyseModelFileJob < ApplicationJob
     return if !file.exist?
     # If the file is modified, or we're lacking metadata
     status[:step] = "jobs.analysis.analyse_model_file.file_statistics" # i18n-tasks-use t('jobs.analysis.analyse_model_file.file_statistics')
-    if File.mtime(file.absolute_path) > file.updated_at || file.digest.nil? || file.size.nil?
+    if file.mtime > file.updated_at || file.digest.nil? || file.size.nil?
       file.digest = file.calculate_digest
       file.size = File.size(file.absolute_path)
       # If the digest has changed, queue up detailed geometric mesh analysis

--- a/app/jobs/analysis/analyse_model_file_job.rb
+++ b/app/jobs/analysis/analyse_model_file_job.rb
@@ -10,9 +10,8 @@ class Analysis::AnalyseModelFileJob < ApplicationJob
     return if !file.exist?
     # If the file is modified, or we're lacking metadata
     status[:step] = "jobs.analysis.analyse_model_file.file_statistics" # i18n-tasks-use t('jobs.analysis.analyse_model_file.file_statistics')
-    if file.mtime > file.updated_at || file.digest.nil? || file.size.nil?
+    if file.mtime > file.updated_at || file.digest.nil?
       file.digest = file.calculate_digest
-      file.size = File.size(file.absolute_path)
       # If the digest has changed, queue up detailed geometric mesh analysis
       Analysis::GeometricAnalysisJob.perform_later(file_id) if file.digest_changed?
       # Store updated file metadata

--- a/app/jobs/analysis/analyse_model_file_job.rb
+++ b/app/jobs/analysis/analyse_model_file_job.rb
@@ -7,7 +7,7 @@ class Analysis::AnalyseModelFileJob < ApplicationJob
     file = ModelFile.find(file_id)
     # Don't run analysis if the file is missing
     # The Problem is raised elsewhere.
-    return if !File.exist?(file.absolute_path)
+    return if !file.exist?
     # If the file is modified, or we're lacking metadata
     status[:step] = "jobs.analysis.analyse_model_file.file_statistics" # i18n-tasks-use t('jobs.analysis.analyse_model_file.file_statistics')
     if File.mtime(file.absolute_path) > file.updated_at || file.digest.nil? || file.size.nil?

--- a/app/jobs/analysis/file_conversion_job.rb
+++ b/app/jobs/analysis/file_conversion_job.rb
@@ -30,12 +30,12 @@ class Analysis::FileConversionJob < ApplicationJob
         filename: file.filename.gsub(".#{file.extension}", ".#{extension}")
       )
       dedup = 0
-      while File.exist?(new_file.pathname)
+      while File.exist?(new_file.absolute_path)
         dedup += 1
         new_file.filename = file.filename.gsub(".#{file.extension}", "-#{dedup}.#{extension}")
       end
       # Save the actual file in new format
-      exporter.export(file.mesh, new_file.pathname)
+      exporter.export(file.mesh, new_file.absolute_path)
       # Store record in database
       new_file.save
       # Queue up file scan

--- a/app/jobs/analysis/file_conversion_job.rb
+++ b/app/jobs/analysis/file_conversion_job.rb
@@ -30,7 +30,7 @@ class Analysis::FileConversionJob < ApplicationJob
         filename: file.filename.gsub(".#{file.extension}", ".#{extension}")
       )
       dedup = 0
-      while File.exist?(new_file.absolute_path)
+      while new_file.exist?
         dedup += 1
         new_file.filename = file.filename.gsub(".#{file.extension}", "-#{dedup}.#{extension}")
       end

--- a/app/jobs/model_file_scan_job.rb
+++ b/app/jobs/model_file_scan_job.rb
@@ -5,7 +5,7 @@ class ModelFileScanJob < ApplicationJob
     file = ModelFile.find(file_id)
     # Try to guess if the file is presupported
     if !(
-      file.pathname.split(/[[:punct:]]|[[:space:]]/).map(&:downcase) & ModelFile::SUPPORT_KEYWORDS
+      file.absolute_path.split(/[[:punct:]]|[[:space:]]/).map(&:downcase) & ModelFile::SUPPORT_KEYWORDS
     ).empty?
       file.update!(presupported: true)
     end

--- a/app/jobs/model_scan_job.rb
+++ b/app/jobs/model_scan_job.rb
@@ -22,12 +22,11 @@ class ModelScanJob < ApplicationJob
 
   def perform(model_id)
     model = Model.find(model_id)
-    model_path = File.join(model.library.path, model.path)
-    return if Problem.create_or_clear(model, :missing, !File.exist?(model_path))
+    return if Problem.create_or_clear(model, :missing, !model.exist?)
     # For each file in the model, create a file object
-    file_list(model_path).each do |filename|
+    file_list(model.absolute_path).each do |filename|
       # Create the file
-      file = model.model_files.find_or_create_by(filename: filename.gsub(model_path + "/", ""))
+      file = model.model_files.find_or_create_by(filename: filename.gsub(model.absolute_path + "/", ""))
       ModelFileScanJob.perform_later(file.id) if file.valid?
     end
     # Set tags and default files

--- a/app/jobs/scan/check_model_integrity_job.rb
+++ b/app/jobs/scan/check_model_integrity_job.rb
@@ -3,13 +3,13 @@ class Scan::CheckModelIntegrityJob < ApplicationJob
 
   def perform(model_id)
     model = Model.find(model_id)
-    Problem.create_or_clear(model, :missing, !File.exist?(File.join(model.library.path, model.path)))
+    Problem.create_or_clear(model, :missing, !model.exist?)
     Problem.create_or_clear model, :empty, (model.model_files.count == 0)
     Problem.create_or_clear model, :nesting, model.contains_other_models?
     Problem.create_or_clear model, :no_image, model.image_files.empty?
     Problem.create_or_clear model, :no_3d_model, model.three_d_files.empty?
     model.model_files.each do |f|
-      Problem.create_or_clear(f, :missing, !File.exist?(File.join(model.library.path, model.path, f.filename)))
+      Problem.create_or_clear(f, :missing, !f.exist?)
     end
   end
 end

--- a/app/jobs/scan/detect_filesystem_changes_job.rb
+++ b/app/jobs/scan/detect_filesystem_changes_job.rb
@@ -10,9 +10,7 @@ class Scan::DetectFilesystemChangesJob < ApplicationJob
 
   # Get a list of all the existing filenames
   def known_filenames(library)
-    library.model_files.reload.map do |x|
-      File.join(library.path, x.model.path, x.filename)
-    end
+    library.model_files.reload.map(&:absolute_path)
   end
 
   def filter_out_common_subfolders(folders)

--- a/app/jobs/scan/detect_filesystem_changes_job.rb
+++ b/app/jobs/scan/detect_filesystem_changes_job.rb
@@ -23,7 +23,7 @@ class Scan::DetectFilesystemChangesJob < ApplicationJob
   def perform(library_id)
     library = Library.find(library_id)
     return if library.nil?
-    return if Problem.create_or_clear(library, :missing, !File.exist?(library.path))
+    return if Problem.create_or_clear(library, :missing, !library.exist?)
     # Make a list of changed filenames using set XOR
     status[:step] = "jobs.scan.detect_filesystem_changes.building_filename_list" # i18n-tasks-use t('jobs.scan.detect_filesystem_changes.building_filename_list')
     changes = (known_filenames(library).to_set ^ filenames_on_disk(library)).to_a

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -1,3 +1,5 @@
+require "shrine/storage/memory"
+
 class Library < ApplicationRecord
   has_many :models, dependent: :destroy
   has_many :model_files, through: :models
@@ -5,6 +7,7 @@ class Library < ApplicationRecord
   serialize :tag_regex, type: Array
   after_initialize :init
   before_validation :ensure_path_case_is_correct
+  after_save :register_storage
 
   validates :path, presence: true, uniqueness: true, existing_path: true
 
@@ -33,6 +36,19 @@ class Library < ApplicationRecord
   def free_space
     stat = Sys::Filesystem.stat(path)
     stat.bytes_available
+  end
+
+  def storage_key
+    "library_#{id}"
+  end
+
+  def storage
+    return Shrine::Storage::Memory.new if Rails.env.test?
+    Shrine::Storage::FileSystem.new(path)
+  end
+
+  def register_storage
+    Shrine.storages[storage_key] = storage
   end
 
   private

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -47,7 +47,6 @@ class Library < ApplicationRecord
   end
 
   def storage
-    return Shrine::Storage::Memory.new if Rails.env.test?
     Shrine::Storage::FileSystem.new(path)
   end
 

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -21,6 +21,10 @@ class Library < ApplicationRecord
     self.name = nil if name == ""
   end
 
+  def exist?
+    Dir.exist?(path)
+  end
+
   def all_tags
     models.includes(:tags).map(&:tags).flatten.uniq.sort_by(&:name)
   end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -115,6 +115,10 @@ class Model < ApplicationRecord
     model_files.select(&:is_3d_model?)
   end
 
+  def exist?
+    Dir.exist?(absolute_path)
+  end
+
   private
 
   def normalize_license

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -165,9 +165,15 @@ class Model < ApplicationRecord
     # Sometimes, if we're trimming separators or normalising paths, we get here
     # but the path hasn't actually changed on disk. In that case, we're done.
     return if absolute_path == previous_absolute_path
-    # Move the folder
-    FileUtils.mkdir_p(File.dirname(absolute_path))
-    File.rename(previous_absolute_path, absolute_path)
+    # Move all the files
+    model_files.each(&:reattach!)
+    if model_files.empty?
+      # Move the empty folder by hand
+      FileUtils.mkdir_p(File.dirname(absolute_path))
+      File.rename(previous_absolute_path, absolute_path)
+    end
+    # Remove the old folder if it's still there and empty
+    Dir.rmdir(previous_absolute_path) if Dir.exist?(previous_absolute_path) && Dir.empty?(previous_absolute_path)
   end
 
   def slugify_name

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -65,7 +65,7 @@ class Model < ApplicationRecord
     # Trigger deletion for each file separately, to make sure cleanup happens
     model_files.each { |f| f.delete_from_disk_and_destroy }
     # Delete directory corresponding to model
-    FileUtils.remove_dir(absolute_path) if File.exist?(absolute_path)
+    FileUtils.remove_dir(absolute_path) if exist?
     # Remove from DB
     destroy
   end

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -61,12 +61,12 @@ class ModelFile < ApplicationRecord
     basename.humanize.titleize
   end
 
-  def pathname
-    File.join(model.library.path, model.path, filename)
+  def absolute_path
+    File.join(model.absolute_path, filename)
   end
 
   def calculate_digest
-    Digest::SHA512.new.file(pathname).hexdigest
+    Digest::SHA512.new.file(absolute_path).hexdigest
   rescue Errno::ENOENT
     nil
   end
@@ -94,7 +94,7 @@ class ModelFile < ApplicationRecord
 
   def delete_from_disk_and_destroy
     # Delete actual file
-    FileUtils.rm(pathname) if File.exist?(pathname)
+    FileUtils.rm(absolute_path) if File.exist?(absolute_path)
     # Rescan any duplicates
     duplicates.each { |x| Analysis::AnalyseModelFileJob.perform_later(x.id) }
     # Remove the db record
@@ -118,7 +118,7 @@ class ModelFile < ApplicationRecord
   end
 
   def mesh
-    loader&.new&.load(pathname)
+    loader&.new&.load(absolute_path)
   end
   memoize :mesh
 

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -122,8 +122,6 @@ class ModelFile < ApplicationRecord
   end
 
   def delete_from_disk_and_destroy
-    # Delete actual file
-    FileUtils.rm(absolute_path) if exist?
     # Rescan any duplicates
     duplicates.each { |x| Analysis::AnalyseModelFileJob.perform_later(x.id) }
     # Remove the db record

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -53,8 +53,8 @@ class ModelFile < ApplicationRecord
     Mime::Type.lookup_by_extension(extension)
   end
 
-  def basename
-    File.basename(filename, ".*")
+  def basename(include_extension: false)
+    File.basename(filename, include_extension ? "" : ".*")
   end
 
   def name
@@ -63,6 +63,10 @@ class ModelFile < ApplicationRecord
 
   def absolute_path
     File.join(model.absolute_path, filename)
+  end
+
+  def path_within_library
+    File.join(model.path, filename)
   end
 
   def exist?

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -69,6 +69,10 @@ class ModelFile < ApplicationRecord
     File.exist?(absolute_path)
   end
 
+  def mtime
+    File.mtime(absolute_path)
+  end
+
   def calculate_digest
     Digest::SHA512.new.file(absolute_path).hexdigest
   rescue Errno::ENOENT

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -149,6 +149,11 @@ class ModelFile < ApplicationRecord
   end
   memoize :mesh
 
+  def reattach!
+    attachment_attacher.assign attachment
+    save!
+  end
+
   private
 
   def presupported_files_cannot_have_presupported_version

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -69,6 +69,16 @@ class ModelFile < ApplicationRecord
     File.join(model.path, filename)
   end
 
+  def attach_existing_file!
+    attachment_attacher.set Shrine.uploaded_file(
+      storage: model.library.storage_key,
+      id: path_within_library,
+      metadata: {filename: basename(include_extension: true)}
+    )
+    attachment_attacher.refresh_metadata!
+    save!
+  end
+
   def exist?
     File.exist?(absolute_path)
   end

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -6,6 +6,8 @@ class ModelFile < ApplicationRecord
   belongs_to :model
   has_many :problems, as: :problematic, dependent: :destroy
 
+  after_create :attach_existing_file!
+
   belongs_to :presupported_version, class_name: "ModelFile", optional: true
   has_one :unsupported_version, class_name: "ModelFile", foreign_key: "presupported_version_id",
     inverse_of: :presupported_version, dependent: :nullify
@@ -70,6 +72,7 @@ class ModelFile < ApplicationRecord
   end
 
   def attach_existing_file!
+    return if attachment.present?
     attachment_attacher.set Shrine.uploaded_file(
       storage: model.library.storage_key,
       id: path_within_library,

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -65,6 +65,10 @@ class ModelFile < ApplicationRecord
     File.join(model.absolute_path, filename)
   end
 
+  def exist?
+    File.exist?(absolute_path)
+  end
+
   def calculate_digest
     Digest::SHA512.new.file(absolute_path).hexdigest
   rescue Errno::ENOENT
@@ -94,7 +98,7 @@ class ModelFile < ApplicationRecord
 
   def delete_from_disk_and_destroy
     # Delete actual file
-    FileUtils.rm(absolute_path) if File.exist?(absolute_path)
+    FileUtils.rm(absolute_path) if exist?
     # Rescan any duplicates
     duplicates.each { |x| Analysis::AnalyseModelFileJob.perform_later(x.id) }
     # Remove the db record

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -1,4 +1,6 @@
 class ModelFile < ApplicationRecord
+  include LibraryUploader::Attachment(:attachment)
+
   extend Memoist
 
   belongs_to :model
@@ -27,7 +29,15 @@ class ModelFile < ApplicationRecord
     withsupports
   ]
 
+  def size
+    attachment.size
+  rescue
+    attributes["size"]
+  end
+
   def extension
+    attachment.extension
+  rescue
     File.extname(filename).delete(".").downcase
   end
 

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -37,6 +37,10 @@ class ModelFile < ApplicationRecord
     attributes["size"]
   end
 
+  def size=(value)
+    ActiveSupport::Deprecation.warn("size is now set by Shrine")
+  end
+
   def extension
     attachment.extension
   rescue

--- a/app/uploaders/library_uploader.rb
+++ b/app/uploaders/library_uploader.rb
@@ -12,7 +12,7 @@ class LibraryUploader < Shrine
   end
 
   def generate_location(io, record: nil, derivative: nil, metadata: {}, **)
-    return super unless record
+    return super unless record&.valid?
     record.path_within_library
   end
 end

--- a/app/uploaders/library_uploader.rb
+++ b/app/uploaders/library_uploader.rb
@@ -1,0 +1,19 @@
+class LibraryUploader < Shrine
+  plugin :dynamic_storage
+
+  storage /store_(\d)/ do |m|
+    Library.find(m[1]).storage
+  end
+
+  class Attacher
+    def store_key
+      @record.model.library.storage_key
+    end
+  end
+
+  def generate_location(io, record: nil, derivative: nil, metadata: {}, **)
+    return super unless record
+    File.join(record.model.path, record.filename)
+  end
+
+end

--- a/app/uploaders/library_uploader.rb
+++ b/app/uploaders/library_uploader.rb
@@ -1,7 +1,7 @@
 class LibraryUploader < Shrine
   plugin :dynamic_storage
 
-  storage(/store_(\d)/) do |m|
+  storage(/library_(\d)/) do |m|
     Library.find(m[1]).storage
   end
 

--- a/app/uploaders/library_uploader.rb
+++ b/app/uploaders/library_uploader.rb
@@ -13,6 +13,6 @@ class LibraryUploader < Shrine
 
   def generate_location(io, record: nil, derivative: nil, metadata: {}, **)
     return super unless record
-    File.join(record.model.path, record.filename)
+    record.path_within_library
   end
 end

--- a/app/uploaders/library_uploader.rb
+++ b/app/uploaders/library_uploader.rb
@@ -1,7 +1,7 @@
 class LibraryUploader < Shrine
   plugin :dynamic_storage
 
-  storage /store_(\d)/ do |m|
+  storage(/store_(\d)/) do |m|
     Library.find(m[1]).storage
   end
 
@@ -15,5 +15,4 @@ class LibraryUploader < Shrine
     return super unless record
     File.join(record.model.path, record.filename)
   end
-
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -35,7 +35,7 @@ module Manyfold
     # in config/environments, which are processed later.
     #
     # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
+    config.eager_load_paths << config.root.join("app/uploaders")
 
     # Load locale files in nested folders as well as locale root
     config.i18n.load_path += Dir[Rails.root.join("config/locales/**/*.{rb,yml}")]

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -2,6 +2,8 @@ require "shrine"
 require "shrine/storage/file_system"
 
 Shrine.plugin :activerecord
+Shrine.plugin :refresh_metadata
+Shrine.plugin :determine_mime_type
 
 Shrine.storages = {
   cache: Shrine::Storage::FileSystem.new("tmp/cache")

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -4,6 +4,7 @@ require "shrine/storage/file_system"
 Shrine.plugin :activerecord
 Shrine.plugin :refresh_metadata
 Shrine.plugin :determine_mime_type
+Shrine.plugin :rack_response
 
 Shrine.storages = {
   cache: Shrine::Storage::FileSystem.new("tmp/cache")

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -9,4 +9,6 @@ Shrine.storages = {
 
 Rails.application.config.after_initialize do
   Library.find_each(&:register_storage)
+rescue ActiveRecord::StatementInvalid
+  nil # migrations probably haven't run yet to create library table
 end

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -1,0 +1,12 @@
+require "shrine"
+require "shrine/storage/file_system"
+
+Shrine.plugin :activerecord
+
+Shrine.storages = {
+  cache: Shrine::Storage::FileSystem.new("tmp/cache")
+}
+
+Rails.application.config.after_initialize do
+  Library.find_each(&:register_storage)
+end

--- a/db/data/20240615085913_move_file_data_into_shrine.rb
+++ b/db/data/20240615085913_move_file_data_into_shrine.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class MoveFileDataIntoShrine < ActiveRecord::Migration[7.0]
+  def up
+    ModelFile.find_each(&:attach_existing_file!)
+  end
+
+  def down
+  end
+end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240322150022)
+DataMigrate::Data.define(version: 20240615085913)

--- a/db/migrate/20240614085913_add_attachment_data_to_model_files.rb
+++ b/db/migrate/20240614085913_add_attachment_data_to_model_files.rb
@@ -1,0 +1,5 @@
+class AddAttachmentDataToModelFiles < ActiveRecord::Migration[7.0]
+  def change
+    add_column :model_files, :attachment_data, :json
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2024_06_10_120318) do
+ActiveRecord::Schema[7.1].define(version: 2024_06_14_085913) do
   create_table "collections", force: :cascade do |t|
     t.string "name"
     t.text "notes"
@@ -105,6 +105,7 @@ ActiveRecord::Schema[7.0].define(version: 2024_06_10_120318) do
     t.text "caption"
     t.bigint "size"
     t.integer "presupported_version_id"
+    t.json "attachment_data"
     t.index ["digest"], name: "index_model_files_on_digest"
     t.index ["filename", "model_id"], name: "index_model_files_on_filename_and_model_id", unique: true
     t.index ["model_id"], name: "index_model_files_on_model_id"

--- a/spec/factories/model.rb
+++ b/spec/factories/model.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :model do
+    library
     name { Faker::Creature::Animal.name }
     path { Faker::File.dir }
-    library
     license { "MIT" }
   end
 end

--- a/spec/factories/model_file.rb
+++ b/spec/factories/model_file.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :model_file do
-    filename { Faker::File.file_name(ext: "stl") }
     model
+    filename { Faker::File.file_name(ext: "stl") }
+    attachment { Rack::Test::UploadedFile.new StringIO.new, original_filename: filename }
   end
 end

--- a/spec/factories/model_file.rb
+++ b/spec/factories/model_file.rb
@@ -2,6 +2,6 @@ FactoryBot.define do
   factory :model_file do
     model
     filename { Faker::File.file_name(ext: "stl") }
-    attachment { Rack::Test::UploadedFile.new StringIO.new, original_filename: filename }
+    attachment { filename ? Rack::Test::UploadedFile.new(StringIO.new, original_filename: filename) : nil }
   end
 end

--- a/spec/jobs/analysis/analyse_model_file_job_spec.rb
+++ b/spec/jobs/analysis/analyse_model_file_job_spec.rb
@@ -3,27 +3,19 @@ require "support/mock_directory"
 
 RSpec.describe Analysis::AnalyseModelFileJob do
   context "with an existing file" do
-    let(:file) { create(:model_file, filename: "test.3mf", digest: "deadc0de", size: 1) }
+    let(:file) { create(:model_file, filename: "test.3mf", digest: "deadc0de") }
 
     before do
       allow(ModelFile).to receive(:find).with(file.id).and_return(file)
       allow(File).to receive(:exist?).and_return(true)
       allow(File).to receive(:mtime).once.and_return(1.day.ago)
       allow(file).to receive(:calculate_digest).once.and_return("deadbeef")
-      allow(File).to receive(:size).once.and_return(1234)
     end
 
     it "calculates file digest if not set" do
       file.update!(digest: nil)
       expect { described_class.perform_now file.id }.to(
         change(file, :digest).from(nil).to("deadbeef")
-      )
-    end
-
-    it "calculates file size if not set" do
-      file.update!(size: nil)
-      expect { described_class.perform_now file.id }.to(
-        change(file, :size).from(nil).to(1234)
       )
     end
 

--- a/spec/jobs/analysis/analyse_model_file_job_spec.rb
+++ b/spec/jobs/analysis/analyse_model_file_job_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Analysis::AnalyseModelFileJob do
       )
     end
 
-    it "queues geometric analysis if file digest doesn't change" do
+    it "doesn't queue geometric analysis if file digest doesn't change" do
       expect { described_class.perform_now file.id }.not_to(
         have_enqueued_job(Analysis::GeometricAnalysisJob)
       )

--- a/spec/jobs/analysis/analyse_model_file_job_spec.rb
+++ b/spec/jobs/analysis/analyse_model_file_job_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Analysis::AnalyseModelFileJob do
 
     it "detects ASCII STL files and creates a Problem record" do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
       allow(file).to receive(:extension).and_return("stl")
-      allow(File).to receive(:read).with(file.pathname, 6).once.and_return("solid ")
+      allow(File).to receive(:read).with(file.absolute_path, 6).once.and_return("solid ")
       expect { described_class.perform_now file.id }.to change(Problem, :count).from(0).to(1)
       expect(Problem.first.category).to eq "inefficient"
       expect(Problem.first.note).to eq "ASCII STL"
@@ -57,7 +57,7 @@ RSpec.describe Analysis::AnalyseModelFileJob do
 
     it "detects ASCII PLY files and creates a Problem record" do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
       allow(file).to receive(:extension).and_return("ply")
-      allow(File).to receive(:read).with(file.pathname, 16).once.and_return("ply\rformat ascii")
+      allow(File).to receive(:read).with(file.absolute_path, 16).once.and_return("ply\rformat ascii")
       expect { described_class.perform_now file.id }.to change(Problem, :count).from(0).to(1)
       expect(Problem.first.category).to eq "inefficient"
       expect(Problem.first.note).to eq "ASCII PLY"

--- a/spec/jobs/analysis/file_conversion_job_spec.rb
+++ b/spec/jobs/analysis/file_conversion_job_spec.rb
@@ -42,17 +42,17 @@ RSpec.describe Analysis::FileConversionJob do
     end
 
     it "avoids filenames that already exist" do
-      allow(File).to receive(:exist?).with(file.pathname.gsub(".stl", ".3mf")).and_return(true).once
-      allow(File).to receive(:exist?).with(file.pathname.gsub(".stl", "-1.3mf")).and_return(true).once
-      allow(File).to receive(:exist?).with(file.pathname.gsub(".stl", "-2.3mf")).and_return(false).once
+      allow(File).to receive(:exist?).with(file.absolute_path.gsub(".stl", ".3mf")).and_return(true).once
+      allow(File).to receive(:exist?).with(file.absolute_path.gsub(".stl", "-1.3mf")).and_return(true).once
+      allow(File).to receive(:exist?).with(file.absolute_path.gsub(".stl", "-2.3mf")).and_return(false).once
       described_class.perform_now(file.id, :threemf)
       expect(ModelFile.where.not(id: file.id).first.filename).to eq "files/awesome-2.3mf"
     end
 
     it "creates an actual 3MF file on disk" do
       described_class.perform_now(file.id, :threemf)
-      pathname = ModelFile.where.not(id: file.id).first.pathname
-      expect(File.exist?(pathname)).to be true
+      absolute_path = ModelFile.where.not(id: file.id).first.absolute_path
+      expect(File.exist?(absolute_path)).to be true
     end
 
     it "does not remove the original file" do

--- a/spec/jobs/scan/check_model_integrity_job_spec.rb
+++ b/spec/jobs/scan/check_model_integrity_job_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Scan::CheckModelIntegrityJob do
 
     it "flags up problems for files that don't exist on disk" do
       thing = create(:model, path: "model_one", library: library)
-      create(:model_file, filename: "missing.stl", model: thing)
+      model = create(:model_file, filename: "missing.stl", model: thing)
+      File.delete(model.absolute_path)
       described_class.perform_now(thing.id)
       expect(thing.model_files.first.problems.map(&:category)).to include("missing")
     end

--- a/spec/models/library_spec.rb
+++ b/spec/models/library_spec.rb
@@ -1,11 +1,11 @@
 require "rails_helper"
 
 RSpec.describe Library do
-  before do
-    allow(File).to receive(:exist?).with("/library1").and_return(true)
-    allow(Dir).to receive(:glob).and_call_original
-    allow(Dir).to receive(:glob).with("/library1").and_return(["/library1"])
-    allow(File).to receive(:exist?).with("/nope").and_return(false)
+  around do |ex|
+    MockDirectory.create([]) do |path|
+      @library_path = path
+      ex.run
+    end
   end
 
   it "is not valid without a path" do
@@ -13,7 +13,7 @@ RSpec.describe Library do
   end
 
   it "is valid if a path is specified" do
-    expect(build(:library, path: "/library1")).to be_valid
+    expect(build(:library, path: @library_path)).to be_valid # rubocop:todo RSpec/InstanceVariable
   end
 
   it "is invalid if a bad path is specified" do # rubocop:todo RSpec/MultipleExpectations
@@ -27,7 +27,7 @@ RSpec.describe Library do
   end
 
   it "must have a unique path" do
-    create(:library, path: "/library1")
-    expect(build(:library, path: "/library1")).not_to be_valid
+    create(:library, path: @library_path) # rubocop:todo RSpec/InstanceVariable
+    expect(build(:library, path: @library_path)).not_to be_valid # rubocop:todo RSpec/InstanceVariable
   end
 end

--- a/spec/models/model_file_spec.rb
+++ b/spec/models/model_file_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ModelFile do
 
     it "removes original file from disk" do
       expect { file.delete_from_disk_and_destroy }.to(
-        change { File.exist?(file.pathname) }.from(true).to(false)
+        change { File.exist?(file.absolute_path) }.from(true).to(false)
       )
     end
 

--- a/spec/models/model_file_spec.rb
+++ b/spec/models/model_file_spec.rb
@@ -35,6 +35,14 @@ RSpec.describe ModelFile do
     expect(part.bounding_box).to eq([10, 15, 20])
   end
 
+  it "calculates file size when attached" do
+    allow(File).to receive(:size).once.and_return(1234)
+    library = create(:library, path: Rails.root.join("spec/fixtures"))
+    model1 = create(:model, library: library, path: "model_file_spec")
+    part = create(:model_file, model: model1, filename: "example.obj", attachment: nil)
+    expect(part.size).to eq(284)
+  end
+
   it "finds duplicate files using digest" do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
     library = create(:library, path: Rails.root.join("/tmp"))
     model1 = create(:model, library: library, path: "model1")

--- a/spec/models/model_file_spec.rb
+++ b/spec/models/model_file_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe ModelFile do
   it "calculates a bounding box for model" do
     library = create(:library, path: Rails.root.join("spec/fixtures"))
     model1 = create(:model, library: library, path: "model_file_spec")
-    part = create(:model_file, model: model1, filename: "example.obj")
+    part = create(:model_file, model: model1, filename: "example.obj", attachment: nil)
     expect(part.bounding_box).to eq([10, 15, 20])
   end
 

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -144,12 +144,17 @@ RSpec.describe Model do
   end
 
   context "when nested inside another with underscores in the name" do
-    before do
-      allow(File).to receive(:exist?).and_call_original
-      allow(File).to receive(:exist?).with("/library").and_return(true)
+    around do |ex|
+      MockDirectory.create([
+        "model_one/part.stl",
+        "model_one/nested_model/part.stl"
+      ]) do |path|
+        @library_path = path
+        ex.run
+      end
     end
 
-    let(:library) { create(:library, path: "/library") }
+    let(:library) { create(:library, path: @library_path) } # rubocop:todo RSpec/InstanceVariable
     let!(:parent) { create(:model, library: library, path: "model_one") }
     let!(:child) { create(:model, library: library, path: "model_one/nested_model") }
 

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -74,33 +74,42 @@ RSpec.describe Model do
   end
 
   context "with a library on disk" do
-    before do
-      allow(File).to receive(:exist?).and_call_original
-      allow(File).to receive(:exist?).with("/original_library").and_return(true)
-      allow(File).to receive(:exist?).with("/new_library").and_return(true)
+    around do |ex|
+      MockDirectory.create([
+        "original_library/model/part.stl",
+        "new_library/model/part.stl"
+      ]) do |path|
+        @libraries_path = path
+        ex.run
+      end
     end
 
     it "must have a unique path within its library" do
-      library = create(:library, path: "/original_library")
+      library = create(:library, path: "#{@libraries_path}/original_library") # rubocop:todo RSpec/InstanceVariable
       create(:model, library: library, path: "model")
       expect(build(:model, library: library, path: "model")).not_to be_valid
     end
 
     it "can have the same path as a model in a different library" do
-      original_library = create(:library, path: "/original_library")
+      original_library = create(:library, path: "#{@libraries_path}/original_library") # rubocop:todo RSpec/InstanceVariable
       create(:model, library: original_library, path: "model")
-      new_library = create(:library, path: "/new_library")
+      new_library = create(:library, path: "#{@libraries_path}/new_library") # rubocop:todo RSpec/InstanceVariable
       expect(build(:model, library: new_library, path: "model")).to be_valid
     end
   end
 
   context "when nested inside another" do
-    before do
-      allow(File).to receive(:exist?).and_call_original
-      allow(File).to receive(:exist?).with("/library").and_return(true)
+    around do |ex|
+      MockDirectory.create([
+        "parent/part.stl",
+        "parent/child/part.stl"
+      ]) do |path|
+        @library_path = path
+        ex.run
+      end
     end
 
-    let(:library) { create(:library, path: "/library") }
+    let(:library) { create(:library, path: @library_path) } # rubocop:todo RSpec/InstanceVariable
     let!(:parent) { create(:model, library: library, path: "parent") }
     let!(:child) { create(:model, library: library, path: "parent/child") }
 


### PR DESCRIPTION
Integrating [Shrine](https://shrinerb.com/) to make storage provider-agnostic, and enable a few other features. Ground work for #1670.

Things to still change:

* [x] Removing models
* [x] Removing files
* [x] Uploading files
* [x] Downloading files
* [x] Moving models within a library
* [x] Moving models between libraries
