### PR TITLE
Add PUID and PGID env vars to control which user the app runs as

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,13 @@ ENV RAILS_SERVE_STATIC_FILES=true
 ENV APP_VERSION=${APP_VERSION}
 ENV GIT_SHA=${GIT_SHA}
 
+# PUID and PGID env vars - these control what user the app is run as inside
+# the entrypoint script. Default to root for backwards compatibility with existing
+# installations, but the admin will be warned if these aren't overridden with something
+# else at runtime, and this default will be removed in future.
+ENV PUID=0
+ENV PGID=0
+
 WORKDIR /usr/src/app
 
 COPY package.json .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,17 @@
 FROM ruby:3.3.0-alpine3.18 AS build
 
-RUN apk add --no-cache tzdata alpine-sdk postgresql-dev nodejs yarn xz libarchive mesa-gl glfw
+RUN apk add --no-cache \
+  tzdata \
+  s6-overlay \
+  alpine-sdk \
+  postgresql-dev \
+  nodejs \
+  yarn \
+  xz \
+  libarchive \
+  mesa-gl \
+  glfw
+
 RUN gem install foreman
 
 ARG APP_VERSION

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -22,6 +22,9 @@ if [ -z ${DATABASE_URL} ]; then
 	export DATABASE_URL="postgresql://${DATABASE_USER}:${DATABASE_PASSWORD}@${DATABASE_HOST}/${DATABASE_NAME}?pool=5"
 fi
 
+echo "Setting temporary directory permissions..."
+chown -R $PUID:$PGID tmp log
+
 echo "Preparing database..."
 bundle exec rails db:prepare:with_data
 

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -26,4 +26,4 @@ echo "Preparing database..."
 bundle exec rails db:prepare:with_data
 
 echo "Launching application..."
-exec "$@"
+exec s6-setuidgid $PUID:$PGID $@

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -8,6 +8,8 @@ services:
     volumes:
       - /path/to/your/libraries:/libraries
     environment:
+      PUID: 1000 # The ID of the user the app will run as
+      PGID: 1000 # The ID of the group the app will run as
       SECRET_KEY_BASE: a_nice_long_random_string
       REDIS_URL: redis://redis:6379/1
       DATABASE_URL: postgresql://manyfold:password@db/manyfold?pool=5


### PR DESCRIPTION
We've added `s6-overlay`, a common toolset for containers, in order to be able to use `s6-setuidgid` to dynamically reduce permission on the running app. If users now set `PUID` and `PGID` in their docker configurations, just like a lot of other apps (e.g. linuxserver/*), that user will be the one the app runs as.

Resolves #2240
Resolves #1704 