### PR TITLE
Add OIDC login support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -152,3 +152,7 @@ gem "caber"
 gem "nanoid", "~> 2.0"
 
 gem "kramdown", "~> 2.4"
+
+gem "omniauth", "~> 2.1"
+gem "omniauth-rails_csrf_protection", "~> 1.0"
+gem "omniauth_openid_connect", "~> 0.8.0"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -145,10 +145,12 @@ GEM
       activerecord (>= 5.0)
     addressable (2.8.7)
       public_suffix (>= 2.0.2, < 7.0)
+    aes_key_wrap (1.1.0)
     arbre (1.7.0)
       activesupport (>= 3.0.0)
       ruby2_keywords (>= 0.0.2)
     ast (2.4.2)
+    attr_required (1.0.2)
     aws-eventstream (1.3.0)
     aws-partitions (1.983.0)
     aws-sdk-core (3.209.1)
@@ -178,6 +180,7 @@ GEM
       parser (>= 2.4)
       smart_properties
     bigdecimal (3.1.8)
+    bindata (2.5.0)
     bindex (0.8.1)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
@@ -230,6 +233,8 @@ GEM
     down (5.4.2)
       addressable (~> 2.8)
     drb (2.2.1)
+    email_validator (2.2.4)
+      activemodel
     erb_lint (0.6.0)
       activesupport
       better_html (>= 2.0.1)
@@ -292,6 +297,7 @@ GEM
     has_scope (0.8.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
+    hashie (5.0.0)
     highline (3.0.1)
     htmlentities (4.3.4)
     i18n (1.14.6)
@@ -332,6 +338,13 @@ GEM
       railties (>= 6.0.0)
     json (2.7.2)
     json-canonicalization (1.0.0)
+    json-jwt (1.16.6)
+      activesupport (>= 4.2)
+      aes_key_wrap
+      base64
+      bindata
+      faraday (~> 2.0)
+      faraday-follow_redirects
     json-ld (3.3.2)
       htmlentities (~> 4.3)
       json-canonicalization (~> 1.0)
@@ -420,7 +433,30 @@ GEM
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
+    omniauth (2.1.2)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-rails_csrf_protection (1.0.2)
+      actionpack (>= 4.2)
+      omniauth (~> 2.0)
+    omniauth_openid_connect (0.8.0)
+      omniauth (>= 1.9, < 3)
+      openid_connect (~> 2.2)
     opengl-bindings (1.6.14)
+    openid_connect (2.3.0)
+      activemodel
+      attr_required (>= 1.0.0)
+      email_validator
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.16)
+      mail
+      rack-oauth2 (~> 2.2)
+      swd (~> 2.0)
+      tzinfo
+      validate_url
+      webfinger (~> 2.0)
     orm_adapter (0.5.0)
     parallel (1.26.3)
     parser (3.3.5.0)
@@ -447,6 +483,16 @@ GEM
     rack (2.2.10)
     rack-contrib (2.5.0)
       rack (< 4)
+    rack-oauth2 (2.2.1)
+      activesupport
+      attr_required
+      faraday (~> 2.0)
+      faraday-follow_redirects
+      json-jwt (>= 1.11.0)
+      rack (>= 2.1.0)
+    rack-protection (3.2.0)
+      base64 (>= 0.1.0)
+      rack (~> 2.2, >= 2.2.4)
     rack-session (1.0.2)
       rack (< 3)
     rack-test (2.1.0)
@@ -640,6 +686,11 @@ GEM
     stopwords-filter2 (0.1.0)
     string-similarity (2.1.0)
     stringio (3.1.1)
+    swd (2.0.3)
+      activesupport (>= 3)
+      attr_required (>= 0.0.5)
+      faraday (~> 2.0)
+      faraday-follow_redirects
     sys-filesystem (1.5.3)
       ffi (~> 1.1)
     terminal-table (3.0.2)
@@ -659,6 +710,9 @@ GEM
     unicode-display_width (2.6.0)
     uniform_notifier (1.16.0)
     uri (0.13.1)
+    validate_url (1.0.15)
+      activemodel (>= 3.0.0)
+      public_suffix
     view_component (3.17.0)
       activesupport (>= 5.2.0, < 8.0)
       concurrent-ruby (~> 1.0)
@@ -670,6 +724,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webfinger (2.1.3)
+      activesupport
+      faraday (~> 2.0)
+      faraday-follow_redirects
     webrick (1.8.2)
     websocket-driver (0.7.6)
       websocket-extensions (>= 0.1.0)
@@ -728,6 +786,9 @@ DEPENDENCIES
   mittsu!
   mysql2 (~> 0.5.6)
   nanoid (~> 2.0)
