### PR TITLE
Markdown support for note fields

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,3 +149,5 @@ gem "federails", git: "https://gitlab.com/manyfold3d/federails.git", branch: "po
 gem "caber"
 
 gem "nanoid", "~> 2.0"
+
+gem "kramdown", "~> 2.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -351,6 +351,8 @@ GEM
       activerecord
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
+    kramdown (2.4.0)
+      rexml
     language_server-protocol (3.17.0.3)
     launchy (2.4.3)
       addressable (~> 2.3)
@@ -713,6 +715,7 @@ DEPENDENCIES
   jbuilder (~> 2.13)
   jsbundling-rails
   kaminari (~> 1.2)
+  kramdown (~> 2.4)
   letter_opener (~> 1.10)
   listen (~> 3.9)
   lograge (~> 0.14.0)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -25,6 +25,13 @@ module ApplicationHelper
     end
   end
 
+  def markdownify(text)
+    Kramdown::Document.new(
+      sanitize(text),
+      header_offset: 2
+    ).to_html.html_safe # rubocop:disable Rails/OutputSafety
+  end
+
   def card(style, title, options = {}, &content)
     id = "card-#{SecureRandom.hex(4)}"
     card_class = "card mb-4"

--- a/app/views/collections/_collection.html.erb
+++ b/app/views/collections/_collection.html.erb
@@ -25,7 +25,7 @@
           <h6 class="card-subtitle mb-2 text-muted"><%= sanitize collection.caption %></h6>
         <% end %>
         <% if collection.notes && collection.notes != "" %>
-          <p class="card-text"><%= sanitize collection.notes %></p>
+          <p class="card-text"><%= markdownify collection.notes %></p>
         <% end %>
         <ul class='links'>
           <% collection.links.each do |link| %>

--- a/app/views/creators/_creator.html.erb
+++ b/app/views/creators/_creator.html.erb
@@ -6,7 +6,7 @@
         <h6 class="card-subtitle mb-2 text-muted"><%= sanitize creator.caption %></h6>
       <% end %>
       <% if creator.notes %>
-        <p class="card-text"><%= sanitize creator.notes %></p>
+        <p class="card-text"><%= markdownify creator.notes %></p>
       <% end %>
       <ul class='links'>
         <% creator.links.each do |link| %>

--- a/app/views/model_files/show.html.erb
+++ b/app/views/model_files/show.html.erb
@@ -29,7 +29,7 @@
     <% end %>
     <% if @file.notes %>
       <%= card(:secondary, t(".notes_heading")) do %>
-        <p class="card-text"><%= sanitize @file.notes %></p>
+        <p class="card-text"><%= markdownify @file.notes %></p>
       <% end %>
     <% end %>
   </div>

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -89,7 +89,7 @@
   <%= render partial: "problem", collection: @model.problems.visible(problem_settings) %>
 
   <%= card(:secondary, t(".notes_heading")) do %>
-    <p class="card-text"><%= sanitize @model.notes %></p>
+    <p class="card-text"><%= markdownify @model.notes %></p>
   <% end if @model.notes %>
 
   <%= card :secondary, t(".files_card.heading") do %>

--- a/app/views/settings/_library_settings.html.erb
+++ b/app/views/settings/_library_settings.html.erb
@@ -52,7 +52,7 @@
           </div>
           <div class="row input-group">
             <%= content_tag(:span, t("activerecord.attributes.library.notes"), class: "col-sm") %>
-            <%= content_tag(:span, library.notes, class: "col-sm-10") %>
+            <%= content_tag(:div, markdownify(library.notes), class: "col-sm-10") %>
           </div>
           <div class="row input-group">
             <%= content_tag(:span, t("activerecord.attributes.library.tag_regex"), class: "col-sm") %>


### PR DESCRIPTION
Now you can add simple links, formatting, etc to notes fields using standard Markdown syntax