### PR TITLE
Add a stable env var for the rails app port

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -7,5 +7,6 @@ then
 fi
 
 bin/setup
-
+export PORT=5000
+export RAILS_PORT=$PORT
 foreman start -f Procfile.dev "$@"

--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -17,4 +17,5 @@ echo "Setting temporary directory permissions..."
 chown -R $PUID:$PGID tmp log
 
 echo "Launching application..."
+export RAILS_PORT=$PORT
 exec s6-setuidgid $PUID:$PGID $@

--- a/config/application.rb
+++ b/config/application.rb
@@ -67,5 +67,5 @@ end
 # Set default URL options from env vars
 Rails.application.default_url_options = {
   host: ENV.fetch("PUBLIC_HOSTNAME", "localhost"),
-  port: ENV.fetch("PUBLIC_PORT", ENV.fetch("PORT", "3214"))
+  port: ENV.fetch("PUBLIC_PORT", ENV.fetch("RAILS_PORT", "3214"))
 }.compact


### PR DESCRIPTION
so that foreman doesn't autoincrement it and we can use it in workers