### PR TITLE
Add trust & safety category to release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -15,6 +15,9 @@ changelog:
     - title: 🧑 Accessibility 🧑
       labels:
         - accessibility
+    - title: ⛑️ Trust & Safety ⛑️
+      labels:
+        - trust+safety
     - title: 🌍 Sustainability & Performance 🌍
       labels:
         - sustainability


### PR DESCRIPTION
So we can call out and highlight those sorts of improvements specifically