### PR TITLE
Don't require PUBLIC_PORT if PUBLIC_HOSTNAME is set, unless it's a non-default port

### DIFF
--- a/app/lib/public_url.rb
+++ b/app/lib/public_url.rb
@@ -1,6 +1,14 @@
 module PublicUrl
   def self.port
-    ENV.fetch("PUBLIC_PORT", ENV.fetch("RAILS_PORT", "3214"))
+    # PUBLIC_PORT overrides everything
+    return ENV.fetch("PUBLIC_PORT") if ENV.key?("PUBLIC_PORT")
+    # If hostname is set, assume a standard port
+    if ENV.key?("PUBLIC_HOSTNAME")
+      https = ENV.fetch("HTTPS_ONLY", nil) === "enabled"
+      return https ? "443" : "80"
+    end
+    # Fall back to RAILS_PORT or default
+    ENV.fetch("RAILS_PORT", "3214")
   end
 
   def self.nonstandard_port

--- a/app/lib/public_url.rb
+++ b/app/lib/public_url.rb
@@ -1,0 +1,13 @@
+module PublicUrl
+  def self.port
+    ENV.fetch("PUBLIC_PORT", ENV.fetch("RAILS_PORT", "3214"))
+  end
+
+  def self.nonstandard_port
+    ["80", "443"].include?(port) ? nil : port
+  end
+
+  def self.hostname
+    ENV.fetch("PUBLIC_HOSTNAME", "localhost")
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -76,8 +76,9 @@ module Manyfold
 end
 
 # Set default URL options from env vars
-port = ENV.fetch("PUBLIC_PORT", ENV.fetch("RAILS_PORT", "3214"))
+# This is done *very* early, so that it cascades to all components
+require "./app/lib/public_url"
 Rails.application.default_url_options = {
-  host: ENV.fetch("PUBLIC_HOSTNAME", "localhost"),
-  port: ["80", "443"].include?(port) ? nil : port
+  host: PublicUrl.hostname,
+  port: PublicUrl.nonstandard_port
 }.compact

--- a/spec/lib/public_url_spec.rb
+++ b/spec/lib/public_url_spec.rb
@@ -1,0 +1,81 @@
+require "rails_helper"
+
+RSpec.describe PublicUrl do
+  it "provides default hostname as a string" do
+    expect(described_class.hostname).to eq "localhost"
+  end
+
+  it "provides default port as a string" do
+    expect(described_class.port).to eq "3214"
+  end
+
+  context "when checking for only nonstandard ports" do
+    it "returns nil for port 80" do
+      ClimateControl.modify PUBLIC_PORT: "80" do
+        expect(described_class.nonstandard_port).to be_nil
+      end
+    end
+
+    it "returns nil for port 443" do
+      ClimateControl.modify PUBLIC_PORT: "443" do
+        expect(described_class.nonstandard_port).to be_nil
+      end
+    end
+
+    it "returns specified port for anything else" do
+      expect(described_class.nonstandard_port).to eq "3214"
+    end
+  end
+
+  context "with only PUBLIC_HOSTNAME set" do
+    around do |example|
+      ClimateControl.modify PUBLIC_HOSTNAME: "manyfold.example.com" do
+        example.run
+      end
+    end
+
+    it "provides specified hostname" do
+      expect(described_class.hostname).to eq "manyfold.example.com"
+    end
+
+    it "sticks to default port" do
+      expect(described_class.port).to eq "3214"
+    end
+  end
+
+  context "with only PUBLIC_PORT set" do
+    around do |example|
+      ClimateControl.modify PUBLIC_PORT: "80" do
+        example.run
+      end
+    end
+
+    it "provides specified port" do
+      expect(described_class.port).to eq "80"
+    end
+  end
+
+  context "with RAILS_PORT set" do
+    around do |example|
+      ClimateControl.modify RAILS_PORT: "5000" do
+        example.run
+      end
+    end
+
+    it "provides specified port" do
+      expect(described_class.port).to eq "5000"
+    end
+  end
+
+  context "with RAILS_PORT and PUBLIC_PORT set" do
+    around do |example|
+      ClimateControl.modify RAILS_PORT: "5000", PUBLIC_PORT: "80" do
+        example.run
+      end
+    end
+
+    it "provides PUBLIC_PORT" do
+      expect(described_class.port).to eq "80"
+    end
+  end
+end

--- a/spec/lib/public_url_spec.rb
+++ b/spec/lib/public_url_spec.rb
@@ -38,8 +38,14 @@ RSpec.describe PublicUrl do
       expect(described_class.hostname).to eq "manyfold.example.com"
     end
 
-    it "sticks to default port" do
-      expect(described_class.port).to eq "3214"
+    it "assumes the standard port 80" do
+      expect(described_class.port).to eq "80"
+    end
+
+    it "assumes standard port 443 if HTTPS_ONLY is set" do
+      ClimateControl.modify HTTPS_ONLY: "enabled" do
+        expect(described_class.port).to eq "443"
+      end
     end
   end
 
@@ -52,6 +58,18 @@ RSpec.describe PublicUrl do
 
     it "provides specified port" do
       expect(described_class.port).to eq "80"
+    end
+  end
+
+  context "with PUBLIC_HOSTNAME and PUBLIC_PORT set" do
+    around do |example|
+      ClimateControl.modify PUBLIC_PORT: "1234", PUBLIC_HOSTNAME: "example.com" do
+        example.run
+      end
+    end
+
+    it "provides specified port" do
+      expect(described_class.port).to eq "1234"
     end
   end
 


### PR DESCRIPTION
The previous logic required PUBLIC PORT to be set, or it would use an internal port; now, if it's not specified but there IS a hostname, we assume public port is a standard value.

Resolves #3021 
Resolves #3119 