### PR TITLE
Don't set standard ports in URL options

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -73,7 +73,8 @@ module Manyfold
 end
 
 # Set default URL options from env vars
+port = ENV.fetch("PUBLIC_PORT", ENV.fetch("RAILS_PORT", "3214"))
 Rails.application.default_url_options = {
   host: ENV.fetch("PUBLIC_HOSTNAME", "localhost"),
-  port: ENV.fetch("PUBLIC_PORT", ENV.fetch("RAILS_PORT", "3214"))
+  port: ["80", "443"].include?(port) ? nil : port
 }.compact


### PR DESCRIPTION
Before, if PUBLIC_PORT was set to 80 or 442, we'd end up with those on the end of URLs, which isn't necessary.