### PR TITLE
Don't show permission options for remote objects

### DIFF
--- a/app/views/application/_caber_relations_form.html.erb
+++ b/app/views/application/_caber_relations_form.html.erb
@@ -1,4 +1,4 @@
-<%- if SiteSettings.multiuser_enabled? %>
+<%- if SiteSettings.multiuser_enabled? && !form.object.try(:remote?) %>
   <div class="row mb-3">
     <div class="col col-auto">
       <%= t(".permissions") %>


### PR DESCRIPTION
We can't make remote objects public, so for now, let's just disable permissions. We'll want to revisit this later, this is just a quick fix.