### PR TITLE
Support SQLite databases in production

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ gem "ffi-libarchive", "~> 1.1"
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", ">= 1.4.4", require: false
 
+# Database adapters
+gem "sqlite3", "~> 1.7"
 group :production do
   gem "pg", "~> 1.5"
 end
@@ -37,7 +39,6 @@ end
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem "byebug", platforms: [:mri, :mingw, :x64_mingw]
-  gem "sqlite3", "~> 1.7"
   gem "rspec-rails"
   gem "standard", "~> 1.39.1"
   gem "factory_bot"

--- a/app/controllers/concerns/model_filters.rb
+++ b/app/controllers/concerns/model_filters.rb
@@ -44,8 +44,8 @@ module ModelFilters
     if @filters[:missingtag].presence || (@filters[:missingtag] && @filters[:library])
       tag_regex_build = []
       regexes = ((@filters[:missingtag] != "") ? [@filters[:missingtag]] : @models[0].library.tag_regex)
-      # technically this is sqlite vs postgres
-      regact = Rails.env.development? ? "REGEXP" : "~"
+      # work out regexp match syntax
+      regact = ApplicationRecord.connection.is_a?(ActiveRecord::ConnectionAdapters::SQLite3Adapter) ? "REGEXP" : "~"
       regexes.each do |reg|
         qreg = ActiveRecord::Base.connection.quote(reg)
         tag_regex_build.push "(select count(*) from tags join taggings on tags.id=taggings.tag_id where tags.name #{regact} #{qreg} and taggings.taggable_id=models.id and taggings.taggable_type='Model')<1"

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -12,12 +12,16 @@ services:
       PGID: 1000 # The ID of the group the app will run as
       SECRET_KEY_BASE: a_nice_long_random_string
       REDIS_URL: redis://redis:6379/1
+
+      # Database connection string
       DATABASE_URL: postgresql://manyfold:password@db/manyfold?pool=5
-#		or
-#      DATABASE_HOST: db
-#      DATABASE_USER: manyfold
-#      DATABASE_PASSWORD: password
-#      DATABASE_NAME: manyfold
+
+      # You can also use SQLite if you don't want to run a separate database server.
+      # Make sure the specified path is on a persistent volume!
+      # DATABASE_URL: sqlite3:/config/manyfold.sqlite3?pool=5
+
+      # Alternatively, you can set database connection parameters (host, username, etc)
+      # in separate variables; see https://manyfold.app/sysadmin/configuration.html.
 
       # For details of other optional environment variables, including features such
       # as multiuser mode, visit https://manyfold.app/sysadmin/configuration.html


### PR DESCRIPTION
SQlite was dev-only, but there's no reason it has to be. These changes allow SQLite URLs like `sqlite3:/config/manyfold.sqlite3?pool=5` to be used in DATABASE_URL.

Needs adding to the configuration page on the website.