### PR TITLE
Fix incorrect library fetching when ID has >1 digit

### DIFF
--- a/app/uploaders/library_uploader.rb
+++ b/app/uploaders/library_uploader.rb
@@ -2,7 +2,7 @@ class LibraryUploader < Shrine
   plugin :dynamic_storage
   plugin :upload_endpoint, max_size: SiteSettings.max_file_upload_size
 
-  storage(/library_(\d)/) do |m|
+  storage(/library_(\d+)/) do |m|
     Library.find(m[1]).storage
   end
 


### PR DESCRIPTION
The storage regex was only picking up single digits. What a chump I am.