### PR TITLE
Fix major performance issues in tag cloud building by removing unrelated tag display

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -6,7 +6,6 @@ class CollectionsController < ApplicationController
     @collections = policy_scope(Collection)
     unless @filters.empty?
       process_filters_init
-      process_filters_tags_fetchall
       process_filters
       @collections = @collections.tree_both(@filters[:collection] || nil, @models.filter_map { |model| model.collection_id })
     end

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -10,7 +10,7 @@ class CollectionsController < ApplicationController
       @collections = @collections.tree_both(@filters[:collection] || nil, @models.filter_map { |model| model.collection_id })
     end
 
-    @tags, @unrelated_tag_count = generate_tag_list(@filters.empty? ? nil : @models)
+    @tags, @unrelated_tag_count = generate_tag_list(@filters.empty? ? nil : @models, @filter_tags)
 
     # Ordering
     @collections = case session["order"]

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -10,7 +10,7 @@ class CollectionsController < ApplicationController
       process_filters_init
       process_filters_tags_fetchall
       process_filters
-      @tags = generate_tag_list(@models)
+      @tags, @unrelated_tag_count = generate_tag_list(@models)
       @collections = @collections.tree_both(@filters[:collection] || nil, @models.filter_map { |model| model.collection_id })
     end
 

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -5,12 +5,11 @@ class CollectionsController < ApplicationController
   def index
     @collections = policy_scope(Collection)
     if @filters.empty?
-      @commontags = @tags = ActsAsTaggableOn::Tag.all
+      @tags = ActsAsTaggableOn::Tag.all
     else
       process_filters_init
       process_filters_tags_fetchall
       process_filters
-      process_filters_tags_highlight
       @collections = @collections.tree_both(@filters[:collection] || nil, @models.filter_map { |model| model.collection_id })
     end
 

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -4,15 +4,14 @@ class CollectionsController < ApplicationController
 
   def index
     @collections = policy_scope(Collection)
-    if @filters.empty?
-      @tags = ActsAsTaggableOn::Tag.all
-    else
+    unless @filters.empty?
       process_filters_init
       process_filters_tags_fetchall
       process_filters
-      @tags, @unrelated_tag_count = generate_tag_list(@models)
       @collections = @collections.tree_both(@filters[:collection] || nil, @models.filter_map { |model| model.collection_id })
     end
+
+    @tags, @unrelated_tag_count = generate_tag_list(@filters.empty? ? nil : @models)
 
     # Ordering
     @collections = case session["order"]

--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -10,6 +10,7 @@ class CollectionsController < ApplicationController
       process_filters_init
       process_filters_tags_fetchall
       process_filters
+      @tags = generate_tag_list(@models)
       @collections = @collections.tree_both(@filters[:collection] || nil, @models.filter_map { |model| model.collection_id })
     end
 

--- a/app/controllers/concerns/model_filters.rb
+++ b/app/controllers/concerns/model_filters.rb
@@ -13,17 +13,6 @@ module ModelFilters
     @models = policy_scope(Model).includes(:tags, :preview_file, :creator, :collection)
   end
 
-  def process_filters_tags_fetchall
-    # libraries may (probably) have wildly varying sets of tags (passed on for use in tag cloud)
-    # grab these before applying filters to get "all" applicable tags (if library filter is set trim to library)
-    @tags = if @filters[:library]
-      Model.includes(:tags).where(library: @filters[:library])
-    else
-      Model.includes(:tags)
-    end
-  end
-
-
   def generate_tag_list(models = nil)
     # All tags bigger than threshold
     tags = all_tags = ActsAsTaggableOn::Tag.where(taggings_count: current_user.tag_cloud_settings["threshold"]..)

--- a/app/controllers/concerns/model_filters.rb
+++ b/app/controllers/concerns/model_filters.rb
@@ -30,6 +30,11 @@ module ModelFilters
     end
   end
 
