### PR TITLE
Accept ActivityPub follow requests

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GIT
 
 GIT
   remote: https://gitlab.com/manyfold3d/federails.git
-  revision: d031a5cadd24b31e95ba9b8aa5cce074dc1300d5
+  revision: 98d8fb6156cb1812e6eaeb307499a54e596d6b9a
   branch: manyfold
   specs:
     federails (0.1.0)

--- a/app/models/concerns/followable.rb
+++ b/app/models/concerns/followable.rb
@@ -8,6 +8,8 @@ module Followable
     delegate :following_followers, to: :actor
     after_commit :post_creation_activity, on: :create
     after_commit :post_update_activity, on: :update
+
+    after_followed :auto_accept
   end
 
   def followers
@@ -42,5 +44,9 @@ module Followable
       entity: actor,
       created_at: updated_at
     )
+  end
+
+  def auto_accept
+    actor.following_followers.where(status: "pending").find_each { |x| x.accept! }
   end
 end


### PR DESCRIPTION
This will become optional later (#2834), but for now this happens automatically in order to be functional.

resolves #2774 