### PR TITLE
Add Download button for entire model, with file subset options 

### DIFF
--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -18,17 +18,24 @@ class ModelsController < ApplicationController
   end
 
   def show
-    files = @model.model_files
-    @images = files.select(&:is_image?)
-    @images.unshift(@model.preview_file) if @images.delete(@model.preview_file)
-    if helpers.file_list_settings["hide_presupported_versions"]
-      hidden_ids = files.select(:presupported_version_id).where.not(presupported_version_id: nil)
-      files = files.where.not(id: hidden_ids)
+    respond_to do |format|
+      format.html do
+        files = @model.model_files
+        @images = files.select(&:is_image?)
+        @images.unshift(@model.preview_file) if @images.delete(@model.preview_file)
+        if helpers.file_list_settings["hide_presupported_versions"]
+          hidden_ids = files.select(:presupported_version_id).where.not(presupported_version_id: nil)
+          files = files.where.not(id: hidden_ids)
+        end
+        files = files.includes(:presupported_version, :problems)
+        files = files.reject(&:is_image?)
+        @groups = helpers.group(files)
+        @extensions = @model.file_extensions
+        @has_supported_and_unsupported = @model.has_supported_and_unsupported?
+        @download_format = :sevenz
+        render layout: "card_list_page"
+      end
     end
-    files = files.includes(:presupported_version, :problems)
-    files = files.reject(&:is_image?)
-    @groups = helpers.group(files)
-    render layout: "card_list_page"
   end
 
   def new

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -152,6 +152,14 @@ class Model < ApplicationRecord
     new_model
   end
 
+  def has_supported_and_unsupported?
+    model_files.where(presupported: true).count && model_files.where(presupported: false).count
+  end
+
+  def file_extensions
+    model_files.map(&:extension).uniq
+  end
+
   private
 
   def normalize_license

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -91,7 +91,7 @@
     <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "), model_path(@model), {method: :delete, class: "float-end btn btn-outline-danger", data: {confirm: translate("models.destroy.confirm")}} if policy(@model).destroy? %>
   <% end %>
 
-  <div class="mb-3 w-100 center">
+  <div class="mb-3 w-100 text-center">
     <div class="btn-group ml-auto mr-auto">
       <%= link_to safe_join([icon("cloud-download", ""), t(".download.label")], " "), model_path(@model, format: @download_format), class: "btn btn-lg btn-primary" %>
       <button type="button" class="btn btn-lg btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -91,6 +91,26 @@
     <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "), model_path(@model), {method: :delete, class: "float-end btn btn-outline-danger", data: {confirm: translate("models.destroy.confirm")}} if policy(@model).destroy? %>
   <% end %>
 
+  <div class="mb-3 w-100 center">
+    <div class="btn-group ml-auto mr-auto">
+      <%= link_to safe_join([icon("cloud-download", ""), t(".download.label")], " "), model_path(@model, format: @download_format), class: "btn btn-lg btn-primary" %>
+      <button type="button" class="btn btn-lg btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
+        <span class="visually-hidden">Download options</span>
+      </button>
+      <ul class="dropdown-menu">
+        <li class="dropdown-header"><%= t(".download.menu_header") %></li>
+        <% if @has_supported_and_unsupported %>
+          <%= content_tag(:li) { link_to t(".download.supported"), model_path(@model, format: @download_format, selection: "supported"), class: "dropdown-item" } %>
+          <%= content_tag(:li) { link_to t(".download.unsupported"), model_path(@model, format: @download_format, selection: "unsupported"), class: "dropdown-item" } %>
+          <li><hr class="dropdown-divider"></li>
+        <% end %>
+        <% @extensions&.each do |type| %>
+          <%= content_tag(:li) { link_to t(".download.file_type", type: type.upcase), model_path(@model, format: @download_format, selection: type), class: "dropdown-item" } %>
+        <% end %>
+      </ul>
+    </div>
+  </div>
+
   <% if !@model.parents.empty? && policy(@model).merge? %>
     <%= card :danger, t(".merge.heading") do %>
       <p>

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -60,11 +60,11 @@ en:
       success: Model scan started
     show:
       download:
+        file_type: "%{type} Files Only"
         label: Download Model
         menu_header: Download Options
         supported: Supported Files Only
         unsupported: Unsupported Files Only
-        file_type: "%{type} Files Only"
       files: Files
       files_card:
         bulk_edit: Edit all files

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -59,6 +59,12 @@ en:
     scan:
       success: Model scan started
     show:
+      download:
+        label: Download Files
+        menu_header: Download Options
+        supported: Supported Files Only
+        unsupported: Unsupported Files Only
+        file_type: "%{type} Files Only"
       files: Files
       files_card:
         bulk_edit: Edit all files

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -60,7 +60,7 @@ en:
       success: Model scan started
     show:
       download:
-        label: Download Files
+        label: Download Model
         menu_header: Download Options
         supported: Supported Files Only
         unsupported: Unsupported Files Only


### PR DESCRIPTION
You can download everything, just supported or unsupported, or just a single file type.

Resolves #2981 
Resolves #2177 
Resolves #1847 