### PR TITLE
Fix ignoring of library root folder

### DIFF
--- a/app/jobs/scan/detect_filesystem_changes_job.rb
+++ b/app/jobs/scan/detect_filesystem_changes_job.rb
@@ -27,7 +27,10 @@ class Scan::DetectFilesystemChangesJob < ApplicationJob
     status[:step] = "jobs.scan.detect_filesystem_changes.building_folder_list" # i18n-tasks-use t('jobs.scan.detect_filesystem_changes.building_folder_list')
     folders_with_changes = changes.map { |f| File.dirname(f) }.uniq
     folders_with_changes = filter_out_common_subfolders(folders_with_changes)
+    # Ignore root folder, however specified
     folders_with_changes.delete("/")
+    folders_with_changes.delete(".")
+    folders_with_changes.delete("./")
     folders_with_changes.compact_blank!
     # For each folder in the library with a change, find or create a model, then scan it
     status[:step] = "jobs.scan.detect_filesystem_changes.creating_models" # i18n-tasks-use t('jobs.scan.detect_filesystem_changes.creating_models')

--- a/spec/models/site_settings_spec.rb
+++ b/spec/models/site_settings_spec.rb
@@ -3,6 +3,8 @@ require "rails_helper"
 RSpec.describe SiteSettings do
   context "when detecting ignored files" do
     %w[
+      ./test.stl
+      /test.stl
       test.stl
       test/test.stl
     ].each do |pathname|


### PR DESCRIPTION
The root folder should be ignored, but wasn't being after the change of file list generation a while back. In time we'll make files in the root into separate models somehow, but for now we should ignore them as we did before. Resolves #2504 