### PR TITLE
Change default tag threshold to 2

### DIFF
--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -47,7 +47,7 @@ class SiteSettings < RailsSettings::Base
     }
 
     TAG_CLOUD = {
-      threshold: 0,
+      threshold: 2,
       heatmap: true,
       keypair: true,
       sorting: "frequency",


### PR DESCRIPTION
Because what's the point in showing tags with 0 or 1?