### PR TITLE
Limit size of extracted files on upload

### DIFF
--- a/app/controllers/uploads_controller.rb
+++ b/app/controllers/uploads_controller.rb
@@ -44,6 +44,7 @@ class UploadsController < ApplicationController
     Dir.mkdir(dest_folder_name)
     Dir.chdir(dest_folder_name) do
       reader.each_entry do |entry|
+        next if entry.size > SiteSettings.max_file_extract_size
         reader.extract(entry, Archive::EXTRACT_SECURE)
       end
     end

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -24,4 +24,8 @@ class SiteSettings < RailsSettings::Base
   def self.max_file_upload_size
     ENV.fetch("MAX_FILE_UPLOAD_SIZE", 268_435_456)
   end
+
+  def self.max_file_extract_size
+    ENV.fetch("MAX_FILE_EXTRACT_SIZE", 1_073_741_824)
+  end
 end

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -22,10 +22,10 @@ class SiteSettings < RailsSettings::Base
   end
 
   def self.max_file_upload_size
-    ENV.fetch("MAX_FILE_UPLOAD_SIZE", 268_435_456)
+    ENV.fetch("MAX_FILE_UPLOAD_SIZE", 268_435_456).to_i
   end
 
   def self.max_file_extract_size
-    ENV.fetch("MAX_FILE_EXTRACT_SIZE", 1_073_741_824)
+    ENV.fetch("MAX_FILE_EXTRACT_SIZE", 1_073_741_824).to_i
   end
 end


### PR DESCRIPTION
To avoid zip decompression bombs, we add a limit to the maximum size of a file that will be extracted from an uploaded archive. By default, this is 1GiB, but it can be changed using the "MAX_FILE_EXTRACT_SIZE" environment variable.