### PR TITLE
Refactor file access so that everything goes through Shrine

### DIFF
--- a/app/jobs/analysis/analyse_model_file_job.rb
+++ b/app/jobs/analysis/analyse_model_file_job.rb
@@ -7,7 +7,7 @@ class Analysis::AnalyseModelFileJob < ApplicationJob
     file = ModelFile.find(file_id)
     # Don't run analysis if the file is missing
     # The Problem is raised elsewhere.
-    return if !file.exist?
+    return if !file.exists?
     # If the file is modified, or we're lacking metadata
     status[:step] = "jobs.analysis.analyse_model_file.file_statistics" # i18n-tasks-use t('jobs.analysis.analyse_model_file.file_statistics')
     if file.mtime > file.updated_at || file.digest.nil?

--- a/app/jobs/analysis/analyse_model_file_job.rb
+++ b/app/jobs/analysis/analyse_model_file_job.rb
@@ -7,7 +7,7 @@ class Analysis::AnalyseModelFileJob < ApplicationJob
     file = ModelFile.find(file_id)
     # Don't run analysis if the file is missing
     # The Problem is raised elsewhere.
-    return if !file.exists?
+    return if !file.exists_on_storage?
     # If the file is modified, or we're lacking metadata
     status[:step] = "jobs.analysis.analyse_model_file.file_statistics" # i18n-tasks-use t('jobs.analysis.analyse_model_file.file_statistics')
     if file.mtime > file.updated_at || file.digest.nil?

--- a/app/jobs/analysis/analyse_model_file_job.rb
+++ b/app/jobs/analysis/analyse_model_file_job.rb
@@ -69,9 +69,9 @@ class Analysis::AnalyseModelFileJob < ApplicationJob
   end
 
   def inefficiency_problem(file)
-    return "ASCII STL" if (file.extension === "stl") && (File.read(file.absolute_path, 6) === "solid ")
+    return "ASCII STL" if (file.extension === "stl") && (file.head(6) === "solid ")
     return "Wavefront OBJ" if file.extension === "obj"
-    return "ASCII PLY" if (file.extension === "ply") && (File.read(file.absolute_path, 16) === "ply\rformat ascii")
+    return "ASCII PLY" if (file.extension === "ply") && (file.head(16) === "ply\rformat ascii")
     nil
   end
 

--- a/app/jobs/analysis/file_conversion_job.rb
+++ b/app/jobs/analysis/file_conversion_job.rb
@@ -31,7 +31,7 @@ class Analysis::FileConversionJob < ApplicationJob
         filename: file.filename.gsub(".#{file.extension}", ".#{extension}")
       )
       dedup = 0
-      while new_file.exist?
+      while new_file.exists?
         dedup += 1
         new_file.filename = file.filename.gsub(".#{file.extension}", "-#{dedup}.#{extension}")
       end

--- a/app/jobs/analysis/file_conversion_job.rb
+++ b/app/jobs/analysis/file_conversion_job.rb
@@ -31,7 +31,7 @@ class Analysis::FileConversionJob < ApplicationJob
         filename: file.filename.gsub(".#{file.extension}", ".#{extension}")
       )
       dedup = 0
-      while new_file.exists?
+      while new_file.exists_on_storage?
         dedup += 1
         new_file.filename = file.filename.gsub(".#{file.extension}", "-#{dedup}.#{extension}")
       end

--- a/app/jobs/model_file_scan_job.rb
+++ b/app/jobs/model_file_scan_job.rb
@@ -5,7 +5,7 @@ class ModelFileScanJob < ApplicationJob
     file = ModelFile.find(file_id)
     # Try to guess if the file is presupported
     if !(
-      file.absolute_path.split(/[[:punct:]]|[[:space:]]/).map(&:downcase) & ModelFile::SUPPORT_KEYWORDS
+      file.path_within_library.split(/[[:punct:]]|[[:space:]]/).map(&:downcase) & ModelFile::SUPPORT_KEYWORDS
     ).empty?
       file.update!(presupported: true)
     end

