### PR TITLE
Set the default worker concurrency to 1 in solo

### DIFF
--- a/docker/solo.dockerfile
+++ b/docker/solo.dockerfile
@@ -17,3 +17,4 @@ COPY ./docker/s6-rc.d/redis/manyfold/dependencies.d/redis /etc/s6-overlay/s6-rc.
 # Set parameters for solo mode connections
 ENV DATABASE_URL=sqlite3:/config/manyfold.sqlite3
 ENV REDIS_URL=redis://localhost:6379
+ENV DEFAULT_WORKER_CONCURRENCY=1


### PR DESCRIPTION
Avoids SQLite errors (see #2395) although we should be able to do better than this.