### PR TITLE
Exclude healthcheck endpoint from forced SSL

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -47,6 +47,10 @@ Rails.application.configure do
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = (ENV.fetch("HTTPS_ONLY", nil) === "enabled")
+  # Exclude health endpoint from SSL redirection, so that reverse proxies can use it
+  config.ssl_options = {
+    redirect: {exclude: ->(request) { request.path == "/health" }}
+  }
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
so that proxies can use it