### PR TITLE
Allow inline style attributes in Content-Security-Policy

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -20,6 +20,7 @@ Rails.application.configure do
     policy.object_src :none
     policy.script_src(*([:self] + scout_csp))
     policy.style_src(*([:self] + scout_csp))
+    policy.style_src_attr :unsafe_inline
   end
 
   unless using_scout


### PR DESCRIPTION
We use them in a few places; ideally they'd not be there, but that's a bigger refactor than this fix.