### PR TITLE
Don't set SSL options if unavailable because of OpenSSL 1.x

### DIFF
--- a/config/initializers/openssl.rb
+++ b/config/initializers/openssl.rb
@@ -2,6 +2,8 @@
 # This solution is a horrible hack from https://stackoverflow.com/questions/76183622/since-a-ruby-container-upgrade-we-expirience-a-lot-of-opensslsslsslerror
 # but it seems the quickest and most global solution without rewriting a bunch of lower-level code.
 # It'll do for now.
-OpenSSL::SSL::SSLContext::DEFAULT_PARAMS = OpenSSL::SSL::SSLContext::DEFAULT_PARAMS.merge(
-  options: OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:options] + OpenSSL::SSL::OP_IGNORE_UNEXPECTED_EOF
-).freeze
+if defined?(OpenSSL::SSL::OP_IGNORE_UNEXPECTED_EOF)
+  OpenSSL::SSL::SSLContext::DEFAULT_PARAMS = OpenSSL::SSL::SSLContext::DEFAULT_PARAMS.merge(
+    options: OpenSSL::SSL::SSLContext::DEFAULT_PARAMS[:options] + OpenSSL::SSL::OP_IGNORE_UNEXPECTED_EOF
+  ).freeze
+end


### PR DESCRIPTION
resolves #3097 