### PR TITLE
Rename extension namespace to f3di

### DIFF
--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -81,7 +81,7 @@ class FollowsController < ApplicationController
 
   def find_or_create_entity(actor)
     return entity if actor.entity
-    case actor.extensions&.dig("concreteType")
+    case actor.extensions&.dig("f3di:concreteType")
     when "Creator"
       Creator.create_from_activitypub_object(actor)
     end

--- a/app/models/creator.rb
+++ b/app/models/creator.rb
@@ -47,22 +47,18 @@ class Creator < ApplicationRecord
   def to_activitypub_object
     {
       "@context": {
-        manyfold: "http://manyfold.app/ns#",
+        f3di: "http://purl.org/f3di/ns#",
         toot: "http://joinmastodon.org/ns#",
         attributionDomains: {
           "@id": "toot:attributionDomains",
           "@type": "@id"
-        },
-        concreteType: {
-          "@id": "manyfold:concreteType",
-          "@type": "@string"
         }
       },
       summary: summary_html,
       attributionDomains: [
         [Rails.application.default_url_options[:host], Rails.application.default_url_options[:port]].compact.join(":")
       ],
-      concreteType: "Creator",
+      "f3di:concreteType": "Creator",
       attachment: links.map { |it| {type: "Link", href: it.url} }
     }
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -141,13 +141,9 @@ class User < ApplicationRecord
   def to_activitypub_object
     {
       "@context": {
-        manyfold: "http://manyfold.app/ns#",
-        concreteType: {
-          "@id": "manyfold:concreteType",
-          "@type": "@string"
-        }
+        f3di: "http://purl.org/f3di/ns#"
       },
-      concreteType: "User"
+      "f3di:concreteType": "User"
     }
   end
 

--- a/spec/models/creator_spec.rb
+++ b/spec/models/creator_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Creator do
     let(:ap) { creator.to_activitypub_object }
 
     it "includes concrete type" do
-      expect(ap[:concreteType]).to eq "Creator"
+      expect(ap[:"f3di:concreteType"]).to eq "Creator"
     end
 
     it "includes attributionDomain" do


### PR DESCRIPTION
Now has a domain-independent URI at purl.org