--- a/app/jobs/model_scan_job.rb
+++ b/app/jobs/model_scan_job.rb
@@ -3,31 +3,27 @@ require "shellwords"
 class ModelScanJob < ApplicationJob
   queue_as :scan
 
-  def file_list(model_path, include_all_subfolders: false)
-    list = []
-    Dir.open(model_path) do |dir|
-      glob = include_all_subfolders ?
-        [File.join(Shellwords.escape(dir.path), "**", ApplicationJob.file_pattern)] :
-        [File.join(Shellwords.escape(dir.path), ApplicationJob.file_pattern)] +
-          ApplicationJob.common_subfolders.map do |name, pattern|
-            File.join(
-              Shellwords.escape(dir.path),
-              ApplicationJob.case_insensitive_glob_string(name),
-              pattern
-            )
-          end
-      list = Dir.glob(glob).uniq.filter { |x| File.file?(x) }
-    end
-    list
+  def file_list(model_path, library, include_all_subfolders: false)
+    glob = include_all_subfolders ?
+      [File.join(Shellwords.escape(model_path), "**", ApplicationJob.file_pattern)] :
+      [File.join(Shellwords.escape(model_path), ApplicationJob.file_pattern)] +
+        ApplicationJob.common_subfolders.map do |name, pattern|
+          File.join(
+            Shellwords.escape(model_path),
+            ApplicationJob.case_insensitive_glob_string(name),
+            pattern
+          )
+        end
+    library.glob(glob).uniq
   end
 
   def perform(model_id, include_all_subfolders: false)
     model = Model.find(model_id)
     return if Problem.create_or_clear(model, :missing, !model.exist?)
     # For each file in the model, create a file object
-    file_list(model.absolute_path, include_all_subfolders: include_all_subfolders).each do |filename|
+    file_list(model.path, model.library, include_all_subfolders: include_all_subfolders).each do |filename|
       # Create the file
-      file = model.model_files.find_or_create_by(filename: filename.gsub(model.absolute_path + "/", ""))
+      file = model.model_files.find_or_create_by(filename: filename.gsub(model.path + "/", ""))
       ModelFileScanJob.perform_later(file.id) if file.valid?
     end
     # Set tags and default files

--- a/app/jobs/model_scan_job.rb
+++ b/app/jobs/model_scan_job.rb
@@ -19,7 +19,7 @@ class ModelScanJob < ApplicationJob
 
   def perform(model_id, include_all_subfolders: false)
     model = Model.find(model_id)
-    return if Problem.create_or_clear(model, :missing, !model.exist?)
+    return if Problem.create_or_clear(model, :missing, !model.exists_on_storage?)
     # For each file in the model, create a file object
     file_list(model.path, model.library, include_all_subfolders: include_all_subfolders).each do |filename|
       # Create the file

--- a/app/jobs/model_scan_job.rb
+++ b/app/jobs/model_scan_job.rb
@@ -14,7 +14,7 @@ class ModelScanJob < ApplicationJob
             pattern
           )
         end
-    library.glob(glob).uniq
+    library.list_files(glob).uniq
   end
 
   def perform(model_id, include_all_subfolders: false)

--- a/app/jobs/scan/check_model_integrity_job.rb
+++ b/app/jobs/scan/check_model_integrity_job.rb
@@ -9,7 +9,7 @@ class Scan::CheckModelIntegrityJob < ApplicationJob
     Problem.create_or_clear model, :no_image, model.image_files.empty?
     Problem.create_or_clear model, :no_3d_model, model.three_d_files.empty?
     model.model_files.each do |f|
-      Problem.create_or_clear(f, :missing, !f.exists?)
+      Problem.create_or_clear(f, :missing, !f.exists_on_storage?)
     end
   end
 end

--- a/app/jobs/scan/check_model_integrity_job.rb
+++ b/app/jobs/scan/check_model_integrity_job.rb
@@ -3,7 +3,7 @@ class Scan::CheckModelIntegrityJob < ApplicationJob
 
   def perform(model_id)
     model = Model.find(model_id)
