### PR TITLE
Reduce javascript payload with tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "lint:ts": "ts-standard --fix",
-    "build": "bundle exec i18n export --config=./config/i18n-js.yml && esbuild app/javascript/*.* --bundle --sourcemap --outdir=app/assets/builds --public-path=assets",
+    "build": "bundle exec i18n export --config=./config/i18n-js.yml && esbuild app/javascript/*.* --minify=true --tree-shaking=true --bundle --sourcemap --outdir=app/assets/builds --public-path=assets",
     "build:css": "sass ./app/assets/stylesheets/application.bootstrap.scss:./app/assets/builds/application.css --no-source-map --load-path=node_modules",
     "typecheck": "bundle exec i18n export --config=./config/i18n-js.yml && tsc --project tsconfig.json"
   },


### PR DESCRIPTION
Get rid of unused code by forcing minification and tree shaking in esbuild. Looks like around a 70% reduction in uncompressed size.