### PR TITLE
Prevent bad URLs from causing page errors

### DIFF
--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -2,7 +2,9 @@ class Link < ApplicationRecord
   belongs_to :linkable, polymorphic: true
 
   def host
-    URI.parse(url).host
+    URI.parse(url).host || url
+  rescue URI::InvalidURIError, URI::InvalidComponentError
+    url
   end
 
   def site


### PR DESCRIPTION
If there's no scheme, `host` was returning nil. Resolves #3304 again I hope.