### PR TITLE
Fix setting the provided password when creating an account when no SMTP server is configured.

### DIFF
--- a/app/controllers/settings/users_controller.rb
+++ b/app/controllers/settings/users_controller.rb
@@ -27,8 +27,8 @@ class Settings::UsersController < ApplicationController
     password = helpers.random_password
     # Create user with a random password if one isn't provided
     @user = User.create({
-      password: password,
-      password_confirmation: password
+      "password" => password,
+      "password_confirmation" => password
     }.merge(user_params))
     if @user.valid?
       @user.send_reset_password_instructions if SiteSettings.email_configured?
@@ -69,6 +69,8 @@ class Settings::UsersController < ApplicationController
     params.require(:user).permit(
       :email,
       :username,
+      :password,
+      :password_confirmation,
       role_ids: []
     )
   end

--- a/spec/requests/settings/users_spec.rb
+++ b/spec/requests/settings/users_spec.rb
@@ -38,13 +38,17 @@ RSpec.describe "/settings/users", :multiuser do
   describe "POST /create", :as_moderator do
     context "with valid parameters" do
       it "creates a new Settings::User" do
+        attributes = attributes_for(:user)
+        attributes[:password_confirmation] = attributes[:password]
         expect {
-          post "/settings/users", params: {user: attributes_for(:user)}
+          post "/settings/users", params: {user: attributes}
         }.to change(User, :count).by(1)
       end
 
       it "redirects to the created user" do
-        post "/settings/users", params: {user: attributes_for(:user)}
+        attributes = attributes_for(:user)
+        attributes[:password_confirmation] = attributes[:password]
+        post "/settings/users", params: {user: attributes}
         expect(response).to redirect_to(settings_user_url(User.last))
       end
     end


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [ ] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

When creating a new account via the `/settings/users/new` page, while Email delivery is not configured, the entered password is not stored into the database. It is instead replaced by a randomly generated password.

## Linked issues

I did not find an existing issue.
<!--
Does this PR resolve an issue? If so, please state "resolves #{number}" here.
Mention any other linked issues or PRs as well, even if this PR doesn't resolve them completely.
-->

## Description of changes

I added `password` and `password_confirmation` to the list of user params that were allowed. I also update the keys from key to string, so they matched with what was provided and would be overwritten by the keys in the `user_params` hash.

<!--
Please add details of what's been added, removed or fixed.
Describe any choices made, why you did things a certain way.
Are there any expected consequences of this PR?
Include screenshots if applicable.
-->
