### PR TITLE
Set secure flags on libarchive extraction to avoid "Zip Slip" exploits

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -33,12 +33,11 @@ class UploadsController < ApplicationController
   def unzip(dest_folder_name, datafile)
     pn = Pathname.new(dest_folder_name)
 
-    flags = Archive::EXTRACT_PERM
     reader = Archive::Reader.open_filename(datafile.path)
     Dir.mkdir(dest_folder_name)
     Dir.chdir(dest_folder_name) do
       reader.each_entry do |entry|
-        reader.extract(entry, flags.to_i)
+        reader.extract(entry, Archive::EXTRACT_SECURE)
       end
     end
 

--- a/config/initializers/libarchive_security.rb
+++ b/config/initializers/libarchive_security.rb
@@ -1,0 +1,11 @@
+module Archive
+  # Create a preset "secure extraction" flag combination for libarchive to make sure we avoid security problems
+  # See https://github.com/libarchive/libarchive/blob/6ee1eebefdf41f36ef1a548c9a7000d132c453f3/libarchive/archive.h#L662
+  EXTRACT_SECURE = [
+    Archive::EXTRACT_NO_OVERWRITE,
+    Archive::EXTRACT_NO_OVERWRITE_NEWER,
+    Archive::EXTRACT_SECURE_SYMLINKS,
+    Archive::EXTRACT_SECURE_NODOTDOT,
+    Archive::EXTRACT_SECURE_NOABSOLUTEPATHS
+  ].reduce(:|).to_i
+end


### PR DESCRIPTION
Part of #2234 