### PR TITLE
Limit file upload size

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -51,7 +51,6 @@ group :development, :test do
   gem "rubocop-performance", "~> 1.21", require: false
   gem "i18n-tasks", "~> 1.0"
   gem "simplecov", "~> 0.22.0", require: false
-  gem "sys-filesystem", "~> 1.5"
 end
 
 group :development do
@@ -136,3 +135,5 @@ gem "logstash-event", "~> 1.2"
 gem "climate_control", "~> 1.2", group: :test
 
 gem "sidekiq-scheduler", github: "manyfold3d/sidekiq-scheduler", branch: "fix-dynamic-schedule-load-on-boot"
+
+gem "sys-filesystem", "~> 1.5"

--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -21,6 +21,9 @@ class UploadsController < ApplicationController
 
   def save_files(files, library_path)
     files.select { |datafile| datafile != "" }.each { |datafile|
+      # Check file is below the max allowed size
+      next if datafile.size > SiteSettings.max_file_upload_size
+      # Then open it up
       file_name_with_zip = datafile.original_filename
       file_name = File.basename(file_name_with_zip, File.extname(file_name_with_zip))
       dest_folder_name = library_path + file_name

--- a/app/javascript/application.ts
+++ b/app/javascript/application.ts
@@ -15,6 +15,7 @@ import 'src/bulk_edit'
 import 'src/model_edit'
 import 'src/tag'
 import 'src/carousel'
+import 'src/file_size_validation'
 
 // Load i18n definitions
 import { I18n } from 'i18n-js'

--- a/app/javascript/src/file_size_validation.ts
+++ b/app/javascript/src/file_size_validation.ts
@@ -10,7 +10,7 @@ const validateFileSizes = (fileList: FileList, maxSize: number): boolean => {
 document.addEventListener('DOMContentLoaded', () => {
   document.querySelectorAll('input[data-max-size]').forEach((input: HTMLInputElement) => {
     input.addEventListener('change', () => {
-			if ((input.files != null) && (input.dataset.maxSize != null) && !validateFileSizes(input.files, parseInt(input.dataset.maxSize))) {
+      if ((input.files != null) && (input.dataset.maxSize != null) && !validateFileSizes(input.files, parseInt(input.dataset.maxSize))) {
         input.setCustomValidity(window.i18n.t('uploads.exceeds_max_size', { max_size: (parseInt(input.dataset.maxSize) / 1024 / 1024).toPrecision(3) }))
       }
     })

--- a/app/javascript/src/file_size_validation.ts
+++ b/app/javascript/src/file_size_validation.ts
@@ -1,0 +1,18 @@
+const validateFileSizes = (fileList: FileList, maxSize: number): boolean => {
+  for (const file of fileList) {
+    if (file.size > maxSize) {
+      return false
+    }
+  }
+  return true
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('input[data-max-size]').forEach((input: HTMLInputElement) => {
+    input.addEventListener('change', () => {
+			if ((input.files != null) && (input.dataset.maxSize != null) && !validateFileSizes(input.files, parseInt(input.dataset.maxSize))) {
+        input.setCustomValidity(window.i18n.t('uploads.exceeds_max_size', { max_size: (parseInt(input.dataset.maxSize) / 1024 / 1024).toPrecision(3) }))
+      }
+    })
+  })
+})

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -1,5 +1,3 @@
-require "sys/filesystem"
-
 class Library < ApplicationRecord
   has_many :models, dependent: :destroy
   has_many :model_files, through: :models

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -1,3 +1,5 @@
+require "sys/filesystem"
+
 class Library < ApplicationRecord
   has_many :models, dependent: :destroy
   has_many :model_files, through: :models

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -20,4 +20,8 @@ class SiteSettings < RailsSettings::Base
   def self.email_configured
     !Rails.env.production? || ENV.fetch("SMTP_SERVER", false)
   end
+
+  def self.max_file_upload_size
+    ENV.fetch("MAX_FILE_UPLOAD_SIZE", 268_435_456)
+  end
 end

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -21,8 +21,7 @@
       <span class="form-text">
         <%= t ".files.help",
               types: safe_join(uploadable_file_extensions, ", "),
-              max_size: number_to_human_size(SiteSettings.max_file_upload_size, precision: 3)
-        %>
+              max_size: number_to_human_size(SiteSettings.max_file_upload_size, precision: 3) %>
       </span>
     </div>
   </div>

--- a/app/views/uploads/index.html.erb
+++ b/app/views/uploads/index.html.erb
@@ -15,9 +15,15 @@
     <div class='col-sm-10 ps-0'>
       <%= form.file_field :files, {
             multiple: true,
-            accept: input_accept_string
+            accept: input_accept_string,
+            "data-max-size": SiteSettings.max_file_upload_size
           } %>
-      <span class="form-text"><%= t ".files.help", types: safe_join(uploadable_file_extensions, ", ") %></span>
+      <span class="form-text">
+        <%= t ".files.help",
+              types: safe_join(uploadable_file_extensions, ", "),
+              max_size: number_to_human_size(SiteSettings.max_file_upload_size, precision: 3)
+        %>
+      </span>
     </div>
   </div>
 

--- a/config/i18n-js.yml
+++ b/config/i18n-js.yml
@@ -5,3 +5,4 @@ translations:
   - file: app/javascript/locales.json
     patterns:
       - "*.renderer.*"
+      - "*.uploads.exceeds_max_size"

--- a/config/i18n-tasks.yml
+++ b/config/i18n-tasks.yml
@@ -139,6 +139,8 @@ ignore_unused:
 - 'devise.failure.*' # Devise failure messages are used deep down
 - 'renderer.errors.*' # Used client side via i18n-js
 - 'renderer.processing' # Used client side via i18n-js
+- 'uploads.exceeds_max_size' # Used client side via i18n-js
+
 # - '{devise,kaminari,will_paginate}.*'
 # - 'simple_form.{yes,no}'
 # - 'simple_form.{placeholders,hints,labels}.*'

--- a/config/locales/uploads/en.yml
+++ b/config/locales/uploads/en.yml
@@ -5,7 +5,7 @@ en:
       success: File(s) uploaded successfully.
     index:
       files:
-        help: 'Supported file types: %{types}'
+        help: 'Supported file types: %{types}. Maximum file size: %{max_size}.'
         label: Select File
       free_space: "(%{available} free)"
       library:

--- a/config/locales/uploads/en.yml
+++ b/config/locales/uploads/en.yml
@@ -3,6 +3,7 @@ en:
   uploads:
     create:
       success: File(s) uploaded successfully.
+    exceeds_max_size: 'Selected file exceeds maximum size: %{max_size} MiB.'
     index:
       files:
         help: 'Supported file types: %{types}. Maximum file size: %{max_size}.'

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "experimentalDecorators": true,
     "lib": [
       "es6",
-      "dom"
+      "dom",
+      "dom.iterable"
     ],
     "module": "es6",
     "moduleResolution": "node",


### PR DESCRIPTION
Adds a configurable limit for file upload size, to mitigate potential DoS attack vectors with too-huge files. 256MiB by default, configurable with `MAX_FILE_UPLOAD_SIZE` env var.

Part of #2234.