### PR TITLE
Allow customisation of site name, tagline and logo

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -45,6 +45,12 @@ class ApplicationController < ActionController::Base
 
   private
 
+  def img_src
+    url = ENV.fetch "SITE_ICON", nil
+    url ? URI.parse(url).host : nil
+    [:self, :data, url].compact
+  end
+
   def configure_content_security_policy
     # Standard security policy
     content_security_policy.default_src :self
@@ -52,7 +58,7 @@ class ApplicationController < ActionController::Base
     content_security_policy.frame_ancestors :self
     content_security_policy.frame_src :self
     content_security_policy.font_src :self, "https://cdn.jsdelivr.net"
-    content_security_policy.img_src :self, :data
+    content_security_policy.img_src(*img_src)
     content_security_policy.object_src :none
     content_security_policy.script_src :self
     content_security_policy.style_src :self

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,16 @@
 module ApplicationHelper
+  def site_name
+    ENV.fetch("SITE_NAME", translate("application.title"))
+  end
+
+  def site_tagline
+    ENV.fetch("SITE_TAGLINE", t("application.tagline"))
+  end
+
+  def site_icon
+    ENV.fetch("SITE_ICON", "roundel.svg")
+  end
+
   def icon(icon, label, id: nil)
     prefix = "bi"
     if icon.starts_with? "ra-"

--- a/app/views/application/_footer.html.erb
+++ b/app/views/application/_footer.html.erb
@@ -2,8 +2,8 @@
   <div class="row">
     <div class="col-lg-3 me-auto">
       <span class="d-inline-flex align-items-center mb-2">
-        <%= image_tag "roundel.svg", width: 48, height: 48, class: "me-2", alt: translate(".logo") %>
-        <span class="fs-5"><%= t "application.title" %></span>
+        <%= image_tag "roundel.svg", width: 48, height: 48, class: "me-2", alt: translate("application.title") %>
+        <span class="fs-5"><%= t("application.title") %></span>
       </span>
       <ul class="list-unstyled small text-muted">
         <li class="mb-2"><%= t ".by_html" %></li>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -1,8 +1,8 @@
 <nav class="navbar navbar-expand-lg bg-body-tertiary">
   <div class='container-fluid'>
     <a class="navbar-brand ms-2" href="<%= root_path %>" aria-label="<%= translate ".home" %>">
-      <%= image_tag "roundel.svg", alt: translate("application.title"), height: "40px", class: "me-2" %>
-      <span class="d-lg-none"><%= t "application.title" %></span>
+      <%= image_tag site_icon, alt: site_name, height: "40px", class: "me-2" %>
+      <span class="d-lg-none"><%= site_name %></span>
     </a>
     <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbarTogglerDemo01" aria-expanded="false" aria-label="<%= translate ".navbar.toggler.label" %>">
       <span class="navbar-toggler-icon"></span>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,7 +1,7 @@
 <div class="row bg-body-tertiary pt-3 mb-3 text-center">
   <%= render "application/content_header" %>
-  <h1 class="d-none d-lg-block"><%= t "application.title" %></h1>
-  <p class='lead'><%= t "application.tagline" %></p>
+  <h1 class="d-none d-lg-block"><%= site_name %></h1>
+  <p class='lead'><%= site_tagline %></p>
   <% if SiteSettings.demo_mode_enabled? %>
     <div class="alert alert-info">
       <%= t "application.demo_mode" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,13 +1,13 @@
 <!DOCTYPE html>
 <html lang="<%= I18n.locale %>">
   <head>
-    <title><%= @title || translate("application.title") %></title>
+    <title><%= @title || site_name %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= tag.meta name: "csp-nonce", content: content_security_policy_nonce if content_security_policy_nonce %>
     <%= favicon_link_tag "roundel.svg" %>
     <%= tag.link rel: "apple-touch-icon", href: asset_path("square-180.png") %>
-    <%= tag.meta name: "apple-mobile-web-app-title", content: translate("application.title") %>
+    <%= tag.meta name: "apple-mobile-web-app-title", content: site_name %>
     <%= javascript_include_tag "application", nonce: true %>
     <%= stylesheet_link_tag "application", nonce: true %>
     <%= yield :head %>

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -218,7 +218,6 @@ de:
       community_heading: Community
       development_heading: Entwicklung
       issues: Bugs
-      logo: Logo
       open_source_html: 'Open Source unter dieser Lizenz: <a href="https://github.com/manyfold3d/manyfold/blob/main/LICENSE.md" target="_blank" rel="license">MIT license</a>'
       social: Social Media
       sponsor: Sponsoren

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -218,7 +218,6 @@ en:
       community_heading: Community
       development_heading: Development
       issues: Issues
-      logo: Logo
       open_source_html: Open Source under the <a href="https://github.com/manyfold3d/manyfold/blob/main/LICENSE.md" target="_blank" rel="license">MIT license</a>.
       social: Social
       sponsor: Sponsor

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -222,7 +222,6 @@ es:
       community_heading: Comunidad
       development_heading: Desarrollo
       issues: Problemas
-      logo: Logo
       open_source_html: Open Source bajo <a href="https://github.com/manyfold3d/manyfold/blob/main/LICENSE.md" target="_blank" rel="license">licencia MIT</a>.
       social: Social
       sponsor: Colaborar

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -218,7 +218,6 @@ fr:
       community_heading: Communauté
       development_heading: Développement
       issues: Problèmes
-      logo: Logo
       open_source_html: Open Source sous <a href="https://github.com/manyfold3d/manyfold/blob/main/LICENSE.md" target="_blank" rel="license noopener">licence MIT.</a>
       social: Social
       sponsor: Sponsor

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -218,7 +218,6 @@ pl:
       community_heading: Społeczność
       development_heading: Rozwój
       issues: Problemy
-      logo: Logo
       open_source_html: Projekt Open Source na <a href="https://github.com/manyfold3d/manyfold/blob/main/LICENSE.md" target="_blank" rel="license">licencji MIT</a>.
       social: Sociale
       sponsor: Sponsoruj


### PR DESCRIPTION
Set with new environment variables. Manyfold name and logo is still shown in the footer.

* SITE_NAME: "Manyfold" by default, but this lets you name your own site how you like.
* SITE_TAGLINE: Sets the line under the title on the home page, above search
* SITE_ICON: A URL for the icon shown in the top left of the site