### PR TITLE
Refactor comment code to use new Federails data entity system

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -148,7 +148,7 @@ gem "better_content_security_policy", "~> 0.1.4"
 gem "devise_zxcvbn", "~> 6.0"
 
 gem "ransack", "~> 4.2"
-gem "federails", "~> 0.4"
+gem "federails", git: "https://gitlab.com/experimentslabs/federails", branch: "22-data-binding-for-incoming-outgoing-objects"
 gem "federails-moderation", "~> 0.2"
 gem "caber"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ GIT
 
 GIT
   remote: https://gitlab.com/experimentslabs/federails
-  revision: ee1a65d0a67a39615ecce01a4a7be62b960793ca
+  revision: e366dc4ff8aa34f7884547180bc94998d320423a
   branch: 22-data-binding-for-incoming-outgoing-objects
   specs:
     federails (0.4.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -7,6 +7,20 @@ GIT
       activerecord (>= 3.2)
       sqlite3
 
+GIT
+  remote: https://gitlab.com/experimentslabs/federails
+  revision: ee1a65d0a67a39615ecce01a4a7be62b960793ca
+  branch: 22-data-binding-for-incoming-outgoing-objects
+  specs:
+    federails (0.4.0)
+      faraday
+      faraday-follow_redirects
+      json-ld (>= 3.2.0)
+      json-ld-preloaded (>= 3.2.0)
+      kaminari (>= 1.2.0)
+      pundit (>= 2.3.0)
+      rails (>= 7.0.4)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -224,14 +238,6 @@ GEM
       faraday (>= 1, < 3)
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
-    federails (0.4.0)
-      faraday
-      faraday-follow_redirects
-      json-ld (>= 3.2.0)
-      json-ld-preloaded (>= 3.2.0)
-      kaminari (>= 1.2.0)
-      pundit (>= 2.3.0)
-      rails (>= 7.0.4)
     federails-moderation (0.2.0)
       federails (~> 0.4)
       public_suffix (~> 6.0)
@@ -792,7 +798,7 @@ DEPENDENCIES
   erb_lint (~> 0.8.0)
   factory_bot
   faker (~> 3.5)
-  federails (~> 0.4)
+  federails!
   federails-moderation (~> 0.2)
   ffi-libarchive (~> 1.1)
   get_process_mem (~> 1.0)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -7,7 +7,7 @@ class Comment < ApplicationRecord
   belongs_to :commentable, polymorphic: true
 
   include Federails::DataEntity
-  acts_as_federails_data handles: "Note", actor_entity_method: :commenter
+  acts_as_federails_data handles: "Note", actor_entity_method: :commenter, url_param: :public_id
 
   def to_activitypub_object
     # Comments become Notes in ActvityPub

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -7,7 +7,7 @@ class Comment < ApplicationRecord
   belongs_to :commentable, polymorphic: true
 
   include Federails::DataEntity
-  acts_as_federails_data handles: "Note", actor_entity_method: :commenter, url_param: :public_id
+  acts_as_federails_data handles: "Note", actor_entity_method: :commenter, url_param: :public_id, should_federate_method: :public?
 
   def to_activitypub_object
     # Comments become Notes in ActvityPub
@@ -19,12 +19,12 @@ class Comment < ApplicationRecord
       }.merge(address_options)
   end
 
-  private
-
   def public?
     Pundit::PolicyFinder.new(commenter.class).policy.new(nil, commenter).show? &&
       Pundit::PolicyFinder.new(commentable.class).policy.new(nil, commentable).show?
   end
+
+  private
 
   def activitypub_tags
     return nil unless commentable.respond_to?(:tags)

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -1,69 +1,55 @@
+require "federails/data_transformer/note"
+
 class Comment < ApplicationRecord
   include PublicIDable
 
-  belongs_to :commenter, polymorphic: true
+  belongs_to :commenter, polymorphic: true, optional: true
   belongs_to :commentable, polymorphic: true
 
-  after_create :post_create_activity
-  after_update :post_update_activity
-
-  def federated_url
-    return nil unless public?
-    Rails.application.routes.url_helpers.url_for([commentable, self, {only_path: false}])
-  end
+  include Federails::DataEntity
+  acts_as_federails_data handles: "Note", actor_entity_method: :commenter
 
   def to_activitypub_object