+  omniauth (~> 2.1)
+  omniauth-rails_csrf_protection (~> 1.0)
+  omniauth_openid_connect (~> 0.8.0)
   pg (~> 1.5)
   public_suffix (~> 6.0)
   puma (~> 6.4)

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -3,13 +3,13 @@ class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
 
   def openid_connect
     @user = User.from_omniauth(request.env["omniauth.auth"])
-
     if @user.persisted?
+      @user.add_role :administrator if User.with_role(:administrator).empty? # Create admin if there isn't one
       sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
       set_flash_message(:notice, :success, kind: "OIDC") if is_navigational_format?
     else
-      session["devise.openid_connect_data"] = request.env["omniauth.auth"].except(:extra) # Removing extra as it can overflow some session stores
-      redirect_to new_user_registration_url
+      redirect_to new_user_session_url
+      set_flash_message(:notice, :error, kind: "OIDC") if is_navigational_format?
     end
   end
 end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,15 @@
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  skip_after_action :verify_authorized
+
+  def openid_connect
+    @user = User.from_omniauth(request.env["omniauth.auth"])
+
+    if @user.persisted?
+      sign_in_and_redirect @user, event: :authentication # this will throw if @user is not activated
+      set_flash_message(:notice, :success, kind: "OIDC") if is_navigational_format?
+    else
+      session["devise.openid_connect_data"] = request.env["omniauth.auth"].except(:extra) # Removing extra as it can overflow some session stores
+      redirect_to new_user_registration_url
+    end
+  end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -32,6 +32,7 @@ class Users::SessionsController < Devise::SessionsController
   # end
 
   def auto_login_single_user
+    return if ENV.fetch("FORCE_OIDC", nil) == "enabled"
     # Autocreate an admin user if there isn't one
     create_admin_user if User.with_role(:administrator).empty?
     # If in single user mode, or on first run,

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -42,6 +42,10 @@ class SiteSettings < RailsSettings::Base
     Rails.application.config.manyfold_features[:federation]
   end
 
+  def self.oidc_enabled?
+    Rails.application.config.manyfold_features[:oidc]
+  end
+
   def self.default_user
     User.with_role(:administrator).first
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,6 +13,8 @@ class User < ApplicationRecord
     :rememberable, :recoverable,
     :lockable, :timeoutable
 
+  devise :omniauthable, omniauth_providers: %i[openid_connect] if SiteSettings.oidc_enabled?
+
   validates :username,
     presence: true,
     uniqueness: {case_sensitive: false},
@@ -79,6 +81,14 @@ class User < ApplicationRecord
 
   def problem_severity(category)
     problem_settings[category.to_s]&.to_sym || Problem::DEFAULT_SEVERITIES[category.to_sym]
+  end
+
+  def self.from_omniauth(auth)
+    find_or_create_by(auth_provider: auth.provider, auth_uid: auth.uid) do |user|
+      user.email = auth.info.email
+      user.password = user.password_confirmation = Devise.friendly_token[0, 20]
+      user.username = auth.info.preferred_username || auth.info.nickname&.parameterize || auth.info.email.split("@")[0]
+    end
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -86,7 +86,6 @@ class User < ApplicationRecord
   def self.from_omniauth(auth)
     find_or_create_by(auth_provider: auth.provider, auth_uid: auth.uid) do |user|
       user.email = auth.info.email
-      user.password = user.password_confirmation = Devise.friendly_token[0, 20]
       user.username = auth.info.preferred_username || auth.info.nickname&.parameterize || auth.info.email.split("@")[0]
     end
   end
@@ -102,6 +101,7 @@ class User < ApplicationRecord
   end
 
   def password_required?
+    return false if auth_provider && auth_uid
     !persisted? || !password.nil? || !password_confirmation.nil?
   end
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,6 +1,6 @@
 <h1><%= t(".sign_in") %></h1>
 
-<% if ENV.fetch("FORCE_OIDC") == "enabled" %>
+<% if ENV.fetch("FORCE_OIDC", nil) == "enabled" %>
 
   <%- if devise_mapping.omniauthable? %>
     <%- resource_class.omniauth_providers.each do |provider| %>

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,18 +1,28 @@
 <h1><%= t(".sign_in") %></h1>
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |form| %>
+<% if ENV.fetch("FORCE_OIDC") == "enabled" %>
 
-  <%= text_input_row form, :email, autofocus: true, autocomplete: "email" %>
-  <%= password_input_row form, :password, autocomplete: "current-password" %>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= form.check_box :remember_me %>
-      <%= form.label :remember_me %>
-    </div>
+  <%- if devise_mapping.omniauthable? %>
+    <%- resource_class.omniauth_providers.each do |provider| %>
+      <%= button_to t("devise.shared.links.sign_in_with_provider", provider: ENV.fetch("OIDC_NAME", OmniAuth::Utils.camelize(provider))), omniauth_authorize_path(resource_name, provider), method: :post, class: "btn btn-primary", data: {turbo: false} %>
+    <% end %>
   <% end %>
 
