### PR TITLE
Fix problems with searching for remote fediverse users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -148,7 +148,7 @@ gem "better_content_security_policy", "~> 0.1.4"
 gem "devise_zxcvbn", "~> 6.0"
 
 gem "ransack", "~> 4.2"
-gem "federails", git: "https://gitlab.com/experimentslabs/federails", branch: "avoid-double-create"
+gem "federails", git: "https://gitlab.com/experimentslabs/federails", branch: "fix-webfinger-type-match"
 gem "federails-moderation", "~> 0.2"
 gem "caber"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,8 +9,8 @@ GIT
 
 GIT
   remote: https://gitlab.com/experimentslabs/federails
-  revision: 6ee94ba7ca869e543b55b0d568d412c5f90a788f
-  branch: avoid-double-create
+  revision: a7cb37c0d24745f56ed7ccc13a7037fe6652d301
+  branch: fix-webfinger-type-match
   specs:
     federails (0.5.0)
       faraday

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -10,7 +10,7 @@ class FollowsController < ApplicationController
 
   # Incoming remote follow
   def new
-    @query = params[:uri].gsub(/\A@/, "")
+    @query = params[:uri]
     @actor = if @query.starts_with?(%r{https?://})
       Federails::Actor.find_by_federation_url @query # rubocop:disable Rails/DynamicFindBy
     else
@@ -80,10 +80,10 @@ class FollowsController < ApplicationController
   end
 
   def find_or_create_entity(actor)
-    return entity if actor.entity
-    case actor.extensions&.dig("f3di:concreteType")
-    when "Creator"
-      Creator.create_from_activitypub_object(actor)
-    end
+    actor.entity ||
+      case actor.extensions&.dig("f3di:concreteType")
+      when "Creator"
+        Creator.create_from_activitypub_object(actor)
+      end
   end
 end

--- a/app/models/creator.rb
+++ b/app/models/creator.rb
@@ -38,8 +38,8 @@ class Creator < ApplicationRecord
       name: actor.name,
       slug: actor.username,
       links_attributes: actor.extensions["attachment"]&.select { |it| it["type"] == "Link" }&.map { |it| {url: it["href"]} },
-      caption: matches[1],
-      notes: matches[2],
+      caption: matches ? matches[1] : nil,
+      notes: matches ? matches[2] : nil,
       federails_actor: actor
     )
   end

--- a/app/views/creators/_creator.html.erb
+++ b/app/views/creators/_creator.html.erb
@@ -5,7 +5,7 @@
         <%= creator.name %>
         <% if creator.remote? %>
           <br>
-          <small class="text-secondary">@<%= creator.federails_actor&.at_address %></small>
+          <small class="text-secondary"><%= creator.federails_actor&.at_address %></small>
           <% end %>
       </div>
       <% if creator.caption %>

--- a/app/views/creators/show.html.erb
+++ b/app/views/creators/show.html.erb
@@ -13,7 +13,7 @@
           </h2>
           <p>
             <% if @creator.remote? %>
-              <small class="text-secondary"><%= link_to "@" + @creator.federails_actor.at_address, @creator.federails_actor.profile_url, target: "new" %></small>
+              <small class="text-secondary"><%= link_to @creator.federails_actor.at_address, @creator.federails_actor.profile_url, target: "new" %></small>
             <% else %>
               <small class="text-secondary">@<%= @creator.federails_actor.username if SiteSettings.federation_enabled? %></small>
             <% end %>

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -2,7 +2,7 @@
   <%= tag.meta property: "og:type", content: "website" %>
   <%= tag.meta property: "og:image", content: model_model_file_url(@model, @model.preview_file, format: @model.preview_file.extension) if @model.preview_file&.is_image? && !@model.sensitive %>
   <%= tag.meta name: "description", content: truncate(sanitize(@model.notes), length: 80) if @model.notes.present? %>
-  <%= tag.meta name: "fediverse:creator", content: "@#{@model.creator.federails_actor.at_address}" if @model.creator %>
+  <%= tag.meta name: "fediverse:creator", content: @model.creator.federails_actor.at_address if @model.creator %>
 <% end %>
 
 <% content_for :page_header do %>

--- a/spec/requests/webfinger_spec.rb
+++ b/spec/requests/webfinger_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe "Webfinger", :multiuser do
     let(:creator) { create(:creator) }
 
     before do
-      get("/.well-known/webfinger?resource=acct:#{creator.federails_actor.at_address}")
+      get("/.well-known/webfinger?resource=#{creator.federails_actor.at_address.gsub(/\A@/, "acct:")}")
     end
 
     it "returns a successful response" do


### PR DESCRIPTION
Mostly caused by mismatched MIME types in webfinger lookup, which is fixed in some Federails PRs.

Resolves #3480 