### PR TITLE
Mitigate timing attacks on user lookups

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,4 +47,10 @@ class ApplicationController < ActionController::Base
     return unless current_user&.is_administrator?
     flash.now[:alert] = t("security.running_as_root_html") if Process.uid == 0
   end
+
+  def random_delay
+    # Not sure how secure this is; it's used to help with timing attacks on login ID lookups
+    # by adding a random 0-2 second delay into the response. There is probably a better way.
+    sleep Random.new.rand(2.0)
+  end
 end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Users::PasswordsController < Devise::PasswordsController
+  before_action :random_delay, only: [:create, :update]
+
   # GET /resource/password/new
   def new
     authorize :"users/passwords"

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Users::RegistrationsController < Devise::RegistrationsController
+  before_action :random_delay, only: [:create, :cancel]
   before_action :configure_sign_up_params, only: [:create]
   before_action :detect_if_first_use, only: [:edit, :update]
   # before_action :configure_account_update_params, only: [:update]

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class Users::SessionsController < Devise::SessionsController
+  before_action :random_delay, only: [:create]
   before_action :auto_login_single_user
   # before_action :configure_sign_in_params, only: [:create]
 


### PR DESCRIPTION
So that attackers can't enumerate accounts that exist as easily.