### PR TITLE
Make archive extraction thread-safe

### DIFF
--- a/config/initializers/libarchive_security.rb
+++ b/config/initializers/libarchive_security.rb
@@ -4,8 +4,6 @@ module Archive
   EXTRACT_SECURE = [
     Archive::EXTRACT_NO_OVERWRITE,
     Archive::EXTRACT_NO_OVERWRITE_NEWER,
-    Archive::EXTRACT_SECURE_SYMLINKS,
-    Archive::EXTRACT_SECURE_NODOTDOT,
-    Archive::EXTRACT_SECURE_NOABSOLUTEPATHS
+    Archive::EXTRACT_SECURE_NODOTDOT
   ].reduce(:|).to_i
 end


### PR DESCRIPTION
Had to allow absolute extraction paths, but that's OK as we're always going to set the destination path. Also had to allow extraction through symlinks because MacOS seems to use them for its temp dirs.

Resolves #2530