### PR TITLE
Ignore Synology-generated files

### DIFF
--- a/app/jobs/model_scan_job.rb
+++ b/app/jobs/model_scan_job.rb
@@ -14,7 +14,7 @@ class ModelScanJob < ApplicationJob
             pattern
           )
         end
-    library.list_files(glob).uniq.reject { |str| SiteSettings.ignored_file?(str) }
+    library.list_files(glob)
   end
 
   def perform(model_id, include_all_subfolders: false)

--- a/app/jobs/model_scan_job.rb
+++ b/app/jobs/model_scan_job.rb
@@ -14,7 +14,7 @@ class ModelScanJob < ApplicationJob
             pattern
           )
         end
-    library.list_files(glob).uniq
+    library.list_files(glob).uniq.reject { |str| SiteSettings.ignored_file?(str) }
   end
 
   def perform(model_id, include_all_subfolders: false)

--- a/app/jobs/process_uploaded_file_job.rb
+++ b/app/jobs/process_uploaded_file_job.rb
@@ -43,7 +43,7 @@ class ProcessUploadedFileJob < ApplicationJob
         Archive::Reader.open_filename(archive.path, strip_components: strip) do |reader|
           reader.each_entry do |entry|
             next if !entry.file? || entry.size > SiteSettings.max_file_extract_size
-            next if hidden?(entry.pathname)
+            next if SiteSettings.ignored_file?(entry.pathname)
             Dir.chdir(tmpdir) do
               reader.extract(entry, Archive::EXTRACT_SECURE)
               model.model_files.create(filename: entry.pathname, attachment: File.open(entry.pathname))
@@ -52,10 +52,6 @@ class ProcessUploadedFileJob < ApplicationJob
         end
       end
     end
-  end
-
-  def hidden?(pathname)
-    (File.split(pathname) - ["."]).any? { |x| x.starts_with? "." }
   end
 
   def count_common_path_components(archive)

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -116,7 +116,7 @@ class Library < ApplicationRecord
   end
 
   def list_files(pattern, flags = 0)
-    case storage_service
+    files = case storage_service
     when "filesystem"
       Dir.glob(pattern, flags, base: Shellwords.escape(path)).filter { |x| File.file?(File.join(path, x)) }
     when "s3"
@@ -129,6 +129,8 @@ class Library < ApplicationRecord
     else
       raise "Invalid storage service: #{storage_service}"
     end
+    # Filter out files that should be ignored
+    files.uniq.reject { |str| SiteSettings.ignored_file?(str) }
   end
 
   def has_file?(path)

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -41,6 +41,10 @@ class SiteSettings < RailsSettings::Base
     Rails.application.config.manyfold_features[:federation]
   end
 