-    Problem.create_or_clear(model, :missing, !model.exist?)
+    Problem.create_or_clear(model, :missing, !model.exists_on_storage?)
     Problem.create_or_clear model, :empty, (model.model_files.count == 0)
     Problem.create_or_clear model, :nesting, model.contains_other_models?
     Problem.create_or_clear model, :no_image, model.image_files.empty?

--- a/app/jobs/scan/check_model_integrity_job.rb
+++ b/app/jobs/scan/check_model_integrity_job.rb
@@ -9,7 +9,7 @@ class Scan::CheckModelIntegrityJob < ApplicationJob
     Problem.create_or_clear model, :no_image, model.image_files.empty?
     Problem.create_or_clear model, :no_3d_model, model.three_d_files.empty?
     model.model_files.each do |f|
-      Problem.create_or_clear(f, :missing, !f.exist?)
+      Problem.create_or_clear(f, :missing, !f.exists?)
     end
   end
 end

--- a/app/jobs/scan/detect_filesystem_changes_job.rb
+++ b/app/jobs/scan/detect_filesystem_changes_job.rb
@@ -3,7 +3,7 @@ class Scan::DetectFilesystemChangesJob < ApplicationJob
 
   # Find all files in the library that we might need to look at
   def filenames_on_disk(library)
-    library.glob(File.join("**", ApplicationJob.file_pattern))
+    library.list_files(File.join("**", ApplicationJob.file_pattern))
   end
 
   # Get a list of all the existing filenames

--- a/app/jobs/scan/detect_filesystem_changes_job.rb
+++ b/app/jobs/scan/detect_filesystem_changes_job.rb
@@ -3,12 +3,12 @@ class Scan::DetectFilesystemChangesJob < ApplicationJob
 
   # Find all files in the library that we might need to look at
   def filenames_on_disk(library)
-    library.glob(File.join("**", ApplicationJob.file_pattern)).filter { |x| File.file?(x) }
+    library.glob(File.join("**", ApplicationJob.file_pattern))
   end
 
   # Get a list of all the existing filenames
   def known_filenames(library)
-    library.model_files.reload.map(&:absolute_path)
+    library.model_files.reload.map(&:path_within_library)
   end
 
   def filter_out_common_subfolders(folders)
@@ -25,7 +25,7 @@ class Scan::DetectFilesystemChangesJob < ApplicationJob
     changes = (known_filenames(library).to_set ^ filenames_on_disk(library)).to_a
     # Make a list of library-relative folders with changed files
     status[:step] = "jobs.scan.detect_filesystem_changes.building_folder_list" # i18n-tasks-use t('jobs.scan.detect_filesystem_changes.building_folder_list')
-    folders_with_changes = changes.map { |f| File.dirname(f.gsub(library.path, "")) }.uniq
+    folders_with_changes = changes.map { |f| File.dirname(f) }.uniq
     folders_with_changes = filter_out_common_subfolders(folders_with_changes)
     folders_with_changes.delete("/")
     folders_with_changes.compact_blank!

--- a/app/jobs/scan/detect_filesystem_changes_job.rb
+++ b/app/jobs/scan/detect_filesystem_changes_job.rb
@@ -1,11 +1,9 @@
-require "shellwords"
-
 class Scan::DetectFilesystemChangesJob < ApplicationJob
   queue_as :scan
 
   # Find all files in the library that we might need to look at
   def filenames_on_disk(library)
-    Dir.glob(File.join(Shellwords.escape(library.path), "**", ApplicationJob.file_pattern)).filter { |x| File.file?(x) }
+    library.glob(File.join("**", ApplicationJob.file_pattern)).filter { |x| File.file?(x) }
   end
 
   # Get a list of all the existing filenames

--- a/app/jobs/scan/detect_filesystem_changes_job.rb
+++ b/app/jobs/scan/detect_filesystem_changes_job.rb
@@ -19,7 +19,7 @@ class Scan::DetectFilesystemChangesJob < ApplicationJob
   def perform(library_id)
     library = Library.find(library_id)
     return if library.nil?
