### PR TITLE
Load all possible SMTP settings from environment vars

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -59,10 +59,14 @@ module Manyfold
 
     config.action_mailer.smtp_settings = {
       address: ENV.fetch("SMTP_SERVER", nil),
+      port: ENV.fetch("SMTP_PORT", nil),
+      domain: ENV.fetch("SMTP_DOMAIN", nil),
       user_name: ENV.fetch("SMTP_USERNAME", nil),
       password: ENV.fetch("SMTP_PASSWORD", nil),
-      port: ENV.fetch("SMTP_PORT", nil),
-      openssl_verify_mode: (ENV.fetch("SMTP_VERIFY_SSL_MODE", nil) == "none") ? :none : nil
+      authentication: ENV.fetch("SMTP_AUTHENTICATION", nil)&.to_sym,
+      openssl_verify_mode: ENV.fetch("SMTP_OPENSSL_VERIFY_MODE", nil)&.to_sym,
+      open_timeout: ENV.fetch("SMTP_OPEN_TIMEOUT", nil)&.to_i,
+      read_timeout: ENV.fetch("SMTP_READ_TIMEOUT", nil)&.to_i
     }.compact
 
     # Load some feature settings from ENV


### PR DESCRIPTION
Builds on #3400 by @fhp to add the rest of the settings.

Resolves #3391 (at least in theory).

New env vars:

* `SMTP_PORT` - port number, if required (added in #3400, included for completeness)
* `SMTP_DOMAIN` - HELO domain if required
* `SMTP_AUTHENTICATION` - one of `plain` (default), `login`, or `cram_md5`
* `SMTP_OPENSSL_VERIFY_MODE` - one of `none` or `peer` (default).
* `SMTP_OPEN_TIMEOUT` - number of seconds to wait for connection (default 5)
* `SMTP_READ_TIMEOUT` - number of seconds to wait for reads (default 5)