### PR TITLE
Fix case-sensitivity in public IDs

### DIFF
--- a/app/models/concerns/public_i_dable.rb
+++ b/app/models/concerns/public_i_dable.rb
@@ -16,12 +16,12 @@ module PublicIDable
 
   private
 
-  ALPHABET = "bcdfghjklmnpqrstvwxzBCDFGHJKLMNPQRSTVWXZ0123456789"
+  ALPHABET = "bcdfghjklmnpqrstvwxz0123456789"
 
   def generate_public_id
     return if public_id
     self.public_id = begin
-      Nanoid.generate(size: 8, alphabet: ALPHABET)
+      Nanoid.generate(size: 12, alphabet: ALPHABET)
     end while public_id.nil? || self.class.exists?(public_id: public_id)
   end
 end

--- a/db/data/20250121164452_make_public_i_ds_lowercase.rb
+++ b/db/data/20250121164452_make_public_i_ds_lowercase.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+class MakePublicIDsLowercase < ActiveRecord::Migration[7.2]
+  def up
+    [
+      Collection,
+      Comment,
+      Creator,
+      Library,
+      ModelFile,
+      Model,
+      Problem,
+      User
+    ].each do |it|
+      it.update_all("public_id = lower(public_id)") # rubocop:disable Rails/SkipsModelValidations
+    end
+  end
+
+  def down
+  end
+end


### PR DESCRIPTION
Public IDs are intended to be usable in URLs. However, URLs are case insensitive, and the public IDs included uppercase letters as well as lowercase. So, this PR removes the uppercase, extends the ID length a bit to cope, and then lowercases all existing IDs in the database.