-    return if Problem.create_or_clear(library, :missing, !library.exist?)
+    return if Problem.create_or_clear(library, :missing, !library.storage_exists?)
     # Make a list of changed filenames using set XOR
     status[:step] = "jobs.scan.detect_filesystem_changes.building_filename_list" # i18n-tasks-use t('jobs.scan.detect_filesystem_changes.building_filename_list')
     changes = (known_filenames(library).to_set ^ filenames_on_disk(library)).to_a

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -18,6 +18,8 @@ class Library < ApplicationRecord
 
   default_scope { order(:path) }
 
+  delegate :exists?, to: :storage
+
   def name
     self[:name] || (path ? File.basename(path) : "")
   end

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -18,8 +18,6 @@ class Library < ApplicationRecord
 
   default_scope { order(:path) }
 
-  delegate :exists?, to: :storage
-
   def name
     self[:name] || (path ? File.basename(path) : "")
   end
@@ -28,8 +26,13 @@ class Library < ApplicationRecord
     self.name = nil if name == ""
   end
 
-  def exist?
-    Dir.exist?(path)
+  def storage_exists?
+    case storage_service
+    when "filesystem"
+      Dir.exist?(path)
+    else
+      raise "Invalid storage service: #{storage_service}"
+    end
   end
 
   def all_tags
@@ -79,6 +82,14 @@ class Library < ApplicationRecord
     else
       raise "Invalid storage service: #{storage_service}"
     end