-    # Build tag structure
-    tags = commentable.respond_to?(:tags) ?
-      commentable.tags.pluck(:name).map do |tag|
-        {
-          type: "Hashtag",
-          name: "##{tag.tr(" ", "_").camelize}",
-          href: Rails.application.routes.url_helpers.url_for([commentable.class, tag: tag])
-        }
-      end
-    : nil
-    tag_html = tags&.map { |t| %(<a href="#{t[:href]}" class="mention hashtag" rel="tag">#{t[:name]}</a>) }&.join(" ")
-    # Comments become Notes in ActvityPub world
-    {
-      id: federated_url,
-      type: "Note",
-      content: [
-        Kramdown::Document.new(comment).to_html,
-        tag_html
-      ].compact.join("\n\n"),
-      context: Rails.application.routes.url_helpers.url_for([commentable, only_path: false]),
-      published: created_at&.iso8601,
-      attributedTo: (commenter&.federails_actor&.respond_to?(:federated_url) ? commenter.federails_actor.federated_url : nil),
-      sensitive: sensitive,
-      to: ["https://www.w3.org/ns/activitystreams#Public"],
-      cc: [commenter.federails_actor.followers_url],
-      tag: tags
-    }.compact
+    # Comments become Notes in ActvityPub
+    Federails::DataTransformer::Note.to_federation self, content: to_html,
+      custom: {
+        "context" => Rails.application.routes.url_helpers.url_for([commentable, only_path: false]),
+        "sensitive" => sensitive,
+        "tag" => activitypub_tags
+      }.merge(address_options)
   end
+
+  private
 
   def public?
     Pundit::PolicyFinder.new(commenter.class).policy.new(nil, commenter).show? &&
       Pundit::PolicyFinder.new(commentable.class).policy.new(nil, commentable).show?
   end
 
-  private
-
-  def post_create_activity
-    post_activity "Create"
-  end
-
-  def post_update_activity
-    post_activity "Update"
-  end
-
-  def post_activity(action)
-    if public?
-      Federails::Activity.create!(
-        actor: commenter.federails_actor,
-        action: action,
-        entity: self
-      )
+  def activitypub_tags
+    return nil unless commentable.respond_to?(:tags)
+    commentable.tags.pluck(:name).map do |tag|
+      {
+        type: "Hashtag",
+        name: "##{tag.tr(" ", "_").camelize}",
+        href: Rails.application.routes.url_helpers.url_for([commentable.class, tag: tag])
+      }
     end
+  end
+
+  def to_html
+    [
+      Kramdown::Document.new(comment).to_html,
+      activitypub_tags&.map { |t| %(<a href="#{t[:href]}" class="mention hashtag" rel="tag">#{t[:name]}</a>) }&.join(" ")
+    ].compact.join("\n\n")
+  end
+
+  def address_options
+    public? ?
+      {
+        "to" => ["https://www.w3.org/ns/activitystreams#Public"],
+        "cc" => [commenter.federails_actor.followers_url]
+      }
+    : {}
   end
 end

--- a/db/migrate/20250114105808_add_federation_attributes_to_comments.rb
+++ b/db/migrate/20250114105808_add_federation_attributes_to_comments.rb
@@ -1,0 +1,10 @@
+class AddFederationAttributesToComments < ActiveRecord::Migration[7.2]
+  def change
+    # Commenter is now optional
+    change_column_null :comments, :commenter_id, true
+    change_column_null :comments, :commenter_type, true
+    # New columns for federation work
+    add_column :comments, :federated_url, :string, null: true, default: nil
+    add_reference :comments, :federails_actor, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_11_28_162214) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_14_105808) do
   create_table "caber_relations", force: :cascade do |t|
     t.string "subject_type"
     t.integer "subject_id"
@@ -43,8 +43,8 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_28_162214) do
 
   create_table "comments", force: :cascade do |t|
     t.string "public_id", null: false
-    t.string "commenter_type", null: false
-    t.integer "commenter_id", null: false
+    t.string "commenter_type"
+    t.integer "commenter_id"
     t.string "commentable_type", null: false
     t.integer "commentable_id", null: false
     t.text "comment"
@@ -52,8 +52,11 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_28_162214) do
     t.datetime "updated_at", null: false
     t.boolean "system", default: false, null: false
     t.boolean "sensitive", default: false, null: false
