### PR TITLE
Don't repeat activities within 5 minutes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,7 +40,7 @@ GIT
 
 GIT
   remote: https://gitlab.com/manyfold3d/federails.git
-  revision: df6de7ed21eb6efae1ff0a68d997d51ec5019fcd
+  revision: 168de5edffdbb30905395868cb892db886806cc6
   branch: polymorphic_actor_relationship
   specs:
     federails (0.0.1)

--- a/app/models/concerns/followable.rb
+++ b/app/models/concerns/followable.rb
@@ -2,6 +2,8 @@ module Followable
   extend ActiveSupport::Concern
   include FederailsCommon
 
+  TIMEOUT = 5
+
   included do
     delegate :following_followers, to: :actor
     after_create :post_creation_activity
@@ -30,6 +32,7 @@ module Followable
   end
 
   def post_update_activity
+    return if actor.activities_as_entity.where(created_at: TIMEOUT.minutes.ago..).count > 0
     default_user = User.with_role(:administrator).first
     return if default_user.nil?
     Federails::Activity.create!(

--- a/spec/models/concerns/followable_shared.rb
+++ b/spec/models/concerns/followable_shared.rb
@@ -1,16 +1,45 @@
 shared_examples "Followable" do
-  let(:follower) { create(:user) }
-  let(:target) { create(described_class.to_s.underscore.to_sym) }
+  context "when being followed" do
+    let(:follower) { create(:user) }
+    let(:target) { create(described_class.to_s.underscore.to_sym) }
 
-  before do
-    follower.follow(target)
+    before do
+      follower.follow(target)
+    end
+
+    it "shows as being followed by follower" do
+      expect(target.followed_by?(follower)).to be true
+    end
+
+    it "gets follower count" do
+      expect(target.followers.count).to eq 1
+    end
   end
 
-  it "shows as being followed by follower" do
-    expect(target.followed_by?(follower)).to be true
+  context "when being created" do
+    before do
+      create(:admin)
+    end
+
+    it "posts an activity" do
+      expect { create(described_class.to_s.underscore.to_sym) }.to change(Federails::Activity, :count).by(1)
+    end
   end
 
-  it "gets follower count" do
-    expect(target.followers.count).to eq 1
+  context "when being updated" do
+    let!(:entity) { create(described_class.to_s.underscore.to_sym) }
+
+    before do
+      create(:admin)
+    end
+
+    it "posts an activity after update" do
+      expect { entity.update caption: "test" }.to change(Federails::Activity, :count).by(1)
+    end
+
+    it "doesn't posts an activity after update if there's already been one recently" do
+      entity.update caption: "change"
+      expect { entity.update caption: "test" }.not_to change(Federails::Activity, :count)
+    end
   end
 end


### PR DESCRIPTION
If a model is edited repeatedly, it will produce a slew of update activities. This PR adds a 5-minute timeout on creation of new activities for an entity.

resolves #2531 