### PR TITLE
Refactor and simplify old file removal code

### DIFF
--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -78,7 +78,7 @@ class ModelFilesController < ApplicationController
 
   def destroy
     authorize @file
-    @file.delete_from_disk_and_destroy
+    @file.destroy
     if request.referer && (URI.parse(request.referer).path == model_model_file_path(@model, @file))
       # If we're coming from the file page itself, we can't go back there
       redirect_to model_path(@model), notice: t(".success")

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -101,7 +101,7 @@ class ProblemsController < ApplicationController
     when "Model"
       problem.problematic.delete_from_disk_and_destroy
     when "ModelFile"
-      problem.problematic.delete_from_disk_and_destroy
+      problem.problematic.destroy
     else
       raise NotImplementedError
     end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -73,7 +73,7 @@ class Model < ApplicationRecord
     # This will go away later when we do proper file relationships rather than linking the tables directly
     model_files.update_all(presupported_version_id: nil) # rubocop:disable Rails/SkipsModelValidations
     # Trigger deletion for each file separately, to make sure cleanup happens
-    model_files.each { |f| f.delete_from_disk_and_destroy }
+    model_files.each { |f| f.destroy }
     # Remove tags first - sometimes this causes problems if we don't do it beforehand
     update!(tags: [])
     # Delete directory corresponding to model

--- a/spec/models/model_file_spec.rb
+++ b/spec/models/model_file_spec.rb
@@ -94,25 +94,25 @@ RSpec.describe ModelFile do
     let(:file) { create(:model_file, model: model, filename: "part_1.3mf", digest: "1234") }
 
     it "removes original file from disk" do
-      expect { file.delete_from_disk_and_destroy }.to(
+      expect { file.destroy }.to(
         change { File.exist?(File.join(library.path, file.path_within_library)) }.from(true).to(false)
+      )
+    end
+
+    it "does not remove original file from disk when deleted, not destroyed" do
+      expect { file.delete }.not_to(
+        change { File.exist?(File.join(library.path, file.path_within_library)) }
       )
     end
 
     it "ignores missing files on deletion" do
       file.update! filename: "gone.3mf"
-      expect { file.delete_from_disk_and_destroy }.not_to raise_exception
-    end
-
-    it "calls standard destroy" do
-      allow(file).to receive(:destroy)
-      file.delete_from_disk_and_destroy
-      expect(file).to have_received(:destroy).once
+      expect { file.destroy }.not_to raise_exception
     end
 
     it "queues up rescans for duplicates on destroy" do
       dupe = create(:model_file, model: model, filename: "duplicate.3mf", digest: "1234")
-      expect { file.delete_from_disk_and_destroy }.to(
+      expect { file.destroy }.to(
         have_enqueued_job(Analysis::AnalyseModelFileJob).with(dupe.id)
       )
     end

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -401,16 +401,16 @@ RSpec.describe Model do
       expect(model).to have_received(:destroy).once
     end
 
-    it "calls delete_from_disk_and_destroy on files" do # rubocop:todo RSpec/ExampleLength
+    it "calls destroy on files" do # rubocop:todo RSpec/ExampleLength
       file = create(:model_file, model: model, filename: "part_1.3mf", digest: "1234")
-      allow(file).to receive(:delete_from_disk_and_destroy)
+      allow(file).to receive(:destroy)
       mock = [file]
       without_partial_double_verification do
         allow(mock).to receive(:update_all).and_return(true)
       end
       allow(model).to receive(:model_files).and_return(mock)
       model.delete_from_disk_and_destroy
-      expect(file).to have_received(:delete_from_disk_and_destroy).once
+      expect(file).to have_received(:destroy).once
     end
   end
 


### PR DESCRIPTION
ModelFile removal used to have more complex logic, but nowadays it's simple enough for just a callback.