### PR TITLE
Fix errors when merging models

### DIFF
--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -178,8 +178,10 @@ class ModelFile < ApplicationRecord
   memoize :mesh
 
   def reattach!
-    attachment_attacher.attach attachment, storage: model.library.storage_key
-    save!
+    if attachment.id != path_within_library || attachment.storage_key != model.library.storage_key
+      attachment_attacher.attach attachment, storage: model.library.storage_key
+      save!
+    end
   end
 
   def convert_to!(format)


### PR DESCRIPTION
File reattachment was being run when it shouldn't have. Added guards to only reattach if the file has actually moved.