### PR TITLE
Usage tracking: remove leading v from app version

### DIFF
--- a/app/lib/usage_report.rb
+++ b/app/lib/usage_report.rb
@@ -7,7 +7,7 @@ module UsageReport
     Jbuilder.encode do |report|
       report.id SiteSettings.anonymous_usage_id
       report.version do |version|
-        version.app Rails.application.config.app_version
+        version.app Rails.application.config.app_version.gsub(/^v/, "")
         version.sha Rails.application.config.git_sha
         version.image ENV.fetch("DOCKER_TAG", nil)&.split(":")&.first
         version.arch RUBY_PLATFORM

--- a/spec/lib/usage_report_spec.rb
+++ b/spec/lib/usage_report_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe UsageReport do
     before do
       allow(SiteSettings).to receive(:anonymous_usage_id).and_return("guid-goes-here")
       allow(Rails.application.config).to receive_messages(
-        app_version: "test",
+        app_version: "v0.89.0",
         git_sha: "deadbeef"
       )
     end
@@ -27,7 +27,7 @@ RSpec.describe UsageReport do
     end
 
     it "includes application version" do
-      expect(parsed["version"]["app"]).to eq "test"
+      expect(parsed["version"]["app"]).to eq "0.89.0"
     end
 
     it "includes image type" do


### PR DESCRIPTION
Linuxserver containers have the v at the start, so we will drop it.