### PR TITLE
Add  target="_blank" to footer links

### DIFF
--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -25,16 +25,16 @@
     <div class="col-4 col-lg-2 mb-3">
       <h5><%= t ".development_heading" %></h5>
       <ul class="list-unstyled">
-        <li class="mb-2"><a href="https://github.com/manyfold3d/manyfold"><%= t ".code" %></a></li>
-        <li class="mb-2"><a href="https://github.com/manyfold3d/manyfold/issues"><%= t ".issues" %></a></li>
+        <li class="mb-2"><a href="https://github.com/manyfold3d/manyfold" target="_blank"><%= t ".code" %></a></li>
+        <li class="mb-2"><a href="https://github.com/manyfold3d/manyfold/issues" target="_blank"><%= t ".issues" %></a></li>
       </ul>
     </div>
     <div class="col-4 col-lg-2 mb-3">
       <h5><%= t ".community_heading" %></h5>
       <ul class="list-unstyled">
-        <li class="mb-2"><a href="https://matrix.to/#/#manyfold:one.ems.host"><%= t ".chat" %></a></li>
-        <li class="mb-2"><a href="https://3dp.chat/@manyfold"><%= t ".social" %></a></li>
-        <li class="mb-2"><a href="https://opencollective.com/manyfold"><%= t ".sponsor" %></a></li>
+        <li class="mb-2"><a href="https://matrix.to/#/#manyfold:one.ems.host" target="_blank"><%= t ".chat" %></a></li>
+        <li class="mb-2"><a href="https://3dp.chat/@manyfold" target="_blank"><%= t ".social" %></a></li>
+        <li class="mb-2"><a href="https://opencollective.com/manyfold" target="_blank"><%= t ".sponsor" %></a></li>
       </ul>
     </div>
   </div>

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -10,7 +10,7 @@
         <li class="mb-2"><%= t ".open_source_html" %></li>
         <li class="mb-2"><%= t ".version" %>:
           <%= link_to "#{ENV.fetch("APP_VERSION", "unknown").split(":")[-1]} (#{ENV.fetch("GIT_SHA", "main")[0, 7]})",
-                "https://github.com/manyfold3d/manyfold/tree/#{ENV.fetch("GIT_SHA", "main")}", target: "_blank" %>
+                "https://github.com/manyfold3d/manyfold/tree/#{ENV.fetch("GIT_SHA", "main")}", target: "_blank", rel: "noopener" %>
         </li>
       </ul>
     </div>

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -10,7 +10,7 @@
         <li class="mb-2"><%= t ".open_source_html" %></li>
         <li class="mb-2"><%= t ".version" %>:
           <%= link_to "#{ENV.fetch("APP_VERSION", "unknown").split(":")[-1]} (#{ENV.fetch("GIT_SHA", "main")[0, 7]})",
-                "https://github.com/manyfold3d/manyfold/tree/#{ENV.fetch("GIT_SHA", "main")}" %>
+                "https://github.com/manyfold3d/manyfold/tree/#{ENV.fetch("GIT_SHA", "main")}", target: "_blank" %>
         </li>
       </ul>
     </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -189,14 +189,14 @@ en:
       title: Filters
       unknown: Unknown
     footer:
-      by_html: Designed and built by <a href="https://floppy.org.uk">James</a> with help from <a href="https://github.com/manyfold3d/manyfold/graphs/contributors">our contributors</a>.
+      by_html: Designed and built by <a href="https://floppy.org.uk" target="_blank">James</a> with help from <a href="https://github.com/manyfold3d/manyfold/graphs/contributors" target="_blank">our contributors</a>.
       chat: Chat
       code: Code
       community_heading: Community
       development_heading: Development
       issues: Issues
       logo: Logo
-      open_source_html: Open Source under the <a href="https://github.com/manyfold3d/manyfold/blob/main/LICENSE.md" target="_blank" rel="license noopener">MIT license</a>.
+      open_source_html: Open Source under the <a href="https://github.com/manyfold3d/manyfold/blob/main/LICENSE.md" target="_blank" rel="license">MIT license</a>.
       social: Social
       sponsor: Sponsor
       stats_heading: Stats


### PR DESCRIPTION
Adding an affordance to open non-internal links in a new tab to avoid confusion and help users posting issues without having to destroy the current UI state

## Checklist

- [X] Make sure you are making a pull request against our **main branch** (left side)
- [X] Check that that your branch is up to date with our main.
- [X] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [ ] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

None

## Summary

- Adds `target="_blank"` to footer urls pointing to external domains

## Linked issues

None

## Description of changes

- Makes the links in the footer open new tabs/windows for all external domains
- If you are concerned with security, [modern browsers now default](https://chromestatus.com/feature/6140064063029248) to `rel="noopener"` to avoid rogue JS taking over the requesting site