+  # Generate a list of tags shared by a list of models, and a count of the how many were unrelated
+  def generate_tag_list(models)
+    ActsAsTaggableOn::Tag.includes(:taggings).where("taggings.taggable": models)
+  end
+
   def process_filters
     # filter by library?
     @models = @models.where(library: params[:library]) if @filters[:library]

--- a/app/controllers/concerns/model_filters.rb
+++ b/app/controllers/concerns/model_filters.rb
@@ -32,7 +32,9 @@ module ModelFilters
 
   # Generate a list of tags shared by a list of models, and a count of the how many were unrelated
   def generate_tag_list(models)
-    ActsAsTaggableOn::Tag.includes(:taggings).where("taggings.taggable": models)
+    tags = ActsAsTaggableOn::Tag.includes(:taggings).where("taggings.taggable": models)
+    unrelated_tag_count = ActsAsTaggableOn::Tag.count - @tags.count
+    return tags, unrelated_tag_count
   end
 
   def process_filters

--- a/app/controllers/concerns/model_filters.rb
+++ b/app/controllers/concerns/model_filters.rb
@@ -30,11 +30,6 @@ module ModelFilters
     end
   end
 
-  def process_filters_tags_highlight
-    # this is used for tag cloud for highlighting.  fetch after processing
-    @commontags = ActsAsTaggableOn::Tag.joins(:taggings).where(taggings: {taggable: @models.except(:limit, :offset, :distinct)})
-  end
-
   def process_filters
     # filter by library?
     @models = @models.where(library: params[:library]) if @filters[:library]

--- a/app/controllers/concerns/model_filters.rb
+++ b/app/controllers/concerns/model_filters.rb
@@ -21,16 +21,16 @@ module ModelFilters
     # Generate a list of tags shared by the list of models
     tags = tags.includes(:taggings).where("taggings.taggable": models) if models
     # Apply tag sorting
-    case current_user.tag_cloud_settings["sorting"]
+    tags = case current_user.tag_cloud_settings["sorting"]
     when "alphabetical"
-      tags = tags.order(name: :asc)
+      tags.order(name: :asc)
     else
-      tags = tags.order(taggings_count: :desc, name: :asc)
+      tags.order(taggings_count: :desc, name: :asc)
     end
     # Work out how many tags were unrelated and will be hidden
     unrelated_tag_count = models ? (all_tags.count - tags.count) : 0
     # Done!
-    return tags, unrelated_tag_count
+    [tags, unrelated_tag_count]
   end
 
   def process_filters

--- a/app/controllers/creators_controller.rb
+++ b/app/controllers/creators_controller.rb
@@ -7,11 +7,10 @@ class CreatorsController < ApplicationController
     unless @filters.empty?
       process_filters_init
       process_filters
-      @tags, @unrelated_tag_count = generate_tag_list(@models)
       @creators = @creators.where(id: @models.map { |model| model.creator_id })
     end
 
-    @tags, @unrelated_tag_count = generate_tag_list(@filters.empty? ? nil : @models)
+    @tags, @unrelated_tag_count = generate_tag_list(@filters.empty? ? nil : @models, @filter_tags)
 
     # Ordering
     @creators = case session["order"]

--- a/app/controllers/creators_controller.rb
+++ b/app/controllers/creators_controller.rb
@@ -5,12 +5,11 @@ class CreatorsController < ApplicationController
   def index
     @creators = policy_scope(Creator)
     if @filters.empty?
-      @commontags = @tags = ActsAsTaggableOn::Tag.all
+      @tags = ActsAsTaggableOn::Tag.all
     else
       process_filters_init
       process_filters_tags_fetchall
       process_filters
-      process_filters_tags_highlight
       @creators = @creators.where(id: @models.map { |model| model.creator_id })
     end
 

--- a/app/controllers/creators_controller.rb
+++ b/app/controllers/creators_controller.rb
@@ -6,7 +6,6 @@ class CreatorsController < ApplicationController
     @creators = policy_scope(Creator)
     unless @filters.empty?
       process_filters_init
-      process_filters_tags_fetchall
       process_filters
       @tags, @unrelated_tag_count = generate_tag_list(@models)
       @creators = @creators.where(id: @models.map { |model| model.creator_id })

