### PR TITLE
Show user fedi address on settings page

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -11,6 +11,12 @@
                   help: (devise_mapping.confirmable? && resource.pending_reconfirmation?) ?
                     t(".currently_waiting_confirmation_for_email", email: resource.unconfirmed_email) :
                     nil %>
+            <% if SiteSettings.federation_enabled? %>
+              <div class="row mb-3">
+                <div class="col-auto col-form-label"><%= t("settings.users.index.fediverse_address") %></div>
+                <div class="col col-form-label"><code><%= resource.federails_actor.at_address %></code></div>
+              </div>
+            <% end %>
           </div>
         </div>
         <div class="card mb-2">


### PR DESCRIPTION
User fediverse addresses are random at the moment, but this will show the user what it is, at least.