### PR TITLE
Add FORCE_HTTPS env option to force secure-only connections

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ "http://example.com", /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = (ENV.fetch("HTTPS_ONLY", nil) === "enabled")
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
setting `FORCE_HTTPS=enabled` in the env vars will enable:

* HSTS connections
* Secure cookie storage
* Auto-redirection to HTTPS urls

Users should note that because of HSTS, going back to allowing insecure connections will be impossible until the timeout expires (which is I think 1 year)