### PR TITLE
Rename model notes to description, and move to under images

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -32,7 +32,7 @@ module ApplicationHelper
     ).to_html.html_safe # rubocop:disable Rails/OutputSafety
   end
 
-  def card(style, title, options = {}, &content)
+  def card(style, title = nil, options = {}, &content)
     id = "card-#{SecureRandom.hex(4)}"
     card_class = "card mb-4"
     if options[:skip_link]
@@ -41,21 +41,23 @@ module ApplicationHelper
     end
     tag.div class: card_class do
       safe_join([
-        tag.div(class: "card-header text-white bg-#{style}") do
-          options[:collapse] ?
-            safe_join([
-              title,
-              tag.span(icon("arrows-expand", t("general.expand")), class: "float-end d-#{options[:collapse]}-none"),
-              tag.a(
-                nil,
-                class: "link-unstyled stretched-link d-#{options[:collapse]}-none",
-                "data-bs-toggle": "collapse",
-                "data-bs-target": "##{id}",
-                "aria-expanded": false,
-                "aria-controls": id
-              )
-            ]) :
-            title
+        if title
+          tag.div(class: "card-header text-white bg-#{style}") do
+            options[:collapse] ?
+              safe_join([
+                title,
+                tag.span(icon("arrows-expand", t("general.expand")), class: "float-end d-#{options[:collapse]}-none"),
+                tag.a(
+                  nil,
+                  class: "link-unstyled stretched-link d-#{options[:collapse]}-none",
+                  "data-bs-toggle": "collapse",
+                  "data-bs-target": "##{id}",
+                  "aria-expanded": false,
+                  "aria-controls": id
+                )
+              ]) :
+              title
+          end
         end,
         skiplink,
         tag.div(class: "card-body #{"collapse d-#{options[:collapse]}-block" if options[:collapse]}", id: id) do

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -12,6 +12,10 @@
 <% content_for :items do %>
   <%= render "image_carousel", images: @images %>
 
+  <%= card(:secondary) do %>
+    <p class="card-text"><%= markdownify @model.notes %></p>
+  <% end if @model.notes %>
+
   <h2><a name="files"><%= t(".files") %></a></h2>
   <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 mb-4">
     <%= render partial: "file", collection: @groups.delete(nil) %>
@@ -87,10 +91,6 @@
   <% end %>
 
   <%= render partial: "problem", collection: @model.problems.visible(problem_settings) %>
-
-  <%= card(:secondary, t(".notes_heading")) do %>
-    <p class="card-text"><%= markdownify @model.notes %></p>
-  <% end if @model.notes %>
 
   <%= card :secondary, t(".files_card.heading") do %>
     <a href="#files">Top</a>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -35,7 +35,7 @@ de:
         library_id: Sammlung
         license: Lizenz
         name: Name
-        notes: Notizen
+        notes: Beschreibung
         path: Pfad
         preview_file: Vorschau Datei
         tags: Tags

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,7 +33,7 @@ en:
         library_id: Library
         license: License
         name: Name
-        notes: Notes
+        notes: Description
         path: Path
         preview_file: Preview File
         tags: Tags

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -33,7 +33,7 @@ fr:
         library_id: Bibliothèque
         license: Licence
         name: Nom
-        notes: Notes
+        notes: Description
         path: Chemin
         preview_file: Prévisualisation
         tags: Étiquettes

--- a/config/locales/models/de.yml
+++ b/config/locales/models/de.yml
@@ -69,7 +69,6 @@ de:
         warning: Bei der Zusammenführung werden alle Dateien dieses Modells auf das Ziel verschoben und das Modell wird entfernt. Die Metadaten der Dateien bleiben erhalten, aber alle Metadaten des Modelle gehen verloren!
         with: Zusammenführen mit
       model_details: Modelldetails
-      notes_heading: Notizen
       organize:
         button_text: Dateien sortieren
         confirm:

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -72,7 +72,6 @@ en:
         warning: Merging moves all files from this model to the target, and removes this model. File metadata is preserved, but any model metadata will be lost!
         with: Merge with
       model_details: Model Details
-      notes_heading: Notes
       organize:
         button_text: Organize files
         confirm:

--- a/config/locales/models/fr.yml
+++ b/config/locales/models/fr.yml
@@ -69,7 +69,6 @@ fr:
         warning: La fusion déplace tous les fichiers de ce modèle vers la cible et supprime ce modèle. Les métadonnées des fichiers sont préservées, mais toutes les métadonnées du modèle sont perdues !
         with: Fusionner avec
       model_details: Détails du modèle
-      notes_heading: Notes
       organize:
         button_text: Organiser les fichiers
         confirm:

--- a/config/locales/models/pl.yml
+++ b/config/locales/models/pl.yml
@@ -69,7 +69,6 @@ pl:
         warning: Scalanie przenosi wszystkie pliki z tego modelu do docelowego i usuwa ten model. Metadane plików zostaną zachowane, ale wszelkie metadane modelu zostaną utracone!
         with: Połącz z
       model_details: Szczegóły Modelu
-      notes_heading: Notatki
       organize:
         button_text: Zorganizuj pliki
         confirm:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -33,7 +33,7 @@ pl:
         library_id: Biblioteka
         license: Licencja
         name: Nazwa
-        notes: Notatki
+        notes: Opis
         path: Ścieżka
         preview_file: Podgląd pliku
         tags: Tagi


### PR DESCRIPTION
Thus making it suitable for descriptions for public models.