+  end
+
+  def has_file?(path)
+    storage.exists?(path)
+  end
+
+  def has_folder?(path)
+    storage.exists?(path)
   end
 
   private

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -1,3 +1,5 @@
+require "shellwords"
+
 class Library < ApplicationRecord
   STORAGE_SERVICES = [
     "filesystem"
@@ -66,6 +68,15 @@ class Library < ApplicationRecord
     find_each(&:register_storage)
   rescue ActiveRecord::StatementInvalid
     nil # migrations probably haven't run yet to create library table
+  end
+
+  def glob(pattern, flags = 0)
+    case storage_service
+    when "filesystem"
+      Dir.glob(File.join(Shellwords.escape(path), pattern), flags)
+    else
+      raise "Invalid storage service: #{storage_service}"
+    end
   end
 
   private

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -70,7 +70,7 @@ class Library < ApplicationRecord
     nil # migrations probably haven't run yet to create library table
   end
 
-  def glob(pattern, flags = 0)
+  def list_files(pattern, flags = 0)
     case storage_service
     when "filesystem"
       Dir.glob(pattern, flags, base: Shellwords.escape(path)).filter { |x| File.file?(File.join(path, x)) }

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -73,7 +73,7 @@ class Library < ApplicationRecord
   def glob(pattern, flags = 0)
     case storage_service
     when "filesystem"
-      Dir.glob(File.join(Shellwords.escape(path), pattern), flags)
+      Dir.glob(pattern, flags, base: Shellwords.escape(path)).filter { |x| File.file?(File.join(path, x)) }
     else
       raise "Invalid storage service: #{storage_service}"
     end

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -100,7 +100,7 @@ class Library < ApplicationRecord
     # models will get the wrong paths. This method makes sure that the
     # case is stored in the canonical form that the OS will give us back
     # in globs
-    if path
+    if storage_service == "filesystem" && path
       normalised = Dir.glob(path).first
       self.path = normalised if normalised
     end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -67,7 +67,7 @@ class Model < ApplicationRecord
     # Remove tags first - sometimes this causes problems if we don't do it beforehand
     update!(tags: [])
     # Delete directory corresponding to model
-    FileUtils.remove_dir(absolute_path) if exist?
+    FileUtils.remove_dir(absolute_path) if exists_on_storage?
     # Remove from DB
     destroy
   end
@@ -117,8 +117,8 @@ class Model < ApplicationRecord
     model_files.select(&:is_3d_model?)
   end
 
-  def exist?
-    Dir.exist?(absolute_path)
+  def exists_on_storage?
+    library.storage.exists?(path)
   end
 
   private
@@ -158,7 +158,7 @@ class Model < ApplicationRecord
   end
 
   def destination_is_vacant
-    if Dir.exist?(absolute_path)
+    if exists_on_storage?
       errors.add(:path, :destination_exists)
     end
   end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -118,7 +118,7 @@ class Model < ApplicationRecord
   end
 
   def exists_on_storage?
-    library.storage.exists?(path)
+    library.has_folder?(path)
   end
 
   private

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -76,7 +76,7 @@ class ModelFile < ApplicationRecord
   end
 
   def attach_existing_file!(refresh: true)
-    return if attachment.present? || !exists?
+    return if attachment.present? || !exists_on_storage?
     attachment_attacher.set Shrine.uploaded_file(
       storage: model.library.storage_key,
       id: path_within_library,
@@ -90,8 +90,8 @@ class ModelFile < ApplicationRecord
     save!
   end
 
-  def exists?
-    model.library.exists?(path_within_library)
+  def exists_on_storage?
+    model.library.has_file?(path_within_library)
   end
 
   def mtime

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -156,7 +156,8 @@ class ModelFile < ApplicationRecord
   end
 
   def mesh
-    loader&.new&.load(absolute_path)
+    # TODO: This can be better, but needs changes upstream in Mittsu to allow loaders to parse from an IO object
+    loader&.new&.parse(attachment.read)
   end
   memoize :mesh
 

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -76,7 +76,7 @@ class ModelFile < ApplicationRecord
   end
 
   def attach_existing_file!(refresh: true)
-    return if attachment.present? || !File.exist?(absolute_path)
+    return if attachment.present? || !exists?
     attachment_attacher.set Shrine.uploaded_file(
       storage: model.library.storage_key,
       id: path_within_library,
@@ -90,8 +90,8 @@ class ModelFile < ApplicationRecord
     save!
   end
 
-  def exist?
-    File.exist?(absolute_path)
+  def exists?
+    model.library.exists?(path_within_library)
   end
 
   def mtime

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -98,6 +98,13 @@ class ModelFile < ApplicationRecord
     File.mtime(absolute_path)
   end
 
+  def head(bytes)
+    io = attachment.open
+    result = io.read(bytes)
+    io.close
+    result
+  end
+
   def calculate_digest
     Digest::SHA512.new.file(absolute_path).hexdigest
   rescue Errno::ENOENT

--- a/spec/jobs/analysis/analyse_model_file_job_spec.rb
+++ b/spec/jobs/analysis/analyse_model_file_job_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Analysis::AnalyseModelFileJob do
 
     it "detects ASCII STL files and creates a Problem record" do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
       allow(file).to receive(:extension).and_return("stl")
-      allow(File).to receive(:read).with(file.absolute_path, 6).once.and_return("solid ")
+      allow(file).to receive(:head).with(6).once.and_return("solid ")
       expect { described_class.perform_now file.id }.to change(Problem, :count).from(0).to(1)
       expect(Problem.first.category).to eq "inefficient"
       expect(Problem.first.note).to eq "ASCII STL"
@@ -49,7 +49,7 @@ RSpec.describe Analysis::AnalyseModelFileJob do
 
     it "detects ASCII PLY files and creates a Problem record" do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
       allow(file).to receive(:extension).and_return("ply")
-      allow(File).to receive(:read).with(file.absolute_path, 16).once.and_return("ply\rformat ascii")
+      allow(file).to receive(:head).with(16).once.and_return("ply\rformat ascii")
       expect { described_class.perform_now file.id }.to change(Problem, :count).from(0).to(1)
       expect(Problem.first.category).to eq "inefficient"
       expect(Problem.first.note).to eq "ASCII PLY"

--- a/spec/jobs/analysis/file_conversion_job_spec.rb
+++ b/spec/jobs/analysis/file_conversion_job_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe Analysis::FileConversionJob do
     end
 
     it "avoids filenames that already exist" do
-      allow(File).to receive(:exist?).with(file.absolute_path.gsub(".stl", ".3mf")).and_return(true).once
-      allow(File).to receive(:exist?).with(file.absolute_path.gsub(".stl", "-1.3mf")).and_return(true).once
-      allow(File).to receive(:exist?).with(file.absolute_path.gsub(".stl", "-2.3mf")).and_return(false)
+      allow(library).to receive(:exists?).with(file.path_within_library.gsub(".stl", ".3mf")).and_return(true).once
+      allow(library).to receive(:exists?).with(file.path_within_library.gsub(".stl", "-1.3mf")).and_return(true).once
+      allow(library).to receive(:exists?).with(file.path_within_library.gsub(".stl", "-2.3mf")).and_return(false)
       described_class.perform_now(file.id, :threemf)
       expect(ModelFile.where.not(id: file.id).first.filename).to eq "files/awesome-2.3mf"
     end

--- a/spec/jobs/analysis/file_conversion_job_spec.rb
+++ b/spec/jobs/analysis/file_conversion_job_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe Analysis::FileConversionJob do
     end
 
     it "avoids filenames that already exist" do
-      allow(library).to receive(:exists?).with(file.path_within_library.gsub(".stl", ".3mf")).and_return(true).once
-      allow(library).to receive(:exists?).with(file.path_within_library.gsub(".stl", "-1.3mf")).and_return(true).once
-      allow(library).to receive(:exists?).with(file.path_within_library.gsub(".stl", "-2.3mf")).and_return(false)
+      allow(library).to receive(:has_file?).with(file.path_within_library.gsub(".stl", ".3mf")).and_return(true).once
+      allow(library).to receive(:has_file?).with(file.path_within_library.gsub(".stl", "-1.3mf")).and_return(true).once
+      allow(library).to receive(:has_file?).with(file.path_within_library.gsub(".stl", "-2.3mf")).and_return(false)
       described_class.perform_now(file.id, :threemf)
       expect(ModelFile.where.not(id: file.id).first.filename).to eq "files/awesome-2.3mf"
     end

--- a/spec/jobs/model_scan_job_spec.rb
+++ b/spec/jobs/model_scan_job_spec.rb
@@ -158,8 +158,9 @@ RSpec.describe ModelScanJob do
 
     it "generates a correct file list" do
       expect(described_class.new.file_list(
-        File.join(library.path, model.path)
-      )).to eq ["#{library.path}/#{model.path}/part_1.obj"]
+        model.path,
+        library
+      )).to eq ["#{model.path}/part_1.obj"]
     end
 
     it "detects model files" do # rubocop:todo RSpec/MultipleExpectations
@@ -187,15 +188,17 @@ RSpec.describe ModelScanJob do
 
     it "ignores subfolders if not told to include them" do
       expect(described_class.new.file_list(
-        File.join(library.path, model.path)
-      )).to eq ["#{library.path}/#{model.path}/part_1.obj"]
+        model.path,
+        library
+      )).to eq ["#{model.path}/part_1.obj"]
     end
 
     it "generates a complete file list if including all subfolders" do
       expect(described_class.new.file_list(
-        File.join(library.path, model.path),
+        model.path,
+        library,
         include_all_subfolders: true
-      )).to eq ["#{library.path}/#{model.path}/part_1.obj", "#{library.path}/#{model.path}/subfolder/part_2.obj"]
+      )).to eq ["#{model.path}/part_1.obj", "#{model.path}/subfolder/part_2.obj"]
     end
   end
 

