### PR TITLE
Move remote follow route to standard path

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -146,7 +146,7 @@ gem "better_content_security_policy", "~> 0.1.4"
 gem "devise_zxcvbn", "~> 6.0"
 
 gem "ransack", "~> 4.2"
-gem "federails", git: "https://gitlab.com/experimentslabs/federails.git", branch: "fix-application-routing"
+gem "federails", git: "https://gitlab.com/experimentslabs/federails.git", branch: "main"
 gem "caber"
 
 gem "nanoid", "~> 2.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,7 +32,7 @@ GIT
 GIT
   remote: https://gitlab.com/experimentslabs/federails.git
   revision: 6164a632938b97f3e9d9aa4992c746cb3f0b4344
-  branch: fix-application-routing
+  branch: main
   specs:
     federails (0.1.0)
       faraday

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
     end
   end
 
-  get "/authorize_interaction"=> "follows#new", :as => :new_follow
+  get "/authorize_interaction" => "follows#new", :as => :new_follow
 
   concern :followable do |options|
     if SiteSettings.multiuser_enabled?

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -35,7 +35,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :follows, {only: [:new]}
+  get "/authorize_interaction"=> "follows#new", :as => :new_follow
 
   concern :followable do |options|
     if SiteSettings.multiuser_enabled?


### PR DESCRIPTION
mainly for mastodon compatibility, which doesn't seem to actually use per-account webfinger for remote follow.