-  <%= form.submit translate(".sign_in"), class: "btn btn-primary" %>
-<% end %>
+<% else %>
+  <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |form| %>
 
-<%= render "devise/shared/links" %>
+    <%= text_input_row form, :email, autofocus: true, autocomplete: "email" %>
+    <%= password_input_row form, :password, autocomplete: "current-password" %>
+
+    <% if devise_mapping.rememberable? %>
+      <div class="field">
+        <%= form.check_box :remember_me %>
+        <%= form.label :remember_me %>
+      </div>
+    <% end %>
+
+    <%= form.submit translate(".sign_in"), class: "btn btn-primary" %>
+  <% end %>
+
+  <%= render "devise/shared/links" %>
+<% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -21,7 +21,7 @@
 
   <%- if devise_mapping.omniauthable? %>
     <%- resource_class.omniauth_providers.each do |provider| %>
-      <%= button_to t(".sign_in_with_provider", provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider), method: :post, data: {turbo: false} %><br>
+      <%= button_to t(".sign_in_with_provider", provider: ENV.fetch("OIDC_NAME", OmniAuth::Utils.camelize(provider))), omniauth_authorize_path(resource_name, provider), method: :post, class: 'btn btn-primary', data: {turbo: false} %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -21,7 +21,7 @@
 
   <%- if devise_mapping.omniauthable? %>
     <%- resource_class.omniauth_providers.each do |provider| %>
-      <%= button_to t(".sign_in_with_provider", provider: ENV.fetch("OIDC_NAME", OmniAuth::Utils.camelize(provider))), omniauth_authorize_path(resource_name, provider), method: :post, class: 'btn btn-primary', data: {turbo: false} %>
+      <%= button_to t(".sign_in_with_provider", provider: ENV.fetch("OIDC_NAME", OmniAuth::Utils.camelize(provider))), omniauth_authorize_path(resource_name, provider), method: :post, class: "btn btn-primary", data: {turbo: false} %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -21,7 +21,7 @@
 
   <%- if devise_mapping.omniauthable? %>
     <%- resource_class.omniauth_providers.each do |provider| %>
-      <%= button_to t(".sign_in_with_provider", provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider), data: {turbo: false} %><br>
+      <%= button_to t(".sign_in_with_provider", provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider), method: :post, data: {turbo: false} %><br>
     <% end %>
   <% end %>
 </div>

--- a/config/application.rb
+++ b/config/application.rb
@@ -68,7 +68,8 @@ module Manyfold
     config.manyfold_features = {
       multiuser: (ENV.fetch("MULTIUSER", nil) == "enabled"),
       federation: (ENV.fetch("FEDERATION", nil) == "enabled"),
-      demo_mode: (ENV.fetch("DEMO_MODE", nil) == "enabled")
+      demo_mode: (ENV.fetch("DEMO_MODE", nil) == "enabled"),
+      oidc: ENV.key?("OIDC_CLIENT_ID") && ENV.key?("OIDC_CLIENT_SECRET") && ENV.key?("OIDC_PROVIDER_HOST")
     }
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -69,7 +69,7 @@ module Manyfold
       multiuser: (ENV.fetch("MULTIUSER", nil) == "enabled"),
       federation: (ENV.fetch("FEDERATION", nil) == "enabled"),
       demo_mode: (ENV.fetch("DEMO_MODE", nil) == "enabled"),