--- a/spec/jobs/scan/check_model_integrity_job_spec.rb
+++ b/spec/jobs/scan/check_model_integrity_job_spec.rb
@@ -21,11 +21,11 @@ RSpec.describe Scan::CheckModelIntegrityJob do
     end
 
     it "flags up problems for files that don't exist on disk" do
-      thing = create(:model, path: "model_one", library: library)
-      model = create(:model_file, filename: "missing.stl", model: thing)
-      File.delete(model.absolute_path)
-      described_class.perform_now(thing.id)
-      expect(thing.model_files.first.problems.map(&:category)).to include("missing")
+      model = create(:model, path: "model_one", library: library)
+      file = create(:model_file, filename: "missing.stl", model: model)
+      File.delete(File.join(library.path, file.path_within_library))
+      described_class.perform_now(model.id)
+      expect(model.model_files.first.problems.map(&:category)).to include("missing")
     end
   end
 

--- a/spec/jobs/scan/create_model_job_spec.rb
+++ b/spec/jobs/scan/create_model_job_spec.rb
@@ -5,26 +5,26 @@ RSpec.describe Scan::CreateModelJob do
   let(:library) { create(:library) }
 
   it "creates a single model" do
-    expect { described_class.perform_now(library.id, "/model") }.to change(Model, :count).from(0).to(1)
+    expect { described_class.perform_now(library.id, "model") }.to change(Model, :count).from(0).to(1)
   end
 
   it "creates model in library" do
