### PR TITLE
Use our own fork of sqlite3_ar_regexp to get Rails 7.1 support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,7 @@ gem "lograge", "~> 0.14.0"
 
 gem "acts_as_favoritor", "~> 6.0"
 
-gem "sqlite3_ar_regexp", "~> 2.2"
+gem "sqlite3_ar_regexp", github: "manyfold3d/sqlite3_ar_regexp", ref: "rails-7.1-support"
 
 gem "mittsu", github: "manyfold3d/mittsu", ref: "manyfold"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,6 +29,15 @@ GIT
       sidekiq (>= 6, < 8)
       tilt (>= 1.4.0, < 3)
 
+GIT
+  remote: https://github.com/manyfold3d/sqlite3_ar_regexp.git
+  revision: 2fa15db50770e86b7b4872486c2ee8ff282a3e2c
+  ref: rails-7.1-support
+  specs:
+    sqlite3_ar_regexp (2.2.0)
+      activerecord (>= 3.2)
+      sqlite3
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -517,9 +526,6 @@ GEM
     sqlite3 (1.7.3-x64-mingw-ucrt)
     sqlite3 (1.7.3-x86_64-darwin)
     sqlite3 (1.7.3-x86_64-linux)
-    sqlite3_ar_regexp (2.2.0)
-      activerecord (>= 3.2)
-      sqlite3
     standard (1.37.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -641,7 +647,7 @@ DEPENDENCIES
   spdx (~> 4.1)
   spring
   sqlite3 (~> 1.7)
-  sqlite3_ar_regexp (~> 2.2)
+  sqlite3_ar_regexp!
   standard (~> 1.37.0)
   stopwords-filter2
   string-similarity (~> 2.1)


### PR DESCRIPTION
We'll head back onto the official release once https://github.com/AaronLasseigne/sqlite3_ar_regexp/pull/7 is merged in.