### PR TITLE
Add tag completion on upload form

### DIFF
--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -120,7 +120,7 @@ class ModelsController < ApplicationController
   def bulk_edit
     authorize Model
     @models = filtered_models @filters
-    @add_tags = ActsAsTaggableOn::Tag.where.not(id: @remove_tags.pluck(:id))
+    generate_available_tag_list
     if helpers.pagination_settings["models"]
       page = params[:page] || 1
       # Double the normal page size for bulk editing
@@ -160,6 +160,14 @@ class ModelsController < ApplicationController
   end
 
   private
+
+  def generate_available_tag_list
+    @available_tags = ActsAsTaggableOn::Tag.where(
+      id: ActsAsTaggableOn::Tagging.where(
+        taggable_type: "Model", taggable_id: policy_scope(Model).select(:id)
+      ).select(:tag_id)
+    )
+  end
 
   def bulk_update_params
     params.permit(

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -54,6 +54,7 @@ class ModelsController < ApplicationController
 
   def new
     authorize :model
+    generate_available_tag_list
   end
 
   def edit

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -120,7 +120,6 @@ class ModelsController < ApplicationController
   def bulk_edit
     authorize Model
     @models = filtered_models @filters
-    @remove_tags, _unused = generate_tag_list(@models)
     @add_tags = ActsAsTaggableOn::Tag.where.not(id: @remove_tags.pluck(:id))
     if helpers.pagination_settings["models"]
       page = params[:page] || 1

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -60,6 +60,7 @@ class ModelsController < ApplicationController
   def edit
     @model.links.build if @model.links.empty? # populate empty link
     @model.caber_relations.build if @model.caber_relations.empty?
+    generate_available_tag_list
   end
 
   def create

--- a/app/models/library.rb
+++ b/app/models/library.rb
@@ -63,10 +63,6 @@ class Library < ApplicationRecord
     end
   end
 
-  def all_tags
-    models.includes(:tags).map(&:tags).flatten.uniq.sort_by(&:name)
-  end
-
   def self.ransackable_attributes(auth_object = nil)
     ["public_id", "caption", "created_at", "icon", "name", "notes", "tag_regex", "updated_at"]
   end

--- a/app/views/models/_bulk_fields.html.erb
+++ b/app/views/models/_bulk_fields.html.erb
@@ -34,4 +34,4 @@
   </div>
 </div>
 
-<%= render "tags_edit", form: form, name: :add_tags, value: "", label: translate(".add_tags"), tags: @add_tags || [] %>
+<%= render "tags_edit", form: form, name: :add_tags, value: "", label: translate(".add_tags"), tags: @available_tags || [] %>

--- a/app/views/models/_form.html.erb
+++ b/app/views/models/_form.html.erb
@@ -20,7 +20,7 @@
     <%= form.collection_select :library_id, Library.all, :id, :name, {include_blank: false}, {class: "form-control col-auto form-select", disabled: @model.contains_other_models?} %>
   </div>
 
-  <%= render "tags_edit", form: form, name: "model[tag_list]", value: (@model.tags.order(taggings_count: :desc, name: :asc).map { |tag| tag.name }).join(","), label: translate(".tags"), tags: @model.library.all_tags %>
+  <%= render "tags_edit", form: form, name: "model[tag_list]", value: (@model.tags.order(taggings_count: :desc, name: :asc).map { |tag| tag.name }).join(","), label: translate(".tags"), tags: @available_tags %>
 
   <div class="row mb-3 input-group">
     <%= form.label :collection_id, class: "col-sm-2 col-form-label" %>

--- a/app/views/models/bulk_edit.html.erb
+++ b/app/views/models/bulk_edit.html.erb
@@ -37,7 +37,7 @@
     <div class="col">
       <%= render "bulk_fields", form: form %>
 
-      <%= render "tags_edit", form: form, name: :remove_tags, value: "", label: translate(".remove_tags"), tags: @remove_tags || [] %>
+      <%= render "tags_edit", form: form, name: :remove_tags, value: "", label: translate(".remove_tags"), tags: [] %>
 
       <div class="row mb-3">
         <%= form.label :new_library_id, class: "col-sm-2 col-form-label" %>


### PR DESCRIPTION
Refactor tag autocompletion for edit and bulk edit, and add to upload form. Also brings all tags autocompletions into line with each other, and only shows tags the user has access to.