-    described_class.perform_now(library.id, "/model")
+    described_class.perform_now(library.id, "model")
     expect(library.models.count).to be 1
   end
 
   it "sets correct path in new model" do
-    described_class.perform_now(library.id, "/model")
+    described_class.perform_now(library.id, "model")
     expect(Model.first.path).to eql "model"
   end
 
   it "queues model up for a full scan" do
-    described_class.perform_now(library.id, "/model")
+    described_class.perform_now(library.id, "model")
     expect(ModelScanJob).to have_been_enqueued.with(Model.first.id, include_all_subfolders: false).once
   end
 
   it "queues model up for a full scan including subfolders" do
-    described_class.perform_now(library.id, "/model", include_all_subfolders: true)
+    described_class.perform_now(library.id, "model", include_all_subfolders: true)
     expect(ModelScanJob).to have_been_enqueued.with(Model.first.id, include_all_subfolders: true).once
   end
 end

--- a/spec/jobs/scan/detect_filesystem_changes_job_spec.rb
+++ b/spec/jobs/scan/detect_filesystem_changes_job_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe Scan::DetectFilesystemChangesJob do
 
     it "can scan a library directory" do # rubocop:todo RSpec/MultipleExpectations
       described_class.perform_now(library.id)
-      expect(Scan::CreateModelJob).to have_been_enqueued.with(library.id, "/model_one")
-      expect(Scan::CreateModelJob).to have_been_enqueued.with(library.id, "/subfolder/model_two")
+      expect(Scan::CreateModelJob).to have_been_enqueued.with(library.id, "model_one")
+      expect(Scan::CreateModelJob).to have_been_enqueued.with(library.id, "subfolder/model_two")
     end
 
     it "only scans models with changes on rescan" do
       model_one = create(:model, path: "model_one", library: library)
       ModelScanJob.perform_now(model_one.id)
-      expect { described_class.perform_now(library.id) }.to have_enqueued_job(Scan::CreateModelJob).with(library.id, "/subfolder/model_two").exactly(1).times
+      expect { described_class.perform_now(library.id) }.to have_enqueued_job(Scan::CreateModelJob).with(library.id, "subfolder/model_two").exactly(1).times
     end
   end
 
@@ -47,8 +47,8 @@ RSpec.describe Scan::DetectFilesystemChangesJob do
 
     it "pulls out nested model as separate" do # rubocop:todo RSpec/MultipleExpectations
       described_class.perform_now(library.id)
-      expect(Scan::CreateModelJob).to have_been_enqueued.with(library.id, "/model_one")
-      expect(Scan::CreateModelJob).to have_been_enqueued.with(library.id, "/model_one/nested")
+      expect(Scan::CreateModelJob).to have_been_enqueued.with(library.id, "model_one")
+      expect(Scan::CreateModelJob).to have_been_enqueued.with(library.id, "model_one/nested")
     end
   end
 
@@ -70,7 +70,7 @@ RSpec.describe Scan::DetectFilesystemChangesJob do
     # rubocop:enable RSpec/InstanceVariable
 
     it "understands that it's a single model" do
