### PR TITLE
Improve automatic part grouping in models

### DIFF
--- a/app/helpers/models_helper.rb
+++ b/app/helpers/models_helper.rb
@@ -1,5 +1,6 @@
 module ModelsHelper
   def group(files)
+    return {} if files.empty?
     sections = {}
     min_section_size = 2
     min_prefix_length = 3
@@ -16,7 +17,7 @@ module ModelsHelper
       end
     end
     # Sort and include empty set
-    { nil => files }.merge sections.sort_by {|k, v| k }.to_h
+    {nil => files}.merge sections.sort_by { |k, v| k }.to_h
   end
 
   def status_badges(model)

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -17,7 +17,7 @@
     <%= render partial: "file", collection: @groups.delete(nil) %>
   </div>
   <% @groups.each_pair do |group, files| %>
-    <h3><a name="<%= group.parameterize %>"><%= group %></a></h3>
+    <h3><a name="<%= group.parameterize %>"><%= group.titleize %></a></h3>
     <div class="row  row-cols-1 row-cols-md-2 row-cols-lg-3 mb-4">
       <%= render partial: "file", collection: files %>
     </div>
@@ -95,7 +95,7 @@
     <a href="#files">Top</a>
     <ul>
       <% @groups.each_pair do |group, files| %>
-        <li><a href="#<%= group.parameterize %>"><%= group %></a></li>
+        <li><a href="#<%= group.parameterize %>"><%= group.titleize %></a></li>
       <% end %>
     </ul>
     <%= link_to t(".files_card.bulk_edit"), bulk_edit_library_model_model_files_path(@model.library, @model), class: "btn btn-secondary" if policy(@model).edit? %>

--- a/spec/helpers/models_helper_spec.rb
+++ b/spec/helpers/models_helper_spec.rb
@@ -4,18 +4,18 @@ RSpec.describe ModelsHelper do
   describe "string concat" do
     let(:files) do
       %w[
-        foo
-        bar
-        foobar
-        foo_bar
-        bar_foo
+        armleft
+        arm_right
+        head_1
+        leg_l
+        leg_r
       ].map { |x| build(:model_file, filename: "#{x}.stl") }
     end
 
     it "groups strings together with similar prefixes" do # rubocop:todo RSpec/MultipleExpectations
       groups = helper.group(files)
-      expect(groups["foo"].count).to eq(2)
-      expect(groups["bar"].count).to eq(2)
+      expect(groups["leg_"].count).to eq(2)
+      expect(groups["arm"].count).to eq(2)
       expect(groups[nil].count).to eq(1)
     end
   end


### PR DESCRIPTION
Instead of a very naïve "split-on-first-non-alphabetical-char" approach, instead we reverse-search for longest common strings to make groups of larger than a certain size. Much more like what I wanted.

resolves #50 
