### PR TITLE
Add session timeouts to reduce session fixation/hijacking

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   devise :database_authenticatable,
     :registerable, :secure_validatable,
     :rememberable, :recoverable,
-    :lockable
+    :lockable, :timeoutable
 
   acts_as_favoritor
 

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -179,7 +179,7 @@ Devise.setup do |config|
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this
   # time the user will be asked for credentials again. Default is 30 minutes.
-  # config.timeout_in = 30.minutes
+  config.timeout_in = 30.minutes
 
   # ==> Configuration for :lockable
   # Defines which strategy will be used to lock an account.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -174,7 +174,7 @@ Devise.setup do |config|
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.
-  config.rememberable_options = {secure: (ENV.fetch("HTTPS_ONLY", nil) === "enabled")}
+  config.rememberable_options = {secure: Rails.application.config.force_ssl}
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -174,7 +174,10 @@ Devise.setup do |config|
 
   # Options to be passed to the created cookie. For instance, you can set
   # secure: true in order to force SSL only cookies.
-  config.rememberable_options = {secure: Rails.application.config.force_ssl}
+  config.rememberable_options = {
+    same_site: :strict,
+    secure: Rails.application.config.force_ssl
+  }
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/config/initializers/session_storage.rb
+++ b/config/initializers/session_storage.rb
@@ -1,0 +1,5 @@
+Rails.application.config.session_store :cookie_store,
+  expire_after: 14.days,
+  key: "_manyfold_session",
+  same_site: :strict,
+  secure: (ENV.fetch("HTTPS_ONLY", nil) === "enabled")

--- a/config/initializers/session_storage.rb
+++ b/config/initializers/session_storage.rb
@@ -2,4 +2,4 @@ Rails.application.config.session_store :cookie_store,
   expire_after: 14.days,
   key: "_manyfold_session",
   same_site: :strict,
-  secure: (ENV.fetch("HTTPS_ONLY", nil) === "enabled")
+  secure: Rails.application.config.force_ssl


### PR DESCRIPTION
Devise will ask for authentication again after 30 minutes of inactivity unless the user has chosen "remember me". Rails more generally will bin the session cookie (whether logged in or out) after 14 days without being used.