### PR TITLE
Improved syntax for single-arg block parameters

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ inherit_gem:
   standard: config/base.yml
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.4
   NewCops: enable
   Exclude:
     - db/schema.rb

--- a/app/controllers/activity_controller.rb
+++ b/app/controllers/activity_controller.rb
@@ -9,7 +9,7 @@ class ActivityController < ApplicationController
   ]
 
   def index
-    @jobs = ActiveJob::Status.all.sort_by { |x| x.last_activity || "" }.reverse
+    @jobs = ActiveJob::Status.all.sort_by { it.last_activity || "" }.reverse
     @jobs.reject! { |x| EXCLUSIONS.include? x.read.dig(:serialized_job, "job_class") }
     @jobs = Kaminari.paginate_array(@jobs).page(params[:page]).per(50)
   end

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -12,9 +12,9 @@ class FollowsController < ApplicationController
   def new
     @query = params[:uri].gsub(/\A@/, "")
     @actor = if @query.starts_with?(%r{https?://})
-      Federails::Actor.find_by_federation_url @query # rubocop:disable RSpec/DynamicFindBy
+      Federails::Actor.find_by_federation_url @query # rubocop:disable Rails/DynamicFindBy
     else
-      Federails::Actor.find_by_account @query # rubocop:disable RSpec/DynamicFindBy
+      Federails::Actor.find_by_account @query # rubocop:disable Rails/DynamicFindBy
     end
     @actor = Federails::Actor.find_or_create_by_federation_url @actor.federated_url
     # If local, go to the real thing

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -99,7 +99,7 @@ class ModelsController < ApplicationController
   end
 
   def merge
-    if params[:target] && (target = (@model.parents.find { |x| x.public_id == params[:target] }))
+    if params[:target] && (target = (@model.parents.find { it.public_id == params[:target] }))
       @model.merge_into! target
       redirect_to target, notice: t(".success")
     elsif params[:all] && @model.contains_other_models?

--- a/app/helpers/models_helper.rb
+++ b/app/helpers/models_helper.rb
@@ -8,12 +8,12 @@ module ModelsHelper
     slice = names.map(&:length).max
     while slice > min_prefix_length
       slice -= 1
-      candidates = names.map { |x| x.slice(0, slice) }
-      groups = candidates.group_by { |x| x }
+      candidates = names.map { it.slice(0, slice) }
+      groups = candidates.group_by { it }
       ready = groups.select { |k, v| v.count >= min_section_size }.map(&:first)
       ready.each do |r|
-        names.reject! { |x| x.starts_with? r }
-        sections[r], files = files.partition { |x| x.basename.starts_with? r }
+        names.reject! { it.starts_with? r }
+        sections[r], files = files.partition { it.basename.starts_with? r }
       end
     end
     # Sort and include empty set

--- a/app/jobs/analysis/analyse_model_file_job.rb
+++ b/app/jobs/analysis/analyse_model_file_job.rb
@@ -55,16 +55,16 @@ class Analysis::AnalyseModelFileJob < ApplicationJob
       # Measure distance from this filename
       d = String::Similarity.cosine(normed.join(" "), human.join(" "))
       [d, s]
-    }.select { |x| x[0] > 0.95 }
+    }.select { it[0] > 0.95 }
     best = case matches.length
     when 0
       nil
     when 1
       matches.first[1]
     else
-      same_format = matches.select { |x| x[1].mime_type === file.mime_type }
+      same_format = matches.select { it[1].mime_type === file.mime_type }
       matches = same_format unless same_format.empty?
-      matches.max_by { |x| x[0] }[1]
+      matches.max_by { it[0] }[1]
     end
     file.update(presupported_version: best)
   end

--- a/app/jobs/analysis/file_conversion_job.rb
+++ b/app/jobs/analysis/file_conversion_job.rb
@@ -55,8 +55,8 @@ class Analysis::FileConversionJob < ApplicationJob
   ensure
     if file
       # Mark inefficient problem resolution as no longer in progress, if it's set
-      file.problems.where(category: :inefficient, in_progress: true).find_each do |x|
-        x.update(in_progress: false)
+      file.problems.where(category: :inefficient, in_progress: true).find_each do
+        it.update(in_progress: false)
       end
     end
   end

--- a/app/jobs/model_scan_job.rb
+++ b/app/jobs/model_scan_job.rb
@@ -28,7 +28,7 @@ class ModelScanJob < ApplicationJob
     end
     # Set tags and default files
     model.model_files.reload
-    model.preview_file = model.model_files.min_by { |x| x.is_image? ? 0 : 1 } unless model.preview_file
+    model.preview_file = model.model_files.min_by { it.is_image? ? 0 : 1 } unless model.preview_file
     if model.tags.empty?
       model.generate_tags_from_directory_name! if SiteSettings.model_tags_tag_model_directory_name
       if SiteSettings.model_tags_auto_tag_new.present?

--- a/app/jobs/process_uploaded_file_job.rb
+++ b/app/jobs/process_uploaded_file_job.rb
@@ -91,6 +91,6 @@ class ProcessUploadedFileJob < ApplicationJob
     return 0 if arrays.empty?
     first = arrays.shift
     zip = first.zip(*arrays)
-    zip.count { |x| x.uniq.count == 1 }
+    zip.count { it.uniq.count == 1 }
   end
 end

--- a/app/models/concerns/followable.rb
+++ b/app/models/concerns/followable.rb
@@ -42,6 +42,6 @@ module Followable
   end
 
   def auto_accept
-    federails_actor.following_followers.where(status: "pending").find_each { |x| x.accept! }
+    federails_actor.following_followers.where(status: "pending").find_each { it.accept! }
   end
 end

--- a/app/models/concerns/path_builder.rb
+++ b/app/models/concerns/path_builder.rb
@@ -6,7 +6,7 @@ module PathBuilder
       case token
       when "{tags}"
         (tags.count > 0) ?
-          File.join(tags.order(taggings_count: :desc, name: :asc).map { |x| x.to_s.parameterize }) :
+          File.join(tags.order(taggings_count: :desc, name: :asc).map { it.to_s.parameterize }) :
           "@untagged"
       when "{creator}"
         path_component(creator) || "@unattributed"

--- a/app/models/concerns/path_parser.rb
+++ b/app/models/concerns/path_parser.rb
@@ -2,7 +2,7 @@ module PathParser
   extend ActiveSupport::Concern
 
   def generate_tags_from_directory_name!
-    tags = File.split(path).last.split(/[\W_+-]/).filter { |x| x.length > 1 }
+    tags = File.split(path).last.split(/[\W_+-]/).filter { it.length > 1 }
     tag_list.add(remove_stop_words(tags))
   end
 

--- a/db/data/20230628194944_make_names_unique.rb
+++ b/db/data/20230628194944_make_names_unique.rb
@@ -5,7 +5,7 @@ class MakeNamesUnique < ActiveRecord::Migration[7.0]
     attributes = [:name, :slug]
     [Creator, Collection].each do |klass|
       attributes.each do |attr|
-        klass.all.group_by { |x| x.send(attr).downcase }.each_pair do |n, items|
+        klass.all.group_by { it.send(attr).downcase }.each_pair do |n, items|
           if items.count > 1
             items.slice(1..-1).each do |c|
               c.name = "#{c.name} #{SecureRandom.hex(4)}"

--- a/db/data/20240615085913_move_file_data_into_shrine.rb
+++ b/db/data/20240615085913_move_file_data_into_shrine.rb
@@ -2,7 +2,7 @@
 
 class MoveFileDataIntoShrine < ActiveRecord::Migration[7.0]
   def up
-    ModelFile.find_each { |x| x.attach_existing_file!(refresh: false, skip_validations: true) }
+    ModelFile.find_each { it.attach_existing_file!(refresh: false, skip_validations: true) }
   end
 
   def down

--- a/spec/jobs/analysis/analyse_model_file_job_spec.rb
+++ b/spec/jobs/analysis/analyse_model_file_job_spec.rb
@@ -112,8 +112,8 @@ RSpec.describe Analysis::AnalyseModelFileJob do
         ["Beefy Arm A Supported.lys", "Beefy Arm A Supported.stl", "Beefy Arm B Supported.lys"]]
     ].each do |filename, correct, incorrect|
       it "matches #{filename} with #{correct} rather than incorrect options" do # rubocop:todo RSpec/ExampleLength
-        incorrect.each do |i|
-          create(:model_file, model: model, filename: i, presupported: true)
+        incorrect.each do
+          create(:model_file, model: model, filename: it, presupported: true)
         end
         unsup = create(:model_file, model: model, filename: filename)
         sup = create(:model_file, model: model, filename: correct, presupported: true)

--- a/spec/models/problem_spec.rb
+++ b/spec/models/problem_spec.rb
@@ -19,16 +19,16 @@ RSpec.describe Problem do
 
     it "lists visible problems" do # rubocop:todo RSpec/MultipleExpectations
       expect(described_class.visible(settings).length).to eq 3
-      expect(described_class.visible(settings).map { |x| x.category.to_sym }).to include :inefficient
+      expect(described_class.visible(settings).map { it.category.to_sym }).to include :inefficient
     end
 
     it "does not include silenced problems" do
-      expect(described_class.visible(settings).map { |x| x.category.to_sym }).not_to include :missing
+      expect(described_class.visible(settings).map { it.category.to_sym }).not_to include :missing
     end
 
     it "falls back to default visibility settings" do # rubocop:todo RSpec/MultipleExpectations
       expect(described_class.visible({missing: :silent}).length).to eq 3
-      expect(described_class.visible({missing: :silent}).map { |x| x.category.to_sym }).to include :inefficient
+      expect(described_class.visible({missing: :silent}).map { it.category.to_sym }).to include :inefficient
     end
   end
 

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -23,10 +23,10 @@ RSpec.describe "Models" do
     let!(:collection) { create(:collection) }
     let!(:library) do
       l = create(:library)
-      build_list(:model, 5, library: l) { |x| x.save! }
-      build_list(:model, 5, library: l, creator: creator) { |x| x.save! }
-      build_list(:model, 5, library: l, collection: collection) { |x| x.save! }
-      build_list(:model, 5, library: l, creator: creator, collection: collection) { |x| x.save! }
+      build_list(:model, 5, library: l) { it.save! }
+      build_list(:model, 5, library: l, creator: creator) { it.save! }
+      build_list(:model, 5, library: l, collection: collection) { it.save! }
+      build_list(:model, 5, library: l, creator: creator, collection: collection) { it.save! }
       l
     end
 


### PR DESCRIPTION
Added in Ruby 3.4, `it` lets us remove single parameters for small blocks, improving stuff like `{ |x| x.something(42) }`