### PR TITLE
Split selected files into new model when bulk editing

### DIFF
--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -133,6 +133,12 @@ class Model < ApplicationRecord
       file.update!(model: new_model)
       file.reattach!
     end
+    # Clear preview file appropriately
+    if files.include?(preview_file)
+      update!(preview_file: nil)
+    else
+      new_model.update!(preview_file: nil)
+    end
     # Done!
     new_model
   end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -123,6 +123,20 @@ class Model < ApplicationRecord
     save!
   end
 
+  def split!(files: [])
+    new_model = dup
+    new_model.name = "Copy of #{name}"
+    new_model.public_id = nil
+    new_model.organize!
+    # Move files
+    files.each do |file|
+      file.update!(model: new_model)
+      file.reattach!
+    end
+    # Done!
+    new_model
+  end
+
   private
 
   def normalize_license

--- a/app/views/model_files/bulk_edit.html.erb
+++ b/app/views/model_files/bulk_edit.html.erb
@@ -53,5 +53,6 @@
     </div>
   </div>
   <%= form.submit translate(".submit"), class: "btn btn-primary" %>
+  <%= form.submit translate(".split"), name: "split", class: "btn btn-warning" %>
 
 <% end %>

--- a/config/locales/model_files/en.yml
+++ b/config/locales/model_files/en.yml
@@ -5,8 +5,9 @@ en:
       description: 'Select files to change:'
       form_subtitle: 'Select changes to make:'
       select: Select file '%{name}'
+      split: Split selected files into new model
       select_all: Select all files
-      submit: Update Selected Files
+      submit: Update selected files
       title: Bulk Edit Files
     bulk_update:
       success: Files updated successfully.

--- a/config/locales/model_files/en.yml
+++ b/config/locales/model_files/en.yml
@@ -5,8 +5,8 @@ en:
       description: 'Select files to change:'
       form_subtitle: 'Select changes to make:'
       select: Select file '%{name}'
-      split: Split selected files into new model
       select_all: Select all files
+      split: Split selected files into new model
       submit: Update selected files
       title: Bulk Edit Files
     bulk_update:

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -279,8 +279,20 @@ RSpec.describe Model do
       expect(new_model.model_files.count).to eq 1
     end
 
-    it "removes selected files from old model" do
-      expect { model.split! files: [model.model_files.first] }.to change { model.model_files.count }.by(-1)
+    it "retains existing preview file for new model if selected for split" do # rubocop:todo RSpec/MultipleExpectations
+      file_to_split = model.model_files.first
+      model.update!(preview_file: file_to_split)
+      new_model = model.split! files: [file_to_split]
+      expect(new_model.preview_file).to eq file_to_split
+      expect(model.reload.preview_file).to be_nil
+    end
+
+    it "new model gets no preview file if not selected" do # rubocop:todo RSpec/MultipleExpectations
+      preview_file = model.model_files.first
+      model.update!(preview_file: preview_file)
+      new_model = model.split! files: [model.model_files.last]
+      expect(new_model.reload.preview_file).to be_nil
+      expect(model.preview_file).to eq preview_file
     end
   end
 


### PR DESCRIPTION
In bulk file edit, you can now press "split" instead of "save" to move those files into a new model with a copy of the current model's metadata.

Resolves #2572 