### PR TITLE
Improve behaviour of background workers

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,3 @@
 rails: bundle exec rails server -p $PORT
-worker: bundle exec sidekiq
+default_worker: bundle exec sidekiq -C config/workers/default.yml
+performance_worker: bundle exec sidekiq -C config/workers/performance.yml

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,5 +1,6 @@
 rails: SCOUT_DEV_TRACE=true bin/rails server -p $PORT
-worker: bundle exec sidekiq
+default_worker: bundle exec sidekiq -C config/workers/default.yml
+performance_worker: bundle exec sidekiq -C config/workers/performance.yml
 js: yarn build --watch
 css: yarn build:css --watch
 typecheck: yarn typecheck --watch --preserveWatchOutput

--- a/app/jobs/analysis/file_conversion_job.rb
+++ b/app/jobs/analysis/file_conversion_job.rb
@@ -8,9 +8,7 @@ end
 
 class Analysis::FileConversionJob < ApplicationJob
   queue_as :performance
-
-  discard_on UnsupportedFormatError
-  discard_on NonManifoldError
+  sidekiq_options retry: false
 
   def perform(file_id, output_format)
     # Can we output this format?

--- a/app/jobs/analysis/file_conversion_job.rb
+++ b/app/jobs/analysis/file_conversion_job.rb
@@ -7,7 +7,10 @@ class NonManifoldError < StandardError
 end
 
 class Analysis::FileConversionJob < ApplicationJob
-  queue_as :analysis
+  queue_as :performance
+
+  discard_on UnsupportedFormatError
+  discard_on NonManifoldError
 
   def perform(file_id, output_format)
     # Can we output this format?

--- a/app/jobs/analysis/geometric_analysis_job.rb
+++ b/app/jobs/analysis/geometric_analysis_job.rb
@@ -3,7 +3,7 @@ end
 
 class Analysis::GeometricAnalysisJob < ApplicationJob
   queue_as :performance
-  discard_on MeshLoadError
+  sidekiq_options retry: false
 
   def perform(file_id)
     # Get model

--- a/app/jobs/analysis/geometric_analysis_job.rb
+++ b/app/jobs/analysis/geometric_analysis_job.rb
@@ -2,7 +2,7 @@ class MeshLoadError < StandardError
 end
 
 class Analysis::GeometricAnalysisJob < ApplicationJob
-  queue_as :analysis
+  queue_as :performance
 
   def perform(file_id)
     # Get model

--- a/app/jobs/analysis/geometric_analysis_job.rb
+++ b/app/jobs/analysis/geometric_analysis_job.rb
@@ -3,6 +3,7 @@ end
 
 class Analysis::GeometricAnalysisJob < ApplicationJob
   queue_as :performance
+  discard_on MeshLoadError
 
   def perform(file_id)
     # Get model

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,6 +1,6 @@
 class ApplicationJob < ActiveJob::Base
   include ActiveJob::Status
-  sidekiq_options retry: 5
+  sidekiq_options retry: 10
 
   # Most jobs are safe to ignore if the underlying records are no longer available
   discard_on ActiveJob::DeserializationError

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,12 +1,9 @@
 class ApplicationJob < ActiveJob::Base
   include ActiveJob::Status
-  sidekiq_options retry: false
-
-  # Automatically retry jobs that encountered a deadlock
-  # retry_on ActiveRecord::Deadlocked
+  sidekiq_options retry: 5
 
   # Most jobs are safe to ignore if the underlying records are no longer available
-  # discard_on ActiveJob::DeserializationError
+  discard_on ActiveJob::DeserializationError
 
   before_perform do |job|
     begin

--- a/config/workers/default.yml
+++ b/config/workers/default.yml
@@ -1,8 +1,8 @@
 ---
 :queues:
   - scan
-  - default
   - analysis
+  - default
 :scheduler:
   :dynamic: true
   :dynamic_every: 15s

--- a/config/workers/default.yml
+++ b/config/workers/default.yml
@@ -1,4 +1,5 @@
 ---
+:concurrency: <%= ENV.fetch("DEFAULT_WORKER_CONCURRENCY", 4) %>
 :queues:
   - scan
   - analysis

--- a/config/workers/performance.yml
+++ b/config/workers/performance.yml
@@ -1,4 +1,4 @@
 ---
-:concurrency: 1
+:concurrency: <%= ENV.fetch("PERFORMANCE_WORKER_CONCURRENCY", 1) %>
 :queues:
   - performance

--- a/config/workers/performance.yml
+++ b/config/workers/performance.yml
@@ -1,0 +1,4 @@
+---
+:concurrency: 1
+:queues:
+  - performance


### PR DESCRIPTION
This PR improves the behaviour of the job runners. It adds a separate "performance" runner which can be scaled independently, and which takes care of the CPU/MEM intensive jobs like GeometricAnalysis and FileConversion.

Default scaling is that there is only one performance runner - this avoids the entire server becoming CPU-saturated when those jobs are queued up.

Concurrency can be controlled with `DEFAULT_WORKER_CONCURRENCY` (default 4) and `PERFORMANCE_WORKER_CONCURRENCY` (default 1)

It also reinstates sidekiq's retry functionality to handle things like database pool exhaustion.