### PR TITLE
Exclude followable objects from nodeinfo stats

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -1,6 +1,6 @@
 class Collection < ApplicationRecord
   include Followable
-  acts_as_federails_actor username_field: :slug, name_field: :name, profile_url_method: :url_for, actor_type: "Collection"
+  acts_as_federails_actor username_field: :slug, name_field: :name, profile_url_method: :url_for, actor_type: "Collection", include_in_user_count: false
 
   has_many :models, dependent: :nullify
   has_many :collections, dependent: :nullify

--- a/app/models/creator.rb
+++ b/app/models/creator.rb
@@ -1,6 +1,6 @@
 class Creator < ApplicationRecord
   include Followable
-  acts_as_federails_actor username_field: :slug, name_field: :name, profile_url_method: :url_for
+  acts_as_federails_actor username_field: :slug, name_field: :name, profile_url_method: :url_for, include_in_user_count: false
 
   has_many :models, dependent: :nullify
   has_many :links, as: :linkable, dependent: :destroy

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -4,7 +4,7 @@ class Model < ApplicationRecord
   include PathParser
   include Followable
 
-  acts_as_federails_actor username_field: :slug, name_field: :name, profile_url_method: :url_for, actor_type: "Document"
+  acts_as_federails_actor username_field: :slug, name_field: :name, profile_url_method: :url_for, actor_type: "Document", include_in_user_count: false
 
   scope :recent, -> { order(created_at: :desc) }
 


### PR DESCRIPTION
Nodeinfo should only show actual users.