### PR TITLE
Exclude documents from duplicate detection

### DIFF
--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -145,7 +145,7 @@ class ModelFile < ApplicationRecord
   end
 
   def duplicate?
-    size > 0 && duplicates.count > 0
+    size > 0 && duplicates.count > 0 && !is_document?
   end
 
   # Used for ETag in conditional GETs


### PR DESCRIPTION
Lots of things have the same README or LICENSE.

Resolves #3054 