### PR TITLE
Completely reset user session on logout

### DIFF
--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -20,6 +20,7 @@ class Users::SessionsController < Devise::SessionsController
   def destroy
     authorize :"users/sessions"
     super
+    reset_session # Completely reset the session
   end
 
   protected


### PR DESCRIPTION
Devise doesn't completely reset the session cookie, it just resets the stuff inside it; we will nuke it from orbit instead (it's the only way to be sure).