### PR TITLE
Update smtp config: add port number and disable ssl certificate validation

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -61,7 +61,8 @@ module Manyfold
       address: ENV.fetch("SMTP_SERVER", nil),
       user_name: ENV.fetch("SMTP_USERNAME", nil),
       password: ENV.fetch("SMTP_PASSWORD", nil),
-      port: ENV.fetch("SMTP_PORT", nil)
+      port: ENV.fetch("SMTP_PORT", nil),
+      openssl_verify_mode: ENV.fetch("SMTP_VERIFY_SSL_MODE", nil) == "none" ? :none : nil
     }.compact
 
     # Load some feature settings from ENV

--- a/config/application.rb
+++ b/config/application.rb
@@ -60,7 +60,8 @@ module Manyfold
     config.action_mailer.smtp_settings = {
       address: ENV.fetch("SMTP_SERVER", nil),
       user_name: ENV.fetch("SMTP_USERNAME", nil),
-      password: ENV.fetch("SMTP_PASSWORD", nil)
+      password: ENV.fetch("SMTP_PASSWORD", nil),
+      port: ENV.fetch("SMTP_PORT", nil)
     }.compact
 
     # Load some feature settings from ENV

--- a/config/application.rb
+++ b/config/application.rb
@@ -62,7 +62,7 @@ module Manyfold
       user_name: ENV.fetch("SMTP_USERNAME", nil),
       password: ENV.fetch("SMTP_PASSWORD", nil),
       port: ENV.fetch("SMTP_PORT", nil),
-      openssl_verify_mode: ENV.fetch("SMTP_VERIFY_SSL_MODE", nil) == "none" ? :none : nil
+      openssl_verify_mode: (ENV.fetch("SMTP_VERIFY_SSL_MODE", nil) == "none") ? :none : nil
     }.compact
 
     # Load some feature settings from ENV


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [ ] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

This PR adds two config options for the SMTP server. I needed to configure the SMTP port, and I found another issue that needed the SSL verification disabled.

## Linked issues

resolves #2380 

## Description of changes

I added two config setting:

- `SMTP_PORT` can be used to set the port for the smtp server. It configures the `config.action_mailer.smtp_settings.port` field if set.
- `SMTP_VERIFY_SSL_MODE` can be set to `none` to disable the checks of the ssl certificate of the SMTP server. It configures the `config.action_mailer.smtp_settings.openssl_verify_mode` field if set.
