### PR TITLE
Improve performance and disk usage during upload processing

### DIFF
--- a/app/jobs/process_uploaded_file_job.rb
+++ b/app/jobs/process_uploaded_file_job.rb
@@ -45,18 +45,22 @@ class ProcessUploadedFileJob < ApplicationJob
 
   def unzip(model, uploaded_file)
     Shrine.with_file(uploaded_file) do |archive|
-      Dir.mktmpdir do |tmpdir|
-        strip = count_common_path_components(archive)
-        Archive::Reader.open_filename(archive.path, strip_components: strip) do |reader|
-          reader.each_entry do |entry|
-            next if !entry.file? || entry.size > SiteSettings.max_file_extract_size
-            next if SiteSettings.ignored_file?(entry.pathname)
-            filename = entry.pathname # Stored because pathname gets mutated by the extract and we want the original
-            reader.extract(entry, Archive::EXTRACT_SECURE, destination: tmpdir)
-            model.model_files.create(filename: filename, attachment: File.open(entry.pathname))
-          end
+      tmpdir = Shrine.find_storage(:cache).directory.join(SecureRandom.uuid)
+      tmpdir.mkdir
+      strip = count_common_path_components(archive)
+      Archive::Reader.open_filename(archive.path, strip_components: strip) do |reader|
+        reader.each_entry do |entry|
+          next if !entry.file? || entry.size > SiteSettings.max_file_extract_size
+          next if SiteSettings.ignored_file?(entry.pathname)
+          filename = entry.pathname # Stored because pathname gets mutated by the extract and we want the original
+          reader.extract(entry, Archive::EXTRACT_SECURE, destination: tmpdir.to_s)
+          model.model_files.create(filename: filename, attachment: File.open(entry.pathname))
+          # Clean up file
+          File.delete(entry.pathname)
         end
       end
+      # Clean up temp folder
+      Dir.rmdir(tmpdir)
     end
   end
 

--- a/app/jobs/process_uploaded_file_job.rb
+++ b/app/jobs/process_uploaded_file_job.rb
@@ -56,11 +56,11 @@ class ProcessUploadedFileJob < ApplicationJob
           reader.extract(entry, Archive::EXTRACT_SECURE, destination: tmpdir.to_s)
           model.model_files.create(filename: filename, attachment: File.open(entry.pathname))
           # Clean up file
-          File.delete(entry.pathname)
+          File.delete(entry.pathname) if File.exist?(entry.pathname)
         end
       end
       # Clean up temp folder
-      Dir.rmdir(tmpdir)
+      Dir.rmdir(tmpdir) if Dir.empty?(tmpdir)
     end
   end
 

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -18,7 +18,7 @@ Rails.application.config.after_initialize do
   Library.all.map do |l|
     upload_options[l.storage_key.to_sym] = {move: true} if l.storage_service == "filesystem"
   end
-  Shrine.plugin :upload_options, **upload_options
+  Shrine.plugin :upload_options, **upload_options unless Rails.env.test?
 
   begin
     Sidekiq.set_schedule("sweep", {every: "1h", class: "CacheSweepJob"})

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -8,7 +8,7 @@ Shrine.plugin :determine_mime_type
 Shrine.plugin :rack_response
 
 Shrine.storages = {
-  cache: Shrine::Storage::FileSystem.new("tmp/cache")
+  cache: Shrine::Storage::FileSystem.new("tmp/shrine")
 }
 
 Rails.application.config.after_initialize do

--- a/config/initializers/shrine.rb
+++ b/config/initializers/shrine.rb
@@ -13,6 +13,13 @@ Shrine.storages = {
 
 Rails.application.config.after_initialize do
   Library.register_all_storage
+
+  upload_options = {cache: {move: true}}
+  Library.all.map do |l|
+    upload_options[l.storage_key.to_sym] = {move: true} if l.storage_service == "filesystem"
+  end
+  Shrine.plugin :upload_options, **upload_options
+
   begin
     Sidekiq.set_schedule("sweep", {every: "1h", class: "CacheSweepJob"})
   rescue RedisClient::CannotConnectError


### PR DESCRIPTION
All unzipping activity now happens inside the Shrine cache folder, which is now also its own subfolder of Rails tmp. Also, files are moved between Filesystem storages where possible.

Partly resolves #2136
Resolves #2663 