+  def self.ignored_file?(pathname)
+    (File.split(pathname) - ["."]).any? { |x| x.starts_with? "." }
+  end
+
   module UserDefaults
     RENDERER = {
       grid_width: 200,

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -43,7 +43,8 @@ class SiteSettings < RailsSettings::Base
 
   def self.ignored_file?(pathname)
     @@patterns ||= [
-      /^\.[^\.]+/ # Hidden files starting with .
+      /^\.[^\.]+/, # Hidden files starting with .
+      /.*\/@eaDir\/.*/ # Synology temp files
     ]
     (File.split(pathname) - ["."]).any? do |path_component|
       @@patterns.any? { |pattern| path_component =~ pattern }

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -42,7 +42,12 @@ class SiteSettings < RailsSettings::Base
   end
 
   def self.ignored_file?(pathname)
-    (File.split(pathname) - ["."]).any? { |x| x.starts_with? "." }
+    @@patterns ||= [
+      /^\.[^\.]+/ # Hidden files starting with .
+    ]
+    (File.split(pathname) - ["."]).any? do |path_component|
+      @@patterns.any? { |pattern| path_component =~ pattern }
+    end
   end
 
   module UserDefaults

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -44,7 +44,8 @@ class SiteSettings < RailsSettings::Base
   def self.ignored_file?(pathname)
     @@patterns ||= [
       /^\.[^\.]+/, # Hidden files starting with .
-      /.*\/@eaDir\/.*/ # Synology temp files
+      /.*\/@eaDir\/.*/, # Synology temp files
+      /__MACOSX/ # MACOS resource forks
     ]
     (File.split(pathname) - ["."]).any? do |path_component|
       @@patterns.any? { |pattern| path_component =~ pattern }

--- a/spec/jobs/process_uploaded_file_job_spec.rb
+++ b/spec/jobs/process_uploaded_file_job_spec.rb
@@ -1,28 +1,6 @@
 require "rails_helper"
 
 RSpec.describe ProcessUploadedFileJob do
-  context "when detecting hidden files" do
-    it "detects normal files" do
-      expect(described_class.new.send(:hidden?, "test.stl")).to be false
-    end
-
-    it "detects normal files in subfolders" do
-      expect(described_class.new.send(:hidden?, "test/test.stl")).to be false
-    end
-
-    it "detects hidden files" do
-      expect(described_class.new.send(:hidden?, ".test.stl")).to be true
-    end
-
-    it "detects hidden files in subfolders" do
-      expect(described_class.new.send(:hidden?, "test/.test.stl")).to be true
-    end
-
-    it "detects normal files in hidden subfolders" do
-      expect(described_class.new.send(:hidden?, ".test/test.stl")).to be true
-    end
-  end
-
   context "when counting common path prefixes" do
     it "returns zero if there are no directories at all" do
       expect(described_class.new.send(:count_common_elements, [])).to eq 0

--- a/spec/models/site_settings_spec.rb
+++ b/spec/models/site_settings_spec.rb
@@ -2,24 +2,23 @@ require "rails_helper"
 
 RSpec.describe SiteSettings do
   context "when detecting ignored files" do
-    it "accepts normal files" do
-      expect(described_class.send(:ignored_file?, "test.stl")).to be false
+    %w[
+      test.stl
+      test/test.stl
+    ].each do |pathname|
+      it "accepts `#{pathname}`" do
+        expect(described_class.send(:ignored_file?, pathname)).to be false
+      end
     end
 
-    it "accepts normal files in subfolders" do
-      expect(described_class.send(:ignored_file?, "test/test.stl")).to be false
-    end
-
-    it "rejects hidden files" do
-      expect(described_class.send(:ignored_file?, ".test.stl")).to be true
-    end
-
-    it "rejects hidden files in subfolders" do
-      expect(described_class.send(:ignored_file?, "test/.test.stl")).to be true
-    end
-
-    it "rejects normal files in hidden subfolders" do
-      expect(described_class.send(:ignored_file?, ".test/test.stl")).to be true
+    %w[
+      .test.stl
+      test/.test.stl
+      .test/test.stl
+    ].each do |pathname|
+      it "ignores `#{pathname}`" do
+        expect(described_class.send(:ignored_file?, pathname)).to be true
+      end
     end
   end
 end

--- a/spec/models/site_settings_spec.rb
+++ b/spec/models/site_settings_spec.rb
@@ -15,6 +15,7 @@ RSpec.describe SiteSettings do
       .test.stl
       test/.test.stl
       .test/test.stl
+      model/@eaDir/test.png/SYNOPHOTO_THUMB_S.png
     ].each do |pathname|
       it "ignores `#{pathname}`" do
         expect(described_class.send(:ignored_file?, pathname)).to be true

--- a/spec/models/site_settings_spec.rb
+++ b/spec/models/site_settings_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe SiteSettings do
       test/.test.stl
       .test/test.stl
       model/@eaDir/test.png/SYNOPHOTO_THUMB_S.png
+      model/__MACOSX
     ].each do |pathname|
       it "ignores `#{pathname}`" do
         expect(described_class.send(:ignored_file?, pathname)).to be true

--- a/spec/models/site_settings_spec.rb
+++ b/spec/models/site_settings_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe SiteSettings do
+  context "when detecting ignored files" do
+    it "accepts normal files" do
+      expect(described_class.send(:ignored_file?, "test.stl")).to be false
+    end
+
+    it "accepts normal files in subfolders" do
+      expect(described_class.send(:ignored_file?, "test/test.stl")).to be false
+    end
+
+    it "rejects hidden files" do
+      expect(described_class.send(:ignored_file?, ".test.stl")).to be true
+    end
+
+    it "rejects hidden files in subfolders" do
+      expect(described_class.send(:ignored_file?, "test/.test.stl")).to be true
+    end
+
+    it "rejects normal files in hidden subfolders" do
+      expect(described_class.send(:ignored_file?, ".test/test.stl")).to be true
+    end
+  end
+end


### PR DESCRIPTION
The refactor in this also makes it easy to add more ignored types in future, and probably make it user-configurable as requested in #2545 