-      oidc: ENV.key?("OIDC_CLIENT_ID") && ENV.key?("OIDC_CLIENT_SECRET") && ENV.key?("OIDC_PROVIDER_HOST")
+      oidc: ENV.key?("OIDC_CLIENT_ID") && ENV.key?("OIDC_CLIENT_SECRET") && ENV.key?("OIDC_ISSUER")
     }
   end
 end

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -272,7 +272,7 @@ Devise.setup do |config|
     config.omniauth :openid_connect, {
       name: :openid_connect,
       issuer: ENV.fetch("OIDC_ISSUER"),
-      scope: [:openid, :email, :preferred_username, :nickname],
+      scope: [:openid, :email, :profile],
       response_type: :code,
       discovery: true,
       client_options: {

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -265,7 +265,23 @@ Devise.setup do |config|
   # ==> OmniAuth
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
-  # config.omniauth :github, 'APP_ID', 'APP_SECRET', scope: 'user,public_repo'
+
+  scheme = Rails.application.config.force_ssl ? "https" : "http"
+  if Rails.application.config.manyfold_features[:oidc]
+    config.omniauth :openid_connect, {
+      name: :openid_connect,
+      issuer: "https://#{ENV["OIDC_PROVIDER_HOST"]}/",
+      scope: [:openid, :email, :preferred_username, :nickname],
+      response_type: :code,
+      discovery: true,
+      client_options: {
+        host: ENV["OIDC_PROVIDER_HOST"],
+        identifier: ENV["OIDC_CLIENT_ID"],
+        secret: ENV["OIDC_CLIENT_SECRET"],
+        redirect_uri: "#{scheme}://#{[Rails.application.default_url_options[:host], Rails.application.default_url_options[:port]].compact.join(":")}/users/auth/openid_connect/callback"
+      }
+    }
+  end
 
   # ==> Warden configuration
   # If you want to use other strategies, that are not supported by Devise, or

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -266,8 +266,8 @@ Devise.setup do |config|
   # Add a new OmniAuth provider. Check the wiki for more information on setting
   # up on your models and hooks.
 
-  scheme = Rails.application.config.force_ssl ? "https" : "http"
   if Rails.application.config.manyfold_features[:oidc]
+    scheme = Rails.application.config.force_ssl ? "https" : "http"
     issuer_uri = URI.parse(ENV.fetch("OIDC_ISSUER"))
     config.omniauth :openid_connect, {
       name: :openid_connect,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -268,16 +268,19 @@ Devise.setup do |config|
 
   scheme = Rails.application.config.force_ssl ? "https" : "http"
   if Rails.application.config.manyfold_features[:oidc]
+    issuer_uri = URI.parse(ENV.fetch("OIDC_ISSUER"))
     config.omniauth :openid_connect, {
       name: :openid_connect,
-      issuer: "https://#{ENV["OIDC_PROVIDER_HOST"]}/",
+      issuer: ENV.fetch("OIDC_ISSUER"),
       scope: [:openid, :email, :preferred_username, :nickname],
       response_type: :code,
       discovery: true,
       client_options: {
-        host: ENV["OIDC_PROVIDER_HOST"],
-        identifier: ENV["OIDC_CLIENT_ID"],
-        secret: ENV["OIDC_CLIENT_SECRET"],
+        scheme: issuer_uri.scheme,
+        port: issuer_uri.port,
+        host: issuer_uri.host,
+        identifier: ENV.fetch("OIDC_CLIENT_ID"),
+        secret: ENV.fetch("OIDC_CLIENT_SECRET"),
         redirect_uri: "#{scheme}://#{[Rails.application.default_url_options[:host], Rails.application.default_url_options[:port]].compact.join(":")}/users/auth/openid_connect/callback"
       }
     }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
   get "health" => "rails/health#show", :as => :rails_health_check
   get "problems/index"
   devise_for :users, controllers: {
+    omniauth_callbacks: "users/omniauth_callbacks",
     passwords: "users/passwords",
     registrations: "users/registrations",
     sessions: "users/sessions"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,12 +6,14 @@ Rails.application.routes.draw do
   get ".well-known/change-password", to: redirect("/users/edit")
   get "health" => "rails/health#show", :as => :rails_health_check
   get "problems/index"
-  devise_for :users, controllers: {
-    omniauth_callbacks: "users/omniauth_callbacks",
+
+  devise_controllers = {
     passwords: "users/passwords",
     registrations: "users/registrations",
     sessions: "users/sessions"
   }
+  devise_controllers[:omniauth_callbacks] = "users/omniauth_callbacks" if Rails.application.config.manyfold_features[:oidc]
+  devise_for :users, controllers: devise_controllers
 
   ActiveAdmin.routes(self)
   authenticate :user, lambda { |u| u.is_administrator? } do

--- a/db/migrate/20241015090803_add_omniauth_to_users.rb
+++ b/db/migrate/20241015090803_add_omniauth_to_users.rb
@@ -1,0 +1,6 @@
+class AddOmniauthToUsers < ActiveRecord::Migration[7.1]
+  def change
+    add_column :users, :auth_provider, :string
+    add_column :users, :auth_uid, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_10_09_122540) do
+ActiveRecord::Schema[7.1].define(version: 2024_10_15_090803) do
   create_table "caber_relations", force: :cascade do |t|
     t.string "subject_type"
     t.integer "subject_id"
@@ -308,6 +308,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_10_09_122540) do
     t.string "interface_language"
     t.integer "failed_attempts", default: 0, null: false
     t.datetime "locked_at"
+    t.string "auth_provider"
+    t.string "auth_uid"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true


### PR DESCRIPTION
Resolves #2940 

New env vars:

* `OIDC_CLIENT_ID`
* `OIDC_CLIENT_SECRET`
* `OIDC_ISSUER`: Full issuer URI
* `OIDC_NAME`: shown in the login button if set, otherwise defaults to "OpenIDConnect"
* `FORCE_OIDC`: set to "enabled" to *only* allow OIDC login and disable local accounts