### PR TITLE
Don't create Federails Actors during migration

### DIFF
--- a/app/models/concerns/federails_common.rb
+++ b/app/models/concerns/federails_common.rb
@@ -2,9 +2,12 @@ module FederailsCommon
   extend ActiveSupport::Concern
   include Federails::Entity
 
-  def create_actor_if_missing
-    return if actor.present?
-    create_actor
-    reload
+  def actor
+    act = Federails::Actor.find_by(entity: self)
+    if act.nil?
+      act = create_actor
+      reload
+    end
+    act
   end
 end

--- a/app/models/concerns/follower.rb
+++ b/app/models/concerns/follower.rb
@@ -12,7 +12,6 @@ module Follower
   end
 
   def follow(target)
-    target.create_actor_if_missing
     following_follows.create(target_actor: target.actor)
   end
 

--- a/db/data/20240731165647_create_federails_actors.rb
+++ b/db/data/20240731165647_create_federails_actors.rb
@@ -2,9 +2,6 @@
 
 class CreateFederailsActors < ActiveRecord::Migration[7.1]
   def up
-    User.find_each do |user|
-      user.create_actor_if_missing
-    end
   end
 
   def down

--- a/db/data/20240802094448_create_more_federails_actors.rb
+++ b/db/data/20240802094448_create_more_federails_actors.rb
@@ -2,15 +2,6 @@
 
 class CreateMoreFederailsActors < ActiveRecord::Migration[7.1]
   def up
-    entity_classes = [User, Model, Creator, Collection]
-    entity_classes.each do |entity_class|
-      puts "Creating actors for #{entity_class.name}" # rubocop:todo Rails/Output
-      entity_class.find_each do |entity|
-        putc "." # rubocop:todo Rails/Output
-        entity.create_actor_if_missing
-      end
-      puts # rubocop:todo Rails/Output
-    end
   end
 
   def down

--- a/db/data/20240909100000_backfill_activities_after_permissions.rb
+++ b/db/data/20240909100000_backfill_activities_after_permissions.rb
@@ -3,7 +3,6 @@
 class BackfillActivitiesAfterPermissions < ActiveRecord::Migration[7.1]
   def up
     Model.unscoped.limit(20).order(created_at: :desc).each do |model|
-      model.create_actor_if_missing
       model.send :post_creation_activity if model.actor&.activities&.empty?
     end
   end


### PR DESCRIPTION
resolves #2906 by removing the creation during migration step, which is vulnerable to code changes. We do it lazily instead.