--- a/app/controllers/creators_controller.rb
+++ b/app/controllers/creators_controller.rb
@@ -4,15 +4,15 @@ class CreatorsController < ApplicationController
 
   def index
     @creators = policy_scope(Creator)
-    if @filters.empty?
-      @tags = ActsAsTaggableOn::Tag.all
-    else
+    unless @filters.empty?
       process_filters_init
       process_filters_tags_fetchall
       process_filters
       @tags, @unrelated_tag_count = generate_tag_list(@models)
       @creators = @creators.where(id: @models.map { |model| model.creator_id })
     end
+
+    @tags, @unrelated_tag_count = generate_tag_list(@filters.empty? ? nil : @models)
 
     # Ordering
     @creators = case session["order"]

--- a/app/controllers/creators_controller.rb
+++ b/app/controllers/creators_controller.rb
@@ -10,7 +10,7 @@ class CreatorsController < ApplicationController
       process_filters_init
       process_filters_tags_fetchall
       process_filters
-      @tags = generate_tag_list(@models)
+      @tags, @unrelated_tag_count = generate_tag_list(@models)
       @creators = @creators.where(id: @models.map { |model| model.creator_id })
     end
 

--- a/app/controllers/creators_controller.rb
+++ b/app/controllers/creators_controller.rb
@@ -10,6 +10,7 @@ class CreatorsController < ApplicationController
       process_filters_init
       process_filters_tags_fetchall
       process_filters
+      @tags = generate_tag_list(@models)
       @creators = @creators.where(id: @models.map { |model| model.creator_id })
     end
 

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -28,7 +28,6 @@ class ModelsController < ApplicationController
 
     process_filters_tags_fetchall
     process_filters
-    process_filters_tags_highlight
 
     # Load extra data
     @models = @models.includes [:library, :model_files, :preview_file, :creator, :collection]

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -26,7 +26,6 @@ class ModelsController < ApplicationController
       @models = @models.page(page).per(current_user.pagination_settings["per_page"])
     end
 
-    process_filters_tags_fetchall
     process_filters
     @tags, @unrelated_tag_count = generate_tag_list(@filters.empty? ? nil : @models)
 

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -27,7 +27,7 @@ class ModelsController < ApplicationController
     end
 
     process_filters
-    @tags, @unrelated_tag_count = generate_tag_list(@filters.empty? ? nil : @models)
+    @tags, @unrelated_tag_count = generate_tag_list(@filters.empty? ? nil : @models, @filter_tags)
 
     # Load extra data
     @models = @models.includes [:library, :model_files, :preview_file, :creator, :collection]

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -28,6 +28,7 @@ class ModelsController < ApplicationController
 
     process_filters_tags_fetchall
     process_filters
+    @tags = generate_tag_list(@models)
 
     # Load extra data
     @models = @models.includes [:library, :model_files, :preview_file, :creator, :collection]

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -28,7 +28,7 @@ class ModelsController < ApplicationController
 
     process_filters_tags_fetchall
     process_filters
-    @tags = generate_tag_list(@models)
+    @tags, @unrelated_tag_count = generate_tag_list(@models)
 
     # Load extra data
     @models = @models.includes [:library, :model_files, :preview_file, :creator, :collection]

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -28,7 +28,7 @@ class ModelsController < ApplicationController
 
     process_filters_tags_fetchall
     process_filters
-    @tags, @unrelated_tag_count = generate_tag_list(@models)
+    @tags, @unrelated_tag_count = generate_tag_list(@filters.empty? ? nil : @models)
 
     # Load extra data
     @models = @models.includes [:library, :model_files, :preview_file, :creator, :collection]

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -52,8 +52,7 @@ class SettingsController < ApplicationController
       "threshold" => settings[:threshold].to_i,
       "heatmap" => settings[:heatmap] == "1",
       "keypair" => settings[:keypair] == "1",
-      "sorting" => settings[:sorting],
-      "hide_unrelated" => settings[:hide_unrelated] == "1"
+      "sorting" => settings[:sorting]
     }
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -52,19 +52,6 @@ module ApplicationHelper
     end
   end
 
-  def tag_class(state)
-    case state
-    when :highlight
-      "bg-primary"
-    when :mute
-      "border border-muted text-muted pe-none"
-    when :hide
-      "d-none"
-    else
-      "bg-secondary"
-    end
-  end
-
   def text_input_row(form, name, options = {})
     content_tag :div, class: "row mb-3 input-group" do
       safe_join [

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -50,8 +50,7 @@ class SiteSettings < RailsSettings::Base
       threshold: 2,
       heatmap: true,
       keypair: true,
-      sorting: "frequency",
-      hide_unrelated: true
+      sorting: "frequency"
     }
 
     FILE_LIST = {

--- a/app/views/application/_filters_card.html.erb
+++ b/app/views/application/_filters_card.html.erb
@@ -32,7 +32,7 @@
     <% if @filters[:tag] %>
       <div class="row">
         <div class="col-auto"><%= icon "tag", ActsAsTaggableOn::Tag.model_name.human(count: 100) %></div>
-        <div class="col" aria-label="<%= ActsAsTaggableOn::Tag.model_name.human(count: 100) %>"><span class='pe-none'><%= render partial: "tag", collection: @filter_tags, locals: {state: :normal} %></span></div>
+        <div class="col" aria-label="<%= ActsAsTaggableOn::Tag.model_name.human(count: 100) %>"><span class='pe-none'><%= render partial: "tag", collection: @filter_tags %></span></div>
         <div class="col-auto"><%= link_to icon("trash", t(".remove_tag_filter")), @filters.except(:tag), {class: "text-danger"} %></div>
       </div>
     <% end %>

--- a/app/views/application/_filters_card.html.erb
+++ b/app/views/application/_filters_card.html.erb
@@ -32,7 +32,7 @@
     <% if @filters[:tag] %>
       <div class="row">
         <div class="col-auto"><%= icon "tag", ActsAsTaggableOn::Tag.model_name.human(count: 100) %></div>
-        <div class="col" aria-label="<%= ActsAsTaggableOn::Tag.model_name.human(count: 100) %>"><span class='pe-none'><%= render partial: "tag", collection: @tag, locals: {state: :normal} %></span></div>
+        <div class="col" aria-label="<%= ActsAsTaggableOn::Tag.model_name.human(count: 100) %>"><span class='pe-none'><%= render partial: "tag", collection: @filter_tags, locals: {state: :normal} %></span></div>
         <div class="col-auto"><%= link_to icon("trash", t(".remove_tag_filter")), @filters.except(:tag), {class: "text-danger"} %></div>
       </div>
     <% end %>

--- a/app/views/application/_tag.html.erb
+++ b/app/views/application/_tag.html.erb
@@ -4,6 +4,6 @@
 <%= link_to current_user.tag_cloud_settings["heatmap"] ? "#{name} (#{tag.taggings_count})" : name,
       filters.merge(tag: filters[:tag] | [tag.name]),
       {
-        class: "badge rounded-pill #{tag_class(state)} tag",
+        class: "badge rounded-pill bg-secondary tag",
         data: {bulk_item_tags: defined?(model_id) ? model_id&.to_s : nil}
       } %>

--- a/app/views/application/_tag_list.html.erb
+++ b/app/views/application/_tag_list.html.erb
@@ -27,6 +27,6 @@
     <% end %>
   </ul>
 <% end %>
-<% if defined?(muted_tags) && !muted_tags.empty? %>
-  <p class="small"><%= t ".muted_tags", count: muted_tags.count %></p>
+<% if defined?(unrelated_tag_count) && unrelated_tag_count > 0 %>
+  <p class="small"><%= t ".unrelated_tag_count", count: unrelated_tag_count %></p>
 <% end %>

--- a/app/views/application/_tag_list.html.erb
+++ b/app/views/application/_tag_list.html.erb
@@ -11,21 +11,14 @@
      end %>
   <% tags = plaintags %>
 <% end %>
-<% tags.each do |tag| %>
-  <%= render partial: "tag", locals: {tag: tag, state: ((defined?(muted_tags) && muted_tags.include?(tag)) ? (current_user.tag_cloud_settings["hide_unrelated"] ? :hide : :mute) : :normal)} %>
-<% end %>
+<%= render partial: "tag", collection: tags %>
 <% if current_user.tag_cloud_settings["keypair"] %>
   <ul class="list-unstyled">
     <% tiers.each do |tier| %>
       <li>
         <details id="<%= tier %>">
           <summary><%= tier %></summary>
-          <%- tiertags.select { |obj| obj.name.match?("^#{tier}:") }.each do |tag| %>
-            <%= render partial: "tag", locals: {
-                  tag: tag,
-                  state: (defined?(muted_tags) && muted_tags.include?(tag)) ? (current_user.tag_cloud_settings["hide_unrelated"] ? :hide : :mute) : :normal
-                } %>
-          <%- end %>
+          <%= render partial: "tag", collection: tiertags.select { |obj| obj.name.match?("^#{tier}:") } %>
           <%- if tierunset && tierunset[tier] > 0 %>
             <%= link_to "unset (#{tierunset[tier]})", (@filters || {}).merge(missingtag: tier), {class: "badge rounded-pill border border-muted text-danger tag"} %>
           <%- end %>
@@ -34,6 +27,6 @@
     <% end %>
   </ul>
 <% end %>
-<% if defined?(muted_tags) && !muted_tags.empty? && current_user.tag_cloud_settings["hide_unrelated"] %>
+<% if defined?(muted_tags) && !muted_tags.empty? %>
   <p class="small"><%= t ".muted_tags", count: muted_tags.count %></p>
 <% end %>

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -28,7 +28,7 @@
   <%= render "filters_card" %>
   <% unless @tags.empty? %>
     <%= card :secondary, ActsAsTaggableOn::Tag.model_name.human(count: 100), collapse: "md", skip_link: {target: "footer", text: t(".skip_tags")}  do %>
-      <%= render "tag_list", tags: @tags - (@tag || []), muted_tags: @tags - @commontags %>
+      <%= render "tag_list", tags: @tags - (@tag || []) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -28,7 +28,7 @@
   <%= render "filters_card" %>
   <% unless @tags.empty? %>
     <%= card :secondary, ActsAsTaggableOn::Tag.model_name.human(count: 100), collapse: "md", skip_link: {target: "footer", text: t(".skip_tags")}  do %>
-      <%= render "tag_list", tags: @tags - (@tag || []), unrelated_tag_count: @unrelated_tag_count %>
+      <%= render "tag_list", tags: @tags, unrelated_tag_count: @unrelated_tag_count %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -28,7 +28,7 @@
   <%= render "filters_card" %>
   <% unless @tags.empty? %>
     <%= card :secondary, ActsAsTaggableOn::Tag.model_name.human(count: 100), collapse: "md", skip_link: {target: "footer", text: t(".skip_tags")}  do %>
-      <%= render "tag_list", tags: @tags - (@tag || []) %>
+      <%= render "tag_list", tags: @tags - (@tag || []), unrelated_tag_count: @unrelated_tag_count %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/creators/index.html.erb
+++ b/app/views/creators/index.html.erb
@@ -25,7 +25,7 @@
   <%= render "filters_card" %>
   <% unless @tags.empty? %>
     <%= card :secondary, ActsAsTaggableOn::Tag.model_name.human(count: 100), collapse: "md", skip_link: {target: "footer", text: t(".skip_tags")}  do %>
-      <%= render "tag_list", tags: @tags - (@tag || []), muted_tags: @tags - @commontags %>
+      <%= render "tag_list", tags: @tags - (@tag || []) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/creators/index.html.erb
+++ b/app/views/creators/index.html.erb
@@ -25,7 +25,7 @@
   <%= render "filters_card" %>
   <% unless @tags.empty? %>
     <%= card :secondary, ActsAsTaggableOn::Tag.model_name.human(count: 100), collapse: "md", skip_link: {target: "footer", text: t(".skip_tags")}  do %>
-      <%= render "tag_list", tags: @tags - (@tag || []), unrelated_tag_count: @unrelated_tag_count %>
+      <%= render "tag_list", tags: @tags, unrelated_tag_count: @unrelated_tag_count %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/creators/index.html.erb
+++ b/app/views/creators/index.html.erb
@@ -25,7 +25,7 @@
   <%= render "filters_card" %>
   <% unless @tags.empty? %>
     <%= card :secondary, ActsAsTaggableOn::Tag.model_name.human(count: 100), collapse: "md", skip_link: {target: "footer", text: t(".skip_tags")}  do %>
-      <%= render "tag_list", tags: @tags - (@tag || []) %>
+      <%= render "tag_list", tags: @tags - (@tag || []), unrelated_tag_count: @unrelated_tag_count %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/models/bulk_edit.html.erb
+++ b/app/views/models/bulk_edit.html.erb
@@ -21,7 +21,7 @@
         <td><%= render partial: "tag",
                   collection: (current_user.tag_cloud_settings["sorting"] == "alphabetical") ?
                     model.tags.sort_by(&:name) : model.tags.sort_by(&:name).reverse.sort_by(&:taggings_count).reverse,
-                  locals: {state: :normal, model_id: model.id} %></td>
+                  locals: {model_id: model.id} %></td>
         <td><%= link_to model.creator.name, model.creator if model.creator %></td>
         <td><%= icon("exclamation-triangle", t(".needs_organizing")) if model.needs_organizing? %></code></td>
       </tr>

--- a/app/views/models/index.html.erb
+++ b/app/views/models/index.html.erb
@@ -30,7 +30,7 @@
   <%= render "filters_card" %>
   <% unless @tags.empty? %>
     <%= card :secondary, ActsAsTaggableOn::Tag.model_name.human(count: 100), collapse: "md", skip_link: {target: "footer", text: t(".skip_tags")} do %>
-      <%= render "tag_list", tags: @tags - (@tag || []), unrelated_tag_count: @unrelated_tag_count %>
+      <%= render "tag_list", tags: @tags, unrelated_tag_count: @unrelated_tag_count %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/models/index.html.erb
+++ b/app/views/models/index.html.erb
@@ -30,7 +30,7 @@
   <%= render "filters_card" %>
   <% unless @tags.empty? %>
     <%= card :secondary, ActsAsTaggableOn::Tag.model_name.human(count: 100), collapse: "md", skip_link: {target: "footer", text: t(".skip_tags")} do %>
-      <%= render "tag_list", tags: @tags - (@tag || []) %>
+      <%= render "tag_list", tags: @tags - (@tag || []), unrelated_tag_count: @unrelated_tag_count %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/models/index.html.erb
+++ b/app/views/models/index.html.erb
@@ -30,7 +30,7 @@
   <%= render "filters_card" %>
   <% unless @tags.empty? %>
     <%= card :secondary, ActsAsTaggableOn::Tag.model_name.human(count: 100), collapse: "md", skip_link: {target: "footer", text: t(".skip_tags")} do %>
-      <%= render "tag_list", tags: @tags - (@tag || []), muted_tags: @tags - @commontags %>
+      <%= render "tag_list", tags: @tags - (@tag || []) %>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/settings/_tag_cloud_settings.html.erb
+++ b/app/views/settings/_tag_cloud_settings.html.erb
@@ -14,12 +14,6 @@
       </div>
     </div>
     <div class="row">
-      <%= form.label nil, t(".hide_unrelated.label"), for: "tag_cloud[hide_unrelated]", class: "col col-form-label" %>
-      <div class="col form-check form-switch">
-        <%= form.check_box "tag_cloud[hide_unrelated]", checked: @user.tag_cloud_settings["hide_unrelated"], class: "form-check-input" %>
-      </div>
-    </div>
-    <div class="row">
       <%= form.label nil, t(".sorting.label"), for: "tag_cloud[sorting]", class: "col col-form-label" %>
       <div class="col">
         <%= form.select "tag_cloud[sorting]", ["frequency", "alphabetical"],

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -226,7 +226,7 @@ de:
       settings: Einstellungen
       upload: Hochladen
     tag_list:
-      muted_tags:
+      unrelated_tag_count:
         one:
         other:
     tagline: Hilft ihnen ihre 3D-Druck Dateien zu verwalten

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -226,7 +226,7 @@ en:
       settings: Settings
       upload: Upload
     tag_list:
-      muted_tags:
+      unrelated_tag_count:
         one: "%{count} unrelated tag hidden"
         other: "%{count} unrelated tags hidden"
     tagline: Helping you keep track of your 3d print files

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -226,7 +226,7 @@ fr:
       settings: Paramètres
       upload: Télécharger
     tag_list:
-      muted_tags:
+      unrelated_tag_count:
         one:
         other:
     tagline: Vous aider à garder une trace de vos fichiers d'impression 3D

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -226,7 +226,7 @@ pl:
       settings: Ustawienia
       upload: Prześlij
     tag_list:
-      muted_tags:
+      unrelated_tag_count:
         one: "%{count} niepowiązany tag ukryty"
         other: "%{count} niepowiązanych tagów ukrytych"
     tagline: Pomaga w śledzeniu plików do druku 3D

--- a/config/locales/settings/de.yml
+++ b/config/locales/settings/de.yml
@@ -104,8 +104,6 @@ de:
       heading:
       heatmap:
         label:
-      hide_unrelated:
-        label: Nicht verwandte Tags in gefilterten Listen ausblenden
       keypair:
         label: Begrenzungszeichen zur Darstellung von Schlüsselpaaren verwenden
       sorting:

--- a/config/locales/settings/en.yml
+++ b/config/locales/settings/en.yml
@@ -104,8 +104,6 @@ en:
       heading: Tag Cloud
       heatmap:
         label: Display tag count for individual tags
-      hide_unrelated:
-        label: Hide unrelated tags in filtered lists
       keypair:
         label: Use delimiter to represent keypairs
       sorting:

--- a/config/locales/settings/fr.yml
+++ b/config/locales/settings/fr.yml
@@ -104,8 +104,6 @@ fr:
       heading: Nuages de mots-clés
       heatmap:
         label: Afficher le nombre d'étiquette pour chaque étiquette
-      hide_unrelated:
-        label: Masquer les tags sans rapport avec le sujet dans les listes filtrées
       keypair:
         label: Utiliser un délimiteur pour représenter les paires de clés
       sorting:

--- a/config/locales/settings/pl.yml
+++ b/config/locales/settings/pl.yml
@@ -104,8 +104,6 @@ pl:
       heading: Chmura tagów
       heatmap:
         label: Wyświetl liczbe tagów dla poszczególnych tagów
-      hide_unrelated:
-        label: Ukryj niepowiązane tagi na filtrowanych listach
       keypair:
         label: Użyj separatora do reprezentowania par kluczy
       sorting:

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -41,15 +41,6 @@ RSpec.describe ApplicationHelper do
     end
   end
 
-  describe "#tag_class" do
-    it "returns the correct class for each state" do # rubocop:todo RSpec/MultipleExpectations
-      expect(helper.tag_class(:highlight)).to eq("bg-primary")
-      expect(helper.tag_class(:mute)).to eq("border border-muted text-muted pe-none")
-      expect(helper.tag_class(:hide)).to eq("d-none")
-      expect(helper.tag_class(:other)).to eq("bg-secondary")
-    end
-  end
-
   describe "#text_input_row" do
     it "returns the correct HTML for the text input row" do # rubocop:todo RSpec/MultipleExpectations
       form = ActionView::Helpers::FormBuilder.new(:test, nil, helper, {})


### PR DESCRIPTION
Should at least partially deal with #2419 and #2084 