### PR TITLE
Stop hashtags appearing as headings in activitypub notes

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -298,7 +298,7 @@ en:
         comment: |
           I've just added a new model: ["%{model_name}"](%{url})
 
-          %{tags}
+          \%{tags}
     scan:
       check_all:
         queueing_model_checks: Queueing model checks


### PR DESCRIPTION
escape beginning of hashtag line so it doesn't turn into a heading