-      expect { described_class.perform_now(library.id) }.to have_enqueued_job(Scan::CreateModelJob).with(library.id, "/thingiverse_model").exactly(1).times
+      expect { described_class.perform_now(library.id) }.to have_enqueued_job(Scan::CreateModelJob).with(library.id, "thingiverse_model").exactly(1).times
     end
   end
 
@@ -95,7 +95,7 @@ RSpec.describe Scan::DetectFilesystemChangesJob do
     # rubocop:enable RSpec/InstanceVariable
 
     it "understands that it's a single model" do
-      expect { described_class.perform_now(library.id) }.to have_enqueued_job(Scan::CreateModelJob).with(library.id, "/model").exactly(1).times
+      expect { described_class.perform_now(library.id) }.to have_enqueued_job(Scan::CreateModelJob).with(library.id, "model").exactly(1).times
     end
   end
 
@@ -120,7 +120,7 @@ RSpec.describe Scan::DetectFilesystemChangesJob do
     # rubocop:enable RSpec/InstanceVariable
 
     it "ignores case and filters out subfolders correctly" do
-      expect { described_class.perform_now(library.id) }.to have_enqueued_job(Scan::CreateModelJob).with(library.id, "/model").exactly(1).times
+      expect { described_class.perform_now(library.id) }.to have_enqueued_job(Scan::CreateModelJob).with(library.id, "model").exactly(1).times
     end
   end
 
@@ -140,11 +140,11 @@ RSpec.describe Scan::DetectFilesystemChangesJob do
     # rubocop:enable RSpec/InstanceVariable
 
     it "does not include directories in file list" do
-      expect(described_class.new.filenames_on_disk(library)).not_to include File.join(library.path, "wrong.stl")
+      expect(described_class.new.filenames_on_disk(library)).not_to include "wrong.stl"
     end
 
     it "does include files within directories in file list" do
-      expect(described_class.new.filenames_on_disk(library)).to include File.join(library.path, "wrong.stl/file.stl")
+      expect(described_class.new.filenames_on_disk(library)).to include "wrong.stl/file.stl"
     end
   end
 
@@ -166,15 +166,15 @@ RSpec.describe Scan::DetectFilesystemChangesJob do
     # rubocop:enable RSpec/InstanceVariable
 
     it "detects lowercase file extensions" do
-      expect(described_class.new.filenames_on_disk(library)).to include File.join(library.path, "model/file.obj")
+      expect(described_class.new.filenames_on_disk(library)).to include "model/file.obj"
     end
 
     it "detects uppercase file extensions" do
-      expect(described_class.new.filenames_on_disk(library)).to include File.join(library.path, "model/file.OBJ")
+      expect(described_class.new.filenames_on_disk(library)).to include "model/file.OBJ"
     end
 
     it "detects mixed case file extensions" do
-      expect(described_class.new.filenames_on_disk(library)).to include File.join(library.path, "model/file.Obj")
+      expect(described_class.new.filenames_on_disk(library)).to include "model/file.Obj"
     end
   end
 
@@ -191,7 +191,7 @@ RSpec.describe Scan::DetectFilesystemChangesJob do
     let(:library) { create(:library, path: @library_path) } # rubocop:todo RSpec/InstanceVariable
 
     it "detects files inside models with square brackets" do
-      expect(described_class.new.filenames_on_disk(library)).to include File.join(library.path, "model [test]/file.obj")
+      expect(described_class.new.filenames_on_disk(library)).to include "model [test]/file.obj"
     end
   end
 end

--- a/spec/models/model_file_spec.rb
+++ b/spec/models/model_file_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe ModelFile do
 
     it "removes original file from disk" do
       expect { file.delete_from_disk_and_destroy }.to(
-        change { File.exist?(file.absolute_path) }.from(true).to(false)
+        change { File.exist?(File.join(library.path, file.path_within_library)) }.from(true).to(false)
       )
     end
 


### PR DESCRIPTION
In preparation for alternative storage backends, everything needs to go through Shrine properly.