### PR TITLE
Fix broken default settings (e.g. render style)

### DIFF
--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -28,4 +28,34 @@ class SiteSettings < RailsSettings::Base
   def self.max_file_extract_size
     ENV.fetch("MAX_FILE_EXTRACT_SIZE", 1_073_741_824).to_i
   end
+
+  module UserDefaults
+    RENDERER = {
+      grid_width: 200,
+      grid_depth: 200,
+      show_grid: true,
+      enable_pan_zoom: false,
+      background_colour: "#000000",
+      object_colour: "#cccccc",
+      render_style: "normals"
+    }
+
+    PAGINATION = {
+      models: true,
+      creators: true,
+      per_page: 12
+    }
+
+    TAG_CLOUD = {
+      threshold: 0,
+      heatmap: true,
+      keypair: true,
+      sorting: "frequency",
+      hide_unrelated: true
+    }
+
+    FILE_LIST = {
+      hide_presupported_versions: true
+    }
+  end
 end

--- a/db/data/20221214230757_add_new_defaults_to_renderer_settings.rb
+++ b/db/data/20221214230757_add_new_defaults_to_renderer_settings.rb
@@ -2,16 +2,9 @@
 
 class AddNewDefaultsToRendererSettings < ActiveRecord::Migration[7.0]
   def up
-    defaults = {
-      "show_grid" => true,
-      "enable_pan_zoom" => false,
-      "background_colour" => "#000000",
-      "object_colour" => "#cccccc",
-      "render_style" => "normals"
-    }
     User.find_each do |user|
       user.update(
-        renderer_settings: defaults.merge(user.renderer_settings)
+        renderer_settings: SiteSettings::UserDefaults::RENDERER.merge(user.renderer_settings)
       )
     end
   end

--- a/db/migrate/20220617122809_add_pagination_settings_to_user.rb
+++ b/db/migrate/20220617122809_add_pagination_settings_to_user.rb
@@ -1,5 +1,5 @@
 class AddPaginationSettingsToUser < ActiveRecord::Migration[7.0]
   def change
-    add_column :users, :pagination_settings, :json, default: {models: true, creators: true, per_page: 12}
+    add_column :users, :pagination_settings, :json, default: SiteSettings::UserDefaults::PAGINATION
   end
 end

--- a/db/migrate/20221128165903_add_renderer_settings_to_users.rb
+++ b/db/migrate/20221128165903_add_renderer_settings_to_users.rb
@@ -1,5 +1,5 @@
 class AddRendererSettingsToUsers < ActiveRecord::Migration[7.0]
   def change
-    add_column :users, :renderer_settings, :json, default: {grid_width: 200, grid_depth: 200}
+    add_column :users, :renderer_settings, :json, default: SiteSettings::UserDefaults::RENDERER
   end
 end

--- a/db/migrate/20230316184012_add_tag_cloud_settings_to_user.rb
+++ b/db/migrate/20230316184012_add_tag_cloud_settings_to_user.rb
@@ -1,11 +1,5 @@
 class AddTagCloudSettingsToUser < ActiveRecord::Migration[7.0]
   def change
-    add_column :users, :tag_cloud_settings, :json, default: {
-      threshold: 0,
-      heatmap: true,
-      keypair: true,
-      sorting: "frequency",
-      hide_unrelated: true
-    }
+    add_column :users, :tag_cloud_settings, :json, default: SiteSettings::UserDefaults::TAG_CLOUD
   end
 end

--- a/db/migrate/20240209125409_add_file_list_settings_to_user.rb
+++ b/db/migrate/20240209125409_add_file_list_settings_to_user.rb
@@ -1,7 +1,5 @@
 class AddFileListSettingsToUser < ActiveRecord::Migration[7.0]
   def change
-    add_column :users, :file_list_settings, :json, default: {
-      hide_presupported_versions: true
-    }
+    add_column :users, :file_list_settings, :json, default: SiteSettings::UserDefaults::FILE_LIST
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -99,6 +99,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_03_160732) do
   end
 
   create_table "model_files", force: :cascade do |t|
+    t.string "filename"
     t.integer "model_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -107,9 +108,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_03_160732) do
     t.string "digest"
     t.text "notes"
     t.text "caption"
+    t.bigint "size"
     t.integer "presupported_version_id"
-    t.string "filename"
-    t.integer "size"
     t.json "attachment_data"
     t.index ["digest"], name: "index_model_files_on_digest"
     t.index ["filename", "model_id"], name: "index_model_files_on_filename_and_model_id", unique: true
@@ -203,9 +203,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_07_03_160732) do
     t.datetime "updated_at", null: false
     t.string "username", null: false
     t.json "pagination_settings", default: {"models"=>true, "creators"=>true, "collections"=>true, "per_page"=>12}
-    t.json "renderer_settings", default: {"grid_width"=>200, "grid_depth"=>200}
+    t.json "renderer_settings", default: {"grid_width"=>200, "grid_depth"=>200, "show_grid"=>true, "enable_pan_zoom"=>false, "background_colour"=>"#000000", "object_colour"=>"#cccccc", "render_style"=>"normals"}
     t.json "tag_cloud_settings", default: {"threshold"=>0, "heatmap"=>true, "keypair"=>true, "sorting"=>"frequency", "hide_unrelated"=>true}
-    t.json "problem_settings", default: {"missing"=>"danger", "empty"=>"info", "nesting"=>"warning", "inefficient"=>"info", "duplicate"=>"warning", "no_image"=>"silent", "no_3d_model"=>"silent"}
+    t.json "problem_settings", default: {"missing"=>"danger", "empty"=>"info", "nesting"=>"warning", "inefficient"=>"info", "duplicate"=>"warning", "no_image"=>"silent", "no_3d_model"=>"silent", "non_manifold"=>"warning", "inside_out"=>"warning"}
     t.json "file_list_settings", default: {"hide_presupported_versions"=>true}
     t.string "reset_password_token"
     t.datetime "remember_created_at"


### PR DESCRIPTION
Done by moving all user default settings into SiteSettings constants, not migrations. We should update users at login to apply any new defaults, sometime.

Resolves #2403 