### PR TITLE
Show admins a security alert if container is being run as root

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,6 +6,7 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   around_action :switch_locale
   before_action :check_for_first_use
+  before_action :show_security_alerts
   before_action :check_scan_status
   before_action :remember_ordering
 
@@ -40,5 +41,10 @@ class ApplicationController < ActionController::Base
   def switch_locale(&action)
     locale = current_user&.interface_language || request.env["rack.locale"]
     I18n.with_locale(locale, &action)
+  end
+
+  def show_security_alerts
+    return unless current_user&.is_administrator?
+    flash.now[:alert] = t("security.running_as_root_html") if Process.uid == 0
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -313,6 +313,8 @@ en:
       webglrenderer: Could not create renderer!
     load: Load
     processing: Reticulating splines...
+  security:
+    running_as_root_html: Manyfold is running as root, which is a security risk. Run as a different system user by setting the <code>PUID</code> and <code>PGID</code> environment variables. See <a href='https://manyfold.app/sysadmin/configuration.html#required'>the configuration documentation</a> for details.
   sites:
     cgtrader: CGTrader
     comicsgamesandthings: Comics, Games, and Things


### PR DESCRIPTION
As part of fix for #2240 and #1704, warn the user if they're running in an insecure mode, and provide instructions on how to fix it. Shown to admins only.