### PR TITLE
add SUDO_RUN_UNSAFELY env var to disable root security warning

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -88,6 +88,7 @@ class ApplicationController < ActionController::Base
 
   def show_security_alerts
     return unless current_user&.is_administrator?
+    return if ENV.fetch("SUDO_RUN_UNSAFELY", nil) === "enabled"
     flash.now[:alert] = t("security.running_as_root_html") if Process.uid == 0
   end
 


### PR DESCRIPTION
Useful for running on PaaS systems where root is OK. Set to "enabled" to disable the warning.

Resolves #3067