### PR TITLE
Remove temporarily-created models if ProcessUploadedFileJob fails

### DIFF
--- a/spec/jobs/process_uploaded_file_job_spec.rb
+++ b/spec/jobs/process_uploaded_file_job_spec.rb
@@ -51,4 +51,23 @@ RSpec.describe ProcessUploadedFileJob do
       ])).to eq 0
     end
   end
+
+  context "when errors occur during processing" do
+    let(:library) { create(:library) }
+    let(:file) { Rack::Test::UploadedFile.new(StringIO.new, original_filename: "test.zip") }
+
+    it "removes the created model" do # rubocop:todo RSpec/ExampleLength
+      job = described_class.new
+      allow(job).to receive(:unzip).and_raise(StandardError)
+      expect {
+        begin
+          job.perform(library.id, file)
+        rescue
+          nil
+        end
+      }.not_to change(Model, :count)
+    end
+
+    it "leaves the uploaded file in place"
+  end
 end


### PR DESCRIPTION
resolves #2525
resolves #2472