### PR TITLE
Fix PostgreSQL error during search

### DIFF
--- a/app/controllers/concerns/model_filters.rb
+++ b/app/controllers/concerns/model_filters.rb
@@ -15,7 +15,7 @@ module ModelFilters
     # Ignore any tags that have been applied as filters
     tags = all_tags = tags.where.not(id: filter_tags) if filter_tags
     # Generate a list of tags shared by the list of models
-    tags = tags.includes(:taggings).where("taggings.taggable": models) if models
+    tags = tags.includes(:taggings).where("taggings.taggable": models.map(&:id)) if models
     # Apply tag sorting
     tags = case current_user.tag_cloud_settings["sorting"]
     when "alphabetical"


### PR DESCRIPTION
Postgres doesn't like including all the conditions for this inside another query, so we split the query and get just a list of model IDs.

Resolves #2439 properly this time.