### PR TITLE
Ignore SSL EOF errors from badly configured servers

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GIT
 
 GIT
   remote: https://gitlab.com/manyfold3d/federails.git
-  revision: 98d8fb6156cb1812e6eaeb307499a54e596d6b9a
+  revision: ba0cbbd473386d38822d308375f4e089fbcf13d8
   branch: manyfold
   specs:
     federails (0.1.0)

--- a/config/initializers/openssl.rb
+++ b/config/initializers/openssl.rb
@@ -1,0 +1,7 @@
+# Ignore OpenSSL EOF errors that are very common with OpenSSL 3 because the Internet is terrible.
+# This solution is a horrible hack from https://stackoverflow.com/questions/76183622/since-a-ruby-container-upgrade-we-expirience-a-lot-of-opensslsslsslerror
+# but it seems the quickest and most global solution without rewriting a bunch of lower-level code.
+# It'll do for now.
+OpenSSL::SSL::SSLContext::DEFAULT_PARAMS = OpenSSL::SSL::SSLContext::DEFAULT_PARAMS.merge(
+  options: OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:options] + OpenSSL::SSL::OP_IGNORE_UNEXPECTED_EOF
+).freeze


### PR DESCRIPTION
OpenSSL 3 increases the occurrence of SSL EOF errors a lot, because many servers are badly configured. This hack ignores the error, which is not ideal and needs a better solution, but that solution may be out of my control.