### PR TITLE
Rename files in bulk

### DIFF
--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -65,7 +65,13 @@ class ModelFilesController < ApplicationController
     files.each do |file|
       ActiveRecord::Base.transaction do
         current_user.set_list_state(file, :printed, params[:printed] === "1")
-        file.update(hash)
+        options = {}
+        if params[:pattern].present?
+          options[:filename] =
+            file.filename.split(file.extension).first.gsub(params[:pattern], params[:replacement]) +
+            file.extension
+        end
+        file.update(hash.merge(options))
       end
     end
     if params[:split]

--- a/app/views/model_files/bulk_edit.html.erb
+++ b/app/views/model_files/bulk_edit.html.erb
@@ -28,6 +28,9 @@
 
   <p class="lead"><%= t ".form_subtitle" %></p>
 
+  <%= text_input_row form, :pattern %>
+  <%= text_input_row form, :replacement %>
+
   <div class="row mb-3">
     <%= form.label :printed, class: "col-sm-2 col-form-label" %>
     <div class="col-sm-10">

--- a/spec/requests/model_files_spec.rb
+++ b/spec/requests/model_files_spec.rb
@@ -39,33 +39,31 @@ RSpec.describe "Model Files" do
     end
 
     describe "PATCH /models/:model_id/model_files/update", :as_moderator do
-      let(:params) do
-        {
-          model_files: {stl_file.public_id => "1", jpg_file.public_id => "0"},
-          y_up: "1",
-          printed: "1",
-          presupported: "1"
-        }
-      end
+      let(:params) { {model_files: {stl_file.public_id => "1", jpg_file.public_id => "0"}} }
 
       it "bulk updates Y Up on the selected files" do
-        patch bulk_update_model_model_files_path(model, params: params)
-        expect(stl_file.reload.y_up).to be_truthy
+        expect {
+          patch bulk_update_model_model_files_path(model, params: params.merge(y_up: "1"))
+        }.to change { stl_file.reload.y_up }.from(false).to(true)
       end
 
       it "bulk updates presupported flag on the selected files" do
-        patch bulk_update_model_model_files_path(model, params: params)
-        expect(stl_file.reload.presupported).to be_truthy
+        expect {
+          patch bulk_update_model_model_files_path(model, params: params.merge(presupported: "1"))
+        }.to change { stl_file.reload.presupported }.from(false).to(true)
       end
 
       it "bulk updates printed flag on the selected files" do
-        patch bulk_update_model_model_files_path(model, params: params)
-        expect(stl_file.listers(:printed)).to include controller.current_user
+        get bulk_edit_model_model_files_path(model) # Do a get so we have controller reference available
+        expect {
+          patch bulk_update_model_model_files_path(model, params: params.merge(printed: "1"))
+        }.to change { stl_file.listers(:printed).include? controller.current_user }.from(false).to(true)
       end
 
       it "does not modify non-selected files" do
-        patch bulk_update_model_model_files_path(model, params: params)
-        expect(jpg_file.reload.y_up).to be_falsy
+        expect {
+          patch bulk_update_model_model_files_path(model, params: params.merge(y_up: "1"))
+        }.not_to change { jpg_file.reload.y_up }
       end
 
       it "splits model" do

--- a/spec/requests/model_files_spec.rb
+++ b/spec/requests/model_files_spec.rb
@@ -60,6 +60,12 @@ RSpec.describe "Model Files" do
         }.to change { stl_file.listers(:printed).include? controller.current_user }.from(false).to(true)
       end
 
+      it "renames selected files" do
+        expect {
+          patch bulk_update_model_model_files_path(model, params: params.merge(pattern: "s", replacement: "n"))
+        }.to change { stl_file.reload.filename }.from("test.stl").to("tent.stl")
+      end
+
       it "does not modify non-selected files" do
         expect {
           patch bulk_update_model_model_files_path(model, params: params.merge(y_up: "1"))


### PR DESCRIPTION
In bulk edit, you can now rename files, given a pattern and a replacement string.