### PR TITLE
Rename default roles for greater clarity alongside ReBAC permissions

### DIFF
--- a/app/jobs/process_uploaded_file_job.rb
+++ b/app/jobs/process_uploaded_file_job.rb
@@ -14,7 +14,7 @@ class ProcessUploadedFileJob < ApplicationJob
     model_name = model_path.humanize.tr("+", " ").titleize
     # Create model
     model = library.models.create(name: model_name, path: "#{model_path}##{SecureRandom.hex(4)}")
-    model.grant_permission_to "owner", owner
+    model.grant_permission_to "own", owner
     model.update! path: "#{model_path}##{model.id}" # Set to proper ID after saving
     # Handle different file types
     begin

--- a/app/models/concerns/default_view_permissions.rb
+++ b/app/models/concerns/default_view_permissions.rb
@@ -7,7 +7,7 @@ module DefaultViewPermissions
 
   def assign_default_view_permissions
     # Grant local view access by default
-    grant_permission_to("view", Role.find_or_create_by(name: :viewer))
+    grant_permission_to("view", Role.find_or_create_by(name: :member))
     # Set default owner
     owner = SiteSettings.default_user
     grant_permission_to("own", owner) if owner

--- a/app/models/concerns/default_view_permissions.rb
+++ b/app/models/concerns/default_view_permissions.rb
@@ -7,9 +7,9 @@ module DefaultViewPermissions
 
   def assign_default_view_permissions
     # Grant local view access by default
-    grant_permission_to("viewer", Role.find_or_create_by(name: :viewer))
+    grant_permission_to("view", Role.find_or_create_by(name: :viewer))
     # Set default owner
     owner = SiteSettings.default_user
-    grant_permission_to("owner", owner) if owner
+    grant_permission_to("own", owner) if owner
   end
 end

--- a/app/models/concerns/followable.rb
+++ b/app/models/concerns/followable.rb
@@ -21,7 +21,7 @@ module Followable
   private
 
   def post_creation_activity
-    user = permitted_users.with_permission("owner").first || SiteSettings.default_user
+    user = permitted_users.with_permission("own").first || SiteSettings.default_user
     return if user.nil?
     user.create_actor_if_missing
     Federails::Activity.create!(
@@ -34,7 +34,7 @@ module Followable
 
   def post_update_activity
     return if actor.activities_as_entity.where(created_at: TIMEOUT.minutes.ago..).count > 0
-    user = permitted_users.with_permission("owner").first || SiteSettings.default_user
+    user = permitted_users.with_permission("own").first || SiteSettings.default_user
     return if user.nil?
     Federails::Activity.create!(
       actor: user.actor,

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -7,7 +7,7 @@ class Role < ApplicationRecord
 
   ROLES = [
     :administrator,   # Can do everything
-    :editor,          # Can edit any models
+    :moderator,       # Can edit any models
     :contributor,     # Can upload models and edit their own
     :viewer           # Can view models; read only access
   ]

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -9,7 +9,7 @@ class Role < ApplicationRecord
     :administrator,   # Can do everything
     :moderator,       # Can edit any models
     :contributor,     # Can upload models and edit their own
-    :viewer           # Can view models; read only access
+    :member           # Can view models; read only access
   ]
 
   has_many :users, through: :users_roles

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -73,8 +73,8 @@ class User < ApplicationRecord
     has_any_role_of? :administrator, :moderator, :contributor
   end
 
-  def is_viewer?
-    has_any_role_of? :administrator, :moderator, :contributor, :viewer
+  def is_member?
+    has_any_role_of? :administrator, :moderator, :contributor, :member
   end
 
   def problem_severity(category)
@@ -88,7 +88,7 @@ class User < ApplicationRecord
   end
 
   def assign_default_role
-    add_role(:viewer) if roles.blank?
+    add_role(:member) if roles.blank?
   end
 
   def password_required?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -65,16 +65,16 @@ class User < ApplicationRecord
     has_any_role_of? :administrator
   end
 
-  def is_editor?
-    has_any_role_of? :administrator, :editor
+  def is_moderator?
+    has_any_role_of? :administrator, :moderator
   end
 
   def is_contributor?
-    has_any_role_of? :administrator, :editor, :contributor
+    has_any_role_of? :administrator, :moderator, :contributor
   end
 
   def is_viewer?
-    has_any_role_of? :administrator, :editor, :contributor, :viewer
+    has_any_role_of? :administrator, :moderator, :contributor, :viewer
   end
 
   def problem_severity(category)

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -14,7 +14,7 @@ class ApplicationPolicy
 
   def show?
     one_of(
-      user&.is_editor?,
+      user&.is_moderator?,
       check_permissions(record, ["viewer", "editor", "owner"], user, role_fallback: :viewer)
     )
   end
@@ -29,8 +29,8 @@ class ApplicationPolicy
 
   def update?
     one_of(
-      user&.is_editor?,
-      check_permissions(record, ["editor", "owner"], user, role_fallback: :editor)
+      user&.is_moderator?,
+      check_permissions(record, ["editor", "owner"], user, role_fallback: :moderator)
     )
   end
 
@@ -41,8 +41,8 @@ class ApplicationPolicy
   def destroy?
     all_of(
       one_of(
-        user&.is_editor?,
-        check_permissions(record, ["editor", "owner"], user, role_fallback: :editor)
+        user&.is_moderator?,
+        check_permissions(record, ["editor", "owner"], user, role_fallback: :moderator)
       ),
       none_of(
         SiteSettings.demo_mode_enabled?
@@ -57,7 +57,7 @@ class ApplicationPolicy
     end
 
     def resolve
-      return scope.all if user.is_editor? || !scope.respond_to?(:granted_to)
+      return scope.all if user.is_moderator? || !scope.respond_to?(:granted_to)
 
       result = scope.granted_to(["viewer", "editor", "owner"], [user, nil])
       result = result.or(scope.granted_to(["viewer", "editor", "owner"], user.roles)) if user

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -15,7 +15,7 @@ class ApplicationPolicy
   def show?
     one_of(
       user&.is_moderator?,
-      check_permissions(record, ["viewer", "editor", "owner"], user, role_fallback: :viewer)
+      check_permissions(record, ["view", "edit", "own"], user, role_fallback: :viewer)
     )
   end
 
@@ -30,7 +30,7 @@ class ApplicationPolicy
   def update?
     one_of(
       user&.is_moderator?,
-      check_permissions(record, ["editor", "owner"], user, role_fallback: :moderator)
+      check_permissions(record, ["edit", "own"], user, role_fallback: :moderator)
     )
   end
 
@@ -42,7 +42,7 @@ class ApplicationPolicy
     all_of(
       one_of(
         user&.is_moderator?,
-        check_permissions(record, ["editor", "owner"], user, role_fallback: :moderator)
+        check_permissions(record, ["edit", "own"], user, role_fallback: :moderator)
       ),
       none_of(
         SiteSettings.demo_mode_enabled?
@@ -59,8 +59,8 @@ class ApplicationPolicy
     def resolve
       return scope.all if user.is_moderator? || !scope.respond_to?(:granted_to)
 
-      result = scope.granted_to(["viewer", "editor", "owner"], [user, nil])
-      result = result.or(scope.granted_to(["viewer", "editor", "owner"], user.roles)) if user
+      result = scope.granted_to(["view", "edit", "own"], [user, nil])
+      result = result.or(scope.granted_to(["view", "edit", "own"], user.roles)) if user
       result
     end
 

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -15,7 +15,7 @@ class ApplicationPolicy
   def show?
     one_of(
       user&.is_moderator?,
-      check_permissions(record, ["view", "edit", "own"], user, role_fallback: :viewer)
+      check_permissions(record, ["view", "edit", "own"], user, role_fallback: :member)
     )
   end
 

--- a/app/policies/model_file_policy.rb
+++ b/app/policies/model_file_policy.rb
@@ -1,9 +1,9 @@
 class ModelFilePolicy < ApplicationPolicy
   def bulk_edit?
-    user&.is_editor?
+    user&.is_moderator?
   end
 
   def bulk_update?
-    user&.is_editor?
+    user&.is_moderator?
   end
 end

--- a/app/policies/model_policy.rb
+++ b/app/policies/model_policy.rb
@@ -3,7 +3,7 @@ class ModelPolicy < ApplicationPolicy
     all_of(
       one_of(
         user&.is_moderator?,
-        check_permissions(record, ["editor", "owner"], user)
+        check_permissions(record, ["edit", "own"], user)
       ),
       none_of(
         SiteSettings.demo_mode_enabled?

--- a/app/policies/model_policy.rb
+++ b/app/policies/model_policy.rb
@@ -2,7 +2,7 @@ class ModelPolicy < ApplicationPolicy
   def merge?
     all_of(
       one_of(
-        user&.is_editor?,
+        user&.is_moderator?,
         check_permissions(record, ["editor", "owner"], user)
       ),
       none_of(
@@ -16,10 +16,10 @@ class ModelPolicy < ApplicationPolicy
   end
 
   def bulk_edit?
-    user&.is_editor?
+    user&.is_moderator?
   end
 
   def bulk_update?
-    user&.is_editor?
+    user&.is_moderator?
   end
 end

--- a/config/initializers/caber.rb
+++ b/config/initializers/caber.rb
@@ -2,8 +2,8 @@
 Caber.configure do |config|
   # List the object-level permissions you want
   config.permissions = [
-    "viewer",
-    "editor",
-    "owner"
+    "view",
+    "edit",
+    "own"
   ]
 end

--- a/db/data/20240830151650_rename_default_roles.rb
+++ b/db/data/20240830151650_rename_default_roles.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class RenameDefaultRoles < ActiveRecord::Migration[7.1]
+  def up
+    Role.find_by(name: :editor).update!(name: :moderator)
+  end
+
+  def down
+    Role.find_by(name: :moderator).update!(name: :editor)
+  end
+end

--- a/db/data/20240830151650_rename_default_roles.rb
+++ b/db/data/20240830151650_rename_default_roles.rb
@@ -2,12 +2,12 @@
 
 class RenameDefaultRoles < ActiveRecord::Migration[7.1]
   def up
-    Role.find_by(name: :editor).update!(name: :moderator)
-    Role.find_by(name: :viewer).update!(name: :member)
+    Role.find_by(name: :editor)&.update!(name: :moderator)
+    Role.find_by(name: :viewer)&.update!(name: :member)
   end
 
   def down
-    Role.find_by(name: :moderator).update!(name: :editor)
-    Role.find_by(name: :member).update!(name: :viewer)
+    Role.find_by(name: :moderator)&.update!(name: :editor)
+    Role.find_by(name: :member)&.update!(name: :viewer)
   end
 end

--- a/db/data/20240830151650_rename_default_roles.rb
+++ b/db/data/20240830151650_rename_default_roles.rb
@@ -3,9 +3,11 @@
 class RenameDefaultRoles < ActiveRecord::Migration[7.1]
   def up
     Role.find_by(name: :editor).update!(name: :moderator)
+    Role.find_by(name: :viewer).update!(name: :member)
   end
 
   def down
     Role.find_by(name: :moderator).update!(name: :editor)
+    Role.find_by(name: :member).update!(name: :viewer)
   end
 end

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20240830121749)
+DataMigrate::Data.define(version: 20240830151650)

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -8,8 +8,8 @@ FactoryBot.define do
       after(:create) { |a| a.add_role :administrator }
     end
 
-    factory :editor do
-      after(:create) { |a| a.add_role :editor }
+    factory :moderator do
+      after(:create) { |a| a.add_role :moderator }
     end
 
     factory :contributor do

--- a/spec/helpers/problems_helper_spec.rb
+++ b/spec/helpers/problems_helper_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ProblemsHelper, :as_viewer do
+RSpec.describe ProblemsHelper, :as_member do
   include Devise::Test::ControllerHelpers
   let(:model) { create(:model) }
 

--- a/spec/jobs/process_uploaded_file_job_spec.rb
+++ b/spec/jobs/process_uploaded_file_job_spec.rb
@@ -44,12 +44,12 @@ RSpec.describe ProcessUploadedFileJob do
 
     it "Sets default owner permission if no owner set" do
       job.perform(library.id, file)
-      expect(Model.last.permitted_users.with_permission(:owner)).to include admin
+      expect(Model.last.permitted_users.with_permission(:own)).to include admin
     end
 
     it "Sets owner permission to provided user" do
       job.perform(library.id, file, owner: uploader)
-      expect(Model.last.permitted_users.with_permission(:owner)).to include uploader
+      expect(Model.last.permitted_users.with_permission(:own)).to include uploader
     end
   end
 

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -29,8 +29,8 @@ RSpec.describe Role do
       expect(admin.is_contributor?).to be true
     end
 
-    it "inherits viewer permission" do
-      expect(admin.is_viewer?).to be true
+    it "inherits member permission" do
+      expect(admin.is_member?).to be true
     end
   end
 
@@ -49,8 +49,8 @@ RSpec.describe Role do
       expect(moderator.is_contributor?).to be true
     end
 
-    it "inherits viewer permission" do
-      expect(moderator.is_viewer?).to be true
+    it "inherits member permission" do
+      expect(moderator.is_member?).to be true
     end
   end
 
@@ -69,28 +69,28 @@ RSpec.describe Role do
       expect(contributor.is_contributor?).to be true
     end
 
-    it "inherits viewer permission" do
-      expect(contributor.is_viewer?).to be true
+    it "inherits member permission" do
+      expect(contributor.is_member?).to be true
     end
   end
 
-  context "when viewer" do
-    let(:viewer) { create(:user) }
+  context "when member" do
+    let(:member) { create(:user) }
 
     it "does not have administrator permission" do
-      expect(viewer.is_administrator?).to be false
+      expect(member.is_administrator?).to be false
     end
 
     it "does not have moderator permission" do
-      expect(viewer.is_moderator?).to be false
+      expect(member.is_moderator?).to be false
     end
 
     it "does not have contributor permission" do
-      expect(viewer.is_contributor?).to be false
+      expect(member.is_contributor?).to be false
     end
 
-    it "has viewer permission" do
-      expect(viewer.is_viewer?).to be true
+    it "has member permission" do
+      expect(member.is_member?).to be true
     end
   end
 end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -21,8 +21,8 @@ RSpec.describe Role do
       expect(admin.is_administrator?).to be true
     end
 
-    it "inherits editor permission" do
-      expect(admin.is_editor?).to be true
+    it "inherits moderator permission" do
+      expect(admin.is_moderator?).to be true
     end
 
     it "inherits contributor permission" do
@@ -34,23 +34,23 @@ RSpec.describe Role do
     end
   end
 
-  context "when editor" do
-    let(:editor) { create(:editor) }
+  context "when moderator" do
+    let(:moderator) { create(:moderator) }
 
     it "does not have administrator permission" do
-      expect(editor.is_administrator?).to be false
+      expect(moderator.is_administrator?).to be false
     end
 
-    it "has editor permission" do
-      expect(editor.is_editor?).to be true
+    it "has moderator permission" do
+      expect(moderator.is_moderator?).to be true
     end
 
     it "inherits contributor permission" do
-      expect(editor.is_contributor?).to be true
+      expect(moderator.is_contributor?).to be true
     end
 
     it "inherits viewer permission" do
-      expect(editor.is_viewer?).to be true
+      expect(moderator.is_viewer?).to be true
     end
   end
 
@@ -61,8 +61,8 @@ RSpec.describe Role do
       expect(contributor.is_administrator?).to be false
     end
 
-    it "does not have editor permission" do
-      expect(contributor.is_editor?).to be false
+    it "does not have moderator permission" do
+      expect(contributor.is_moderator?).to be false
     end
 
     it "has contributor permission" do
@@ -81,8 +81,8 @@ RSpec.describe Role do
       expect(viewer.is_administrator?).to be false
     end
 
-    it "does not have editor permission" do
-      expect(viewer.is_editor?).to be false
+    it "does not have moderator permission" do
+      expect(viewer.is_moderator?).to be false
     end
 
     it "does not have contributor permission" do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe User do
     expect(build(:user, username: "USERNAME")).not_to be_valid
   end
 
-  it "gets viewer role by default" do
+  it "gets member role by default" do
     u = create(:user)
-    expect(u).to have_role(:viewer)
+    expect(u).to have_role(:member)
   end
 end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -60,11 +60,11 @@ describe ApplicationPolicy do
   end
 
   permissions :edit?, :update?, :destroy? do
-    let(:editor) { create(:editor) }
+    let(:moderator) { create(:moderator) }
     let(:contributor) { create(:contributor) }
 
-    it "allows all users with editor role" do
-      expect(policy).to permit(editor, model)
+    it "allows all users with moderator role" do
+      expect(policy).to permit(moderator, model)
     end
 
     it "denies users with contributor role" do

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -18,7 +18,7 @@ describe ApplicationPolicy do
 
     context "when default viewer role access is removed" do
       before do
-        model.revoke_permission("viewer", Role.find_by(name: :viewer))
+        model.revoke_permission("view", Role.find_by(name: :viewer))
       end
 
       it "denies users without individual viewer permission" do
@@ -26,7 +26,7 @@ describe ApplicationPolicy do
       end
 
       it "allows users with individual viewer permission" do
-        model.grant_permission_to "viewer", viewer
+        model.grant_permission_to "view", viewer
         expect(policy).to permit(viewer, model)
       end
     end
@@ -37,7 +37,7 @@ describe ApplicationPolicy do
       end
 
       it "allows access if public view permission is set" do
-        model.grant_permission_to "viewer", nil
+        model.grant_permission_to "view", nil
         expect(policy).to permit(nil, model)
       end
     end
@@ -72,17 +72,17 @@ describe ApplicationPolicy do
     end
 
     it "allows users with granted edit permission" do
-      model.grant_permission_to "editor", viewer
+      model.grant_permission_to "edit", viewer
       expect(policy).to permit(viewer, model)
     end
 
     it "allows users with granted owner permission" do
-      model.grant_permission_to "owner", viewer
+      model.grant_permission_to "own", viewer
       expect(policy).to permit(viewer, model)
     end
 
     it "denies unknown users on public models" do
-      model.grant_permission_to "viewer", nil
+      model.grant_permission_to "view", nil
       expect(policy).not_to permit(nil, model)
     end
   end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -3,31 +3,31 @@ require "rails_helper"
 describe ApplicationPolicy do
   subject(:policy) { described_class }
 
-  let(:viewer) { create(:user) }
+  let(:member) { create(:user) }
   let(:model) { create(:model) }
 
   permissions :index?, :show? do
-    it "allows users with viewer role by default" do
-      expect(policy).to permit(viewer, model)
+    it "allows users with member role by default" do
+      expect(policy).to permit(member, model)
     end
 
-    it "falls back to viewer role if ReBAC isn't available on the record" do
+    it "falls back to member role if ReBAC isn't available on the record" do
       problem = create(:problem)
-      expect(policy).to permit(viewer, problem)
+      expect(policy).to permit(member, problem)
     end
 
-    context "when default viewer role access is removed" do
+    context "when default member role access is removed" do
       before do
-        model.revoke_permission("view", Role.find_by(name: :viewer))
+        model.revoke_permission("view", Role.find_by(name: :member))
       end
 
-      it "denies users without individual viewer permission" do
-        expect(policy).not_to permit(viewer, model)
+      it "denies users without individual view permission" do
+        expect(policy).not_to permit(member, model)
       end
 
-      it "allows users with individual viewer permission" do
-        model.grant_permission_to "view", viewer
-        expect(policy).to permit(viewer, model)
+      it "allows users with individual view permission" do
+        model.grant_permission_to "view", member
+        expect(policy).to permit(member, model)
       end
     end
 
@@ -50,8 +50,8 @@ describe ApplicationPolicy do
       expect(policy).to permit(contributor)
     end
 
-    it "denies users with viewer role by default" do
-      expect(policy).not_to permit(viewer)
+    it "denies users with member role by default" do
+      expect(policy).not_to permit(member)
     end
 
     it "denies unknown users" do
@@ -72,13 +72,13 @@ describe ApplicationPolicy do
     end
 
     it "allows users with granted edit permission" do
-      model.grant_permission_to "edit", viewer
-      expect(policy).to permit(viewer, model)
+      model.grant_permission_to "edit", member
+      expect(policy).to permit(member, model)
     end
 
     it "allows users with granted owner permission" do
-      model.grant_permission_to "own", viewer
-      expect(policy).to permit(viewer, model)
+      model.grant_permission_to "own", member
+      expect(policy).to permit(member, model)
     end
 
     it "denies unknown users on public models" do

--- a/spec/requests/activity_spec.rb
+++ b/spec/requests/activity_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Activities" do
     end
   end
 
-  context "when logged in as non-admin", :as_editor do
+  context "when logged in as non-admin", :as_moderator do
     describe "GET /" do
       it "raises a routing error" do
         expect { get "/activity" }.to raise_error(ActionController::RoutingError)

--- a/spec/requests/admin/collections_spec.rb
+++ b/spec/requests/admin/collections_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Collections" do
-  it "is inaccessible to anything less than admin", :as_editor do
+  it "is inaccessible to anything less than admin", :as_moderator do
     get "/admin/collections"
     expect(response).to have_http_status(:unauthorized)
   end

--- a/spec/requests/admin/creators_spec.rb
+++ b/spec/requests/admin/creators_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Creators" do
-  it "is inaccessible to anything less than admin", :as_editor do
+  it "is inaccessible to anything less than admin", :as_moderator do
     get "/admin/creators"
     expect(response).to have_http_status(:unauthorized)
   end

--- a/spec/requests/admin/dashboard_spec.rb
+++ b/spec/requests/admin/dashboard_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Dashboard" do
-  it "is inaccessible to anything less than admin", :as_editor do
+  it "is inaccessible to anything less than admin", :as_moderator do
     get "/admin"
     expect(response).to have_http_status(:unauthorized)
   end

--- a/spec/requests/admin/link_spec.rb
+++ b/spec/requests/admin/link_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Links" do
-  it "is inaccessible to anything less than admin", :as_editor do
+  it "is inaccessible to anything less than admin", :as_moderator do
     get "/admin/links"
     expect(response).to have_http_status(:unauthorized)
   end

--- a/spec/requests/admin/log_spec.rb
+++ b/spec/requests/admin/log_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Log" do
-  it "is inaccessible to anything less than admin", :as_editor do
+  it "is inaccessible to anything less than admin", :as_moderator do
     get "/admin/log"
     expect(response).to have_http_status(:unauthorized)
   end

--- a/spec/requests/admin/model_files_spec.rb
+++ b/spec/requests/admin/model_files_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Model_Files" do
-  it "is inaccessible to anything less than admin", :as_editor do
+  it "is inaccessible to anything less than admin", :as_moderator do
     get "/admin/model_files"
     expect(response).to have_http_status(:unauthorized)
   end

--- a/spec/requests/admin/models_spec.rb
+++ b/spec/requests/admin/models_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Models" do
-  it "is inaccessible to anything less than admin", :as_editor do
+  it "is inaccessible to anything less than admin", :as_moderator do
     get "/admin/models"
     expect(response).to have_http_status(:unauthorized)
   end

--- a/spec/requests/admin/problem_spec.rb
+++ b/spec/requests/admin/problem_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Problems" do
-  it "is inaccessible to anything less than admin", :as_editor do
+  it "is inaccessible to anything less than admin", :as_moderator do
     get "/admin/problems"
     expect(response).to have_http_status(:unauthorized)
   end

--- a/spec/requests/admin/tags_spec.rb
+++ b/spec/requests/admin/tags_spec.rb
@@ -1,7 +1,7 @@
 require "rails_helper"
 
 RSpec.describe "Admin::Tags" do
-  it "is inaccessible to anything less than admin", :as_editor do
+  it "is inaccessible to anything less than admin", :as_moderator do
     get "/admin/acts_as_taggable_on_tags"
     expect(response).to have_http_status(:unauthorized)
   end

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Collections" do
     end
 
     describe "GET /collections" do
-      it "returns paginated collections", :as_viewer do # rubocop:todo RSpec/MultipleExpectations
+      it "returns paginated collections", :as_member do # rubocop:todo RSpec/MultipleExpectations
         get "/collections?page=2"
         expect(response).to have_http_status(:success)
         expect(response.body).to match(/pagination/)
@@ -39,7 +39,7 @@ RSpec.describe "Collections" do
         expect(response).to redirect_to("/collections")
       end
 
-      it "denies viewer permission", :as_viewer do
+      it "denies member permission", :as_member do
         expect { post "/collections", params: {collection: {name: "newname"}} }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
@@ -50,7 +50,7 @@ RSpec.describe "Collections" do
         expect(response).to have_http_status(:success)
       end
 
-      it "denies viewer permission", :as_viewer do
+      it "denies member permission", :as_member do
         expect { get "/collections/new" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
@@ -66,7 +66,7 @@ RSpec.describe "Collections" do
       end
     end
 
-    describe "GET /collections/:id", :as_viewer do
+    describe "GET /collections/:id", :as_member do
       it "Redirects to a list of models with that collection" do
         get "/collections/#{collection.id}"
         expect(response).to redirect_to("/models?collection=#{collection.id}")

--- a/spec/requests/collections_spec.rb
+++ b/spec/requests/collections_spec.rb
@@ -56,12 +56,12 @@ RSpec.describe "Collections" do
     end
 
     describe "GET /collections/:id/edit" do
-      it "Shows the new collection form", :as_editor do
+      it "Shows the new collection form", :as_moderator do
         get "/collections/#{collection.id}/edit"
         expect(response).to have_http_status(:success)
       end
 
-      it "is denied to non-editors", :as_contributor do
+      it "is denied to non-moderators", :as_contributor do
         expect { get "/collections/#{collection.id}/edit" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
@@ -74,23 +74,23 @@ RSpec.describe "Collections" do
     end
 
     describe "PATCH /collections/:id" do
-      it "saves details", :as_editor do
+      it "saves details", :as_moderator do
         patch "/collections/#{collection.id}", params: {collection: {name: "newname"}}
         expect(response).to redirect_to("/collections")
       end
 
-      it "is denied to non-editors", :as_contributor do
+      it "is denied to non-moderators", :as_contributor do
         expect { patch "/collections/#{collection.id}", params: {collection: {name: "newname"}} }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
     describe "DELETE /collections/:id" do
-      it "removes collection", :as_editor do
+      it "removes collection", :as_moderator do
         delete "/collections/#{collection.id}"
         expect(response).to redirect_to("/collections")
       end
 
-      it "is denied to non-editors", :as_contributor do
+      it "is denied to non-moderators", :as_contributor do
         expect { delete "/collections/#{collection.id}" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end

--- a/spec/requests/creators_spec.rb
+++ b/spec/requests/creators_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe "Creators" do
     end
 
     describe "GET /creators" do
-      it "returns paginated creators", :as_viewer do # rubocop:todo RSpec/MultipleExpectations
+      it "returns paginated creators", :as_member do # rubocop:todo RSpec/MultipleExpectations
         get "/creators?page=2"
         expect(response).to have_http_status(:success)
         expect(response.body).to match(/pagination/)
@@ -39,7 +39,7 @@ RSpec.describe "Creators" do
         expect(response).to redirect_to("/creators")
       end
 
-      it "denies viewer permission", :as_viewer do
+      it "denies member permission", :as_member do
         expect { post "/creators", params: {creator: {name: "newname"}} }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
@@ -50,7 +50,7 @@ RSpec.describe "Creators" do
         expect(response).to have_http_status(:success)
       end
 
-      it "denies viewer permission", :as_viewer do
+      it "denies member permission", :as_member do
         expect { get "/creators/new" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
@@ -66,7 +66,7 @@ RSpec.describe "Creators" do
       end
     end
 
-    describe "GET /creators/:id", :as_viewer do
+    describe "GET /creators/:id", :as_member do
       it "Redirects to a list of models with that creator" do
         get "/creators/#{creator.id}"
         expect(response).to redirect_to("/models?creator=#{creator.id}")

--- a/spec/requests/creators_spec.rb
+++ b/spec/requests/creators_spec.rb
@@ -56,12 +56,12 @@ RSpec.describe "Creators" do
     end
 
     describe "GET /creators/:id/edit" do
-      it "Shows the new creator form", :as_editor do
+      it "Shows the new creator form", :as_moderator do
         get "/creators/#{creator.id}/edit"
         expect(response).to have_http_status(:success)
       end
 
-      it "is denied to non-editors", :as_contributor do
+      it "is denied to non-moderators", :as_contributor do
         expect { get "/creators/#{creator.id}/edit" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
@@ -74,23 +74,23 @@ RSpec.describe "Creators" do
     end
 
     describe "PATCH /creators/:id" do
-      it "saves details", :as_editor do
+      it "saves details", :as_moderator do
         patch "/creators/#{creator.id}", params: {creator: {name: "newname"}}
         expect(response).to redirect_to("/creators/#{creator.id}")
       end
 
-      it "is denied to non-editors", :as_contributor do
+      it "is denied to non-moderators", :as_contributor do
         expect { patch "/creators/#{creator.id}", params: {creator: {name: "newname"}} }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
     describe "DELETE /creators/:id" do
-      it "removes creator", :as_editor do
+      it "removes creator", :as_moderator do
         delete "/creators/#{creator.id}"
         expect(response).to redirect_to("/creators")
       end
 
-      it "is denied to non-editors", :as_contributor do
+      it "is denied to non-moderators", :as_contributor do
         expect { delete "/creators/#{creator.id}" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -9,12 +9,12 @@ RSpec.describe "Home" do
 
   context "when signed in" do
     describe "GET /" do
-      it "redirects to library creation if there isn't one already", :as_viewer do
+      it "redirects to library creation if there isn't one already", :as_member do
         get "/"
         expect(response).to redirect_to("/libraries/new")
       end
 
-      it "shows the homepage if a library has been created", :as_viewer do
+      it "shows the homepage if a library has been created", :as_member do
         create(:library)
         get "/"
         expect(response).to have_http_status(:success)

--- a/spec/requests/libraries_spec.rb
+++ b/spec/requests/libraries_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe "Libraries" do
         expect(response).to have_http_status(:success)
       end
 
-      it "is denied to non-admins", :as_editor do
+      it "is denied to non-admins", :as_moderator do
         expect { post "/libraries", params: {library: {name: "new"}} }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
@@ -69,7 +69,7 @@ RSpec.describe "Libraries" do
         expect(response).to have_http_status(:success)
       end
 
-      it "is denied to non-admins", :as_editor do
+      it "is denied to non-admins", :as_moderator do
         expect { get "/libraries/new" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
@@ -80,7 +80,7 @@ RSpec.describe "Libraries" do
         expect(response).to have_http_status(:success)
       end
 
-      it "is denied to non-administrators", :as_editor do
+      it "is denied to non-administrators", :as_moderator do
         expect { get "/libraries/#{library.id}/edit" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
@@ -98,7 +98,7 @@ RSpec.describe "Libraries" do
         expect(response).to redirect_to("/models")
       end
 
-      it "is denied to non-administrators", :as_editor do
+      it "is denied to non-administrators", :as_moderator do
         expect { patch "/libraries/#{library.id}", params: {library: {name: "new"}} }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
@@ -109,7 +109,7 @@ RSpec.describe "Libraries" do
         expect(response).to redirect_to("/libraries")
       end
 
-      it "is denied to non-administrators", :as_editor do
+      it "is denied to non-administrators", :as_moderator do
         expect { delete "/libraries/#{library.id}" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end

--- a/spec/requests/libraries_spec.rb
+++ b/spec/requests/libraries_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe "Libraries" do
         expect(response).to redirect_to("/libraries/#{library.id}")
       end
 
-      it "denies viewer permission", :as_viewer do
+      it "denies member permission", :as_member do
         expect { post "/libraries/#{library.id}/scan" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
@@ -40,12 +40,12 @@ RSpec.describe "Libraries" do
         expect(response).to redirect_to("/models")
       end
 
-      it "denies viewer permission", :as_viewer do
+      it "denies member permission", :as_member do
         expect { post "/libraries/scan" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
-    describe "GET /libraries", :as_viewer do
+    describe "GET /libraries", :as_member do
       it "redirects to models index" do
         get "/libraries"
         expect(response).to redirect_to("/models")
@@ -86,7 +86,7 @@ RSpec.describe "Libraries" do
     end
 
     describe "GET /libraries/:id" do
-      it "redirects to models index with library filter", :as_viewer do
+      it "redirects to models index with library filter", :as_member do
         get "/libraries/#{library.id}"
         expect(response).to redirect_to("/models?library=#{library.id}")
       end

--- a/spec/requests/model_files_spec.rb
+++ b/spec/requests/model_files_spec.rb
@@ -31,21 +31,21 @@ RSpec.describe "Model Files" do
       end
     end
 
-    describe "GET /models/:model_id/model_files/edit", :as_editor do
+    describe "GET /models/:model_id/model_files/edit", :as_moderator do
       it "shows bulk update form" do
         get bulk_edit_model_model_files_path(model, stl_file)
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "PATCH /models/:model_id/model_files/update", :as_editor do
+    describe "PATCH /models/:model_id/model_files/update", :as_moderator do
       it "bulk updates the files" do
         patch model_model_file_path(model, stl_file), params: {model_file: {name: "name"}}
         expect(response).to redirect_to(model_model_file_path(model, stl_file))
       end
     end
 
-    describe "GET /models/:model_id/model_files/:id/edit", :as_editor do
+    describe "GET /models/:model_id/model_files/:id/edit", :as_moderator do
       it "shows edit page for file" do
         get edit_model_model_file_path(model, stl_file)
         expect(response).to have_http_status(:success)
@@ -82,7 +82,7 @@ RSpec.describe "Model Files" do
       end
     end
 
-    describe "POST /models/:model_id/model_files", :as_editor do
+    describe "POST /models/:model_id/model_files", :as_moderator do
       context "when requesting a conversion" do
         let(:params) { {convert: {id: stl_file.id, to: "threemf"}} }
 
@@ -108,14 +108,14 @@ RSpec.describe "Model Files" do
       end
     end
 
-    describe "PATCH /models/:model_id/model_files/:id", :as_editor do
+    describe "PATCH /models/:model_id/model_files/:id", :as_moderator do
       it "updates the file" do
         patch model_model_file_path(model, stl_file), params: {model_file: {name: "name"}}
         expect(response).to redirect_to(model_model_file_path(model, stl_file))
       end
     end
 
-    describe "DELETE /models/:model_id/model_files/:id", :as_editor do
+    describe "DELETE /models/:model_id/model_files/:id", :as_moderator do
       it "removes the file" do
         delete model_model_file_path(model, stl_file)
         expect(response).to redirect_to(model_path(model))

--- a/spec/requests/model_files_spec.rb
+++ b/spec/requests/model_files_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Model Files" do
       end
     end
 
-    describe "GET /models/:model_id/model_files/:id", :as_viewer do
+    describe "GET /models/:model_id/model_files/:id", :as_member do
       describe "GET a model file in its original file format" do
         before do
           get model_model_file_path(model, stl_file, format: :stl)
@@ -67,7 +67,7 @@ RSpec.describe "Model Files" do
         end
       end
 
-      describe "GET an image file in its original file format", :as_viewer do
+      describe "GET an image file in its original file format", :as_member do
         before do
           get model_model_file_path(model, jpg_file, format: :jpg)
         end

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -38,18 +38,18 @@ RSpec.describe "Models" do
     end
 
     describe "GET /models/:id/edit" do
-      it "shows edit page for file", :as_editor do
+      it "shows edit page for file", :as_moderator do
         get "/models/#{library.models.first.id}/edit"
         expect(response).to have_http_status(:success)
       end
 
-      it "is denied to non-editors", :as_contributor do
+      it "is denied to non-moderators", :as_contributor do
         expect { get "/models/#{library.models.first.id}/edit" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
     describe "PUT /models/:id" do
-      it "adds tags to a model", :as_editor do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
+      it "adds tags to a model", :as_moderator do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
         put "/models/#{library.models.first.id}", params: {model: {tag_list: ["a", "b", "c"]}}
         expect(response).to have_http_status(:redirect)
         tags = library.models.first.tag_list
@@ -59,7 +59,7 @@ RSpec.describe "Models" do
         expect(tags[2]).to eq "c"
       end
 
-      it "removes tags from a model", :as_editor do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
+      it "removes tags from a model", :as_moderator do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
         first = library.models.first
         first.tag_list = "a, b, c"
         first.save
@@ -73,7 +73,7 @@ RSpec.describe "Models" do
         expect(tags[1]).to eq "b"
       end
 
-      it "both adds and removes tags from a model", :as_editor do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
+      it "both adds and removes tags from a model", :as_moderator do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
         first = library.models.first
         first.tag_list = "a, b, c"
         first.save
@@ -88,35 +88,35 @@ RSpec.describe "Models" do
         expect(tags[2]).to eq "d"
       end
 
-      it "is denied to non-editors", :as_contributor do
+      it "is denied to non-moderators", :as_contributor do
         expect { put "/models/#{library.models.first.id}" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
     describe "DELETE /models/:id" do # rubocop:todo RSpec/RepeatedExampleGroupBody
-      it "redirects to model list after deletion", :as_editor do
+      it "redirects to model list after deletion", :as_moderator do
         delete "/models/#{library.models.first.id}"
         expect(response).to redirect_to("/")
       end
 
-      it "is denied to non-editors", :as_contributor do
+      it "is denied to non-moderators", :as_contributor do
         expect { delete "/models/#{library.models.first.id}" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
     describe "GET /models/edit" do # rubocop:todo RSpec/RepeatedExampleGroupBody
-      it "shows bulk edit page", :as_editor do
+      it "shows bulk edit page", :as_moderator do
         get "/models/edit"
         expect(response).to have_http_status(:success)
       end
 
-      it "is denied to non-editors", :as_contributor do
+      it "is denied to non-moderators", :as_contributor do
         expect { get "/models/edit" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
     describe "PATCH /models/edit" do
-      it "updates models creator", :as_editor do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
+      it "updates models creator", :as_moderator do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
         models = library.models.take(2)
         update = {}
         update[models[0].id] = 1
@@ -130,7 +130,7 @@ RSpec.describe "Models" do
         expect(models[1].creator_id).to eq creator.id
       end
 
-      it "adds tags to models", :as_editor do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
+      it "adds tags to models", :as_moderator do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
         update = {}
         library.models.take(2).each do |model|
           update[model.id] = 1
@@ -144,7 +144,7 @@ RSpec.describe "Models" do
         end
       end
 
-      it "removes tags from models", :as_editor do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
+      it "removes tags from models", :as_moderator do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
         update = {}
         library.models.take(2).each do |model|
           model.tag_list = "a, b, c"
@@ -161,7 +161,7 @@ RSpec.describe "Models" do
         end
       end
 
-      it "is denied to non-editors", :as_contributor do
+      it "is denied to non-moderators", :as_contributor do
         update = {}
         expect { patch "/models/update", params: {models: update, remove_tags: ["a", "b"]} }.to raise_error(Pundit::NotAuthorizedError)
       end
@@ -194,18 +194,18 @@ RSpec.describe "Models" do
     end
 
     describe "POST /models/:id/merge" do
-      it "gives a bad request response if no merge parameter is provided", :as_editor do
+      it "gives a bad request response if no merge parameter is provided", :as_moderator do
         post "/models/#{library.models.first.id}/merge"
         expect(response).to have_http_status(:bad_request)
       end
 
-      it "is denied to non-editors", :as_contributor do
+      it "is denied to non-moderators", :as_contributor do
         expect { post "/models/#{library.models.first.id}/merge" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
 
     describe "POST /models/:id/scan" do
-      it "schedules a scan job", :as_editor do
+      it "schedules a scan job", :as_moderator do
         expect { post "/models/#{library.models.first.id}/scan" }.to(
           have_enqueued_job(Scan::CheckModelJob).with(library.models.first.id).once
         )

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe "Models" do
       l
     end
 
-    describe "GET /models/:id", :as_viewer do
+    describe "GET /models/:id", :as_member do
       it "returns http success" do
         get "/models/#{library.models.first.id}"
         expect(response).to have_http_status(:success)
@@ -167,7 +167,7 @@ RSpec.describe "Models" do
       end
     end
 
-    describe "GET /models", :as_viewer do
+    describe "GET /models", :as_member do
       it "allows search queries" do
         get "/models?q=#{library.models.first.name}"
         expect(response).to have_http_status(:success)
@@ -216,7 +216,7 @@ RSpec.describe "Models" do
         expect(response).to redirect_to("/models/#{library.models.first.id}")
       end
 
-      it "is denied to non-contributors", :as_viewer do
+      it "is denied to non-contributors", :as_member do
         expect { post "/models/#{library.models.first.id}/scan" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
@@ -227,7 +227,7 @@ RSpec.describe "Models" do
         expect(response).to have_http_status(:success)
       end
 
-      it "denies viewer permission", :as_viewer do
+      it "denies member permission", :as_member do
         expect { get "/models/new" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end
@@ -238,7 +238,7 @@ RSpec.describe "Models" do
         expect(response).to redirect_to("/libraries")
       end
 
-      it "denies viewer permission", :as_viewer do
+      it "denies member permission", :as_member do
         expect { post "/models", params: {post: {library_pick: library.id, scan_after_upload: "1"}, upload: {datafiles: []}} }.to raise_error(Pundit::NotAuthorizedError)
       end
     end

--- a/spec/requests/problems_spec.rb
+++ b/spec/requests/problems_spec.rb
@@ -92,12 +92,12 @@ RSpec.describe "Problems" do
     describe "PATCH /problems/:id" do
       let(:problem) { create(:problem) }
 
-      it "updates the problem and returns to list", :as_editor do
+      it "updates the problem and returns to list", :as_moderator do
         patch "/problems/#{problem.id}", params: {problem: {ignored: true}}
         expect(response).to redirect_to("/problems")
       end
 
-      it "is denied to non-editors", :as_contributor do
+      it "is denied to non-moderators", :as_contributor do
         expect { patch "/problems/#{problem.id}", params: {problem: {ignored: true}} }.to raise_error(Pundit::NotAuthorizedError)
       end
     end

--- a/spec/requests/problems_spec.rb
+++ b/spec/requests/problems_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe "Problems" do
   end
 
   context "when signed in" do
-    describe "GET /problems", :as_viewer do
-      it "is denied to viewers" do
+    describe "GET /problems", :as_member do
+      it "is denied to members" do
         expect { get "/problems/index" }.to raise_error(Pundit::NotAuthorizedError)
       end
     end

--- a/spec/requests/settings_spec.rb
+++ b/spec/requests/settings_spec.rb
@@ -10,21 +10,21 @@ RSpec.describe "Settings" do
   end
 
   context "when signed in" do
-    describe "GET /users/:user_id/settings", :as_viewer do
+    describe "GET /users/:user_id/settings", :as_member do
       it "returns http success" do
         get "/users/#{User.first.username}/settings"
         expect(response).to have_http_status(:success)
       end
     end
 
-    describe "PATCH /users/:user_id/settings", :as_viewer do
+    describe "PATCH /users/:user_id/settings", :as_member do
       it "redirects back to settings on success" do
         patch "/users/#{User.first.username}/settings"
         expect(response).to redirect_to("/users/#{User.first.username}/settings")
       end
     end
 
-    describe "PUT /users/:user_id/settings", :as_viewer do
+    describe "PUT /users/:user_id/settings", :as_member do
       it "redirects back to settings on success" do
         put "/users/#{User.first.username}/settings"
         expect(response).to redirect_to("/users/#{User.first.username}/settings")

--- a/spec/requests/uploads_spec.rb
+++ b/spec/requests/uploads_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe "Uploads" do
 
   context "when signed in" do
     describe "POST /uploads" do
-      it "is denied to non-contributors", :as_viewer do
+      it "is denied to non-contributors", :as_member do
         expect { post "/uploads" }.to raise_error(ActionController::RoutingError)
       end
 

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe "Users::Sessions" do
       end
     end
 
-    context "when signed in", :as_viewer do
+    context "when signed in", :as_member do
       describe "GET /users/sign_in" do
         it "redirects to root" do
           get "/users/sign_in"
@@ -78,7 +78,7 @@ RSpec.describe "Users::Sessions" do
       end
     end
 
-    context "when signed in", :as_viewer do
+    context "when signed in", :as_member do
       describe "GET /users/sign_in" do
         it "redirects to root" do
           get "/users/sign_in"

--- a/spec/support/sign_in_role.rb
+++ b/spec/support/sign_in_role.rb
@@ -3,8 +3,8 @@ RSpec.configure do |config|
     sign_in create(:admin)
   end
 
-  config.before(:each, :as_editor) do
-    sign_in create(:editor)
+  config.before(:each, :as_moderator) do
+    sign_in create(:moderator)
   end
 
   config.before(:each, :as_contributor) do

--- a/spec/support/sign_in_role.rb
+++ b/spec/support/sign_in_role.rb
@@ -11,7 +11,7 @@ RSpec.configure do |config|
     sign_in create(:contributor)
   end
 
-  config.before(:each, :as_viewer) do
+  config.before(:each, :as_member) do
     sign_in create(:user)
   end
 end


### PR DESCRIPTION
"editor" is now "moderator", and "viewer" is now "member".