+    t.string "federated_url"
+    t.integer "federails_actor_id"
     t.index ["commentable_type", "commentable_id"], name: "index_comments_on_commentable"
     t.index ["commenter_type", "commenter_id"], name: "index_comments_on_commenter"
+    t.index ["federails_actor_id"], name: "index_comments_on_federails_actor_id"
     t.index ["public_id"], name: "index_comments_on_public_id", unique: true
   end
 
@@ -346,6 +349,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_11_28_162214) do
   end
 
   add_foreign_key "collections", "collections"
+  add_foreign_key "comments", "federails_actors"
   add_foreign_key "federails_activities", "federails_actors", column: "actor_id"
   add_foreign_key "federails_followings", "federails_actors", column: "actor_id"
   add_foreign_key "federails_followings", "federails_actors", column: "target_actor_id"

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -25,57 +25,57 @@ RSpec.describe Comment do
     end
 
     it "has a federated_url method" do
-      expect(comment.federated_url).to eq "http://localhost:3214/models/#{commentable.public_id}/comments/#{comment.public_id}"
+      expect(comment.federated_url).to eq "http://localhost:3214/federation/objects/comments/#{comment.public_id}"
     end
 
     context "when serializing to an ActivityPub Note" do
       let(:ap_object) { comment.to_activitypub_object }
 
       it "creates a Note" do
-        expect(ap_object[:type]).to eq "Note"
+        expect(ap_object["type"]).to eq "Note"
       end
 
       it "includes content" do
-        expect(ap_object[:content]).to be_present
+        expect(ap_object["content"]).to be_present
       end
 
       it "includes id" do
-        expect(ap_object[:id]).to eq comment.federated_url
+        expect(ap_object["id"]).to eq comment.federated_url
       end
 
       it "includes commentable ID in context" do
-        expect(ap_object[:context]).to eq "http://localhost:3214/models/#{commentable.public_id}"
+        expect(ap_object["context"]).to eq "http://localhost:3214/models/#{commentable.public_id}"
       end
 
       it "includes publication time" do
-        expect(ap_object[:published]).to be_present
+        expect(ap_object["published"]).to be_present
       end
 
       it "includes sensitive flag" do
-        expect(ap_object[:sensitive]).to be true
+        expect(ap_object["sensitive"]).to be true
       end
 
       it "includes attribution" do
-        expect(ap_object[:attributedTo]).to eq commenter.federails_actor.federated_url
+        expect(ap_object["attributedTo"]).to eq commenter.federails_actor.federated_url
       end
 
       it "includes to field" do
-        expect(ap_object[:to]).to include "https://www.w3.org/ns/activitystreams#Public"
+        expect(ap_object["to"]).to include "https://www.w3.org/ns/activitystreams#Public"
       end
 
       it "includes cc field" do
-        expect(ap_object[:cc]).to include commenter.federails_actor.followers_url
+        expect(ap_object["cc"]).to include commenter.federails_actor.followers_url
       end
 
       it "includes tags appended to content" do
         {"tag+one": "#TagOne", tag2: "#Tag2"}.each_pair do |link, hashtag|
-          expect(ap_object[:content]).to include %(<a href="http://localhost:3214/models?tag=#{link}" class="mention hashtag" rel="tag">#{hashtag}</a>)
+          expect(ap_object["content"]).to include %(<a href="http://localhost:3214/models?tag=#{link}" class="mention hashtag" rel="tag">#{hashtag}</a>)
         end
       end
 
       it "includes tags as mentions" do # rubocop:disable RSpec/ExampleLength
         {"tag+one": "#TagOne", tag2: "#Tag2"}.each_pair do |link, hashtag|
-          expect(ap_object[:tag]).to include(
+          expect(ap_object["tag"]).to include(
             type: "Hashtag",
             href: "http://localhost:3214/models?tag=#{link}",
             name: hashtag


### PR DESCRIPTION
The new system in https://gitlab.com/experimentslabs/federails/-/merge_requests/45 adds support for data entities to federails core, so a lot of the stuff we've done in Manyfold now is handled in there. This PR does the appropriate refactoring.

cc @mtancoigne 