### PR TITLE
Add an environment flag to override the zxcvbn minimal password score requirement.

### DIFF
--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -224,6 +224,13 @@ Devise.setup do |config|
   # reset. Defaults to true, so a user is signed in automatically after a reset.
   # config.sign_in_after_reset_password = true
 
+  # ==> Configuration for :zxcvbnable
+  # Change the minimum zxcvbn score for passwords. This determines the strength of
+  # the password that is required. The default is 4, which is the recommended
+  # minimum for a secure password.
+  # Must be a number between 0 and 5.
+  config.min_password_score = ENV.fetch("MIN_PASSWORD_SCORE", "4")&.to_i
+
   # ==> Configuration for :encryptable
   # Allow you to use another hashing or encryption algorithm besides bcrypt (default).
   # You can use :sha1, :sha512 or algorithms from others authentication tools as


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [ ] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

Add a new environment variable `MIN_PASSWORD_SCORE` that allows the site administrator to set the password complexity requirements. Defaults to 4, which is the [recommended default](https://github.com/bitzesty/devise_zxcvbn?tab=readme-ov-file#default-parameters) value from the zxcvbn package.

The default of 4 was a bit high to my taste, as it is already protected by other measures (local/vpn only).

<!--
What does this PR do? Why did you open it?
-->

## Linked issues

No linked issues.

<!--
Does this PR resolve an issue? If so, please state "resolves #{number}" here.
Mention any other linked issues or PRs as well, even if this PR doesn't resolve them completely.
-->

## Description of changes

See summary, changes are simple enough.

<!--
Please add details of what's been added, removed or fixed.
Describe any choices made, why you did things a certain way.
Are there any expected consequences of this PR?
Include screenshots if applicable.
-->
