### PR TITLE
Add the ability to select from bootwatch themes

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -45,3 +45,19 @@ namespace :db do
     end
   end
 end
+
+namespace :themes do
+  task generate: :environment do
+    raw = Net::HTTP.get(URI.parse("https://bootswatch.com/api/5.json"))
+    json = JSON.parse(raw)
+    json["themes"].each do |theme|
+      name = theme["name"].downcase
+      contents = <<~EOF
+        @import "bootswatch/dist/#{name}/variables";
+        @import '../../application';
+        @import "bootswatch/dist/#{name}/bootswatch";
+      EOF
+      Rails.root.join("app/assets/stylesheets/entrypoints/themes/#{name}.scss").write(contents)
+    end
+  end
+end

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,11 +9,11 @@ $bootstrap-icons-font-dir: "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/
 $ra-font-path: "https://cdn.jsdelivr.net/npm/rpg-awesome@0.2.0/fonts";
 @import 'rpg-awesome/scss/rpg-awesome';
 
-@import '../src/layout';
-@import '../src/libraries';
-@import '../src/links';
-@import '../src/models';
-@import '../src/model_files';
+@import 'src/layout';
+@import 'src/libraries';
+@import 'src/links';
+@import 'src/models';
+@import 'src/model_files';
 
 @import '@selectize/selectize/dist/css/selectize.bootstrap5';
 
@@ -24,6 +24,7 @@ $ra-font-path: "https://cdn.jsdelivr.net/npm/rpg-awesome@0.2.0/fonts";
 	padding: 1px;
 }
 
-p.alert:empty, p.notice:empty {
+p.alert:empty,
+p.notice:empty {
 	display: none;
 }

--- a/app/assets/stylesheets/entrypoints/themes/cerulean.scss
+++ b/app/assets/stylesheets/entrypoints/themes/cerulean.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/cerulean/variables";
+@import '../../application';
+@import "bootswatch/dist/cerulean/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/cosmo.scss
+++ b/app/assets/stylesheets/entrypoints/themes/cosmo.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/cosmo/variables";
+@import '../../application';
+@import "bootswatch/dist/cosmo/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/cyborg.scss
+++ b/app/assets/stylesheets/entrypoints/themes/cyborg.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/cyborg/variables";
+@import '../../application';
+@import "bootswatch/dist/cyborg/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/darkly.scss
+++ b/app/assets/stylesheets/entrypoints/themes/darkly.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/darkly/variables";
+@import '../../application';
+@import "bootswatch/dist/darkly/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/default.scss
+++ b/app/assets/stylesheets/entrypoints/themes/default.scss
@@ -1,0 +1,1 @@
+@import '../application';

--- a/app/assets/stylesheets/entrypoints/themes/default.scss
+++ b/app/assets/stylesheets/entrypoints/themes/default.scss
@@ -1,1 +1,1 @@
-@import '../application';
+@import '../../application';

--- a/app/assets/stylesheets/entrypoints/themes/flatly.scss
+++ b/app/assets/stylesheets/entrypoints/themes/flatly.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/flatly/variables";
+@import '../../application';
+@import "bootswatch/dist/flatly/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/journal.scss
+++ b/app/assets/stylesheets/entrypoints/themes/journal.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/journal/variables";
+@import '../../application';
+@import "bootswatch/dist/journal/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/litera.scss
+++ b/app/assets/stylesheets/entrypoints/themes/litera.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/litera/variables";
+@import '../../application';
+@import "bootswatch/dist/litera/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/lumen.scss
+++ b/app/assets/stylesheets/entrypoints/themes/lumen.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/lumen/variables";
+@import '../../application';
+@import "bootswatch/dist/lumen/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/lux.scss
+++ b/app/assets/stylesheets/entrypoints/themes/lux.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/lux/variables";
+@import '../../application';
+@import "bootswatch/dist/lux/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/materia.scss
+++ b/app/assets/stylesheets/entrypoints/themes/materia.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/materia/variables";
+@import '../../application';
+@import "bootswatch/dist/materia/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/minty.scss
+++ b/app/assets/stylesheets/entrypoints/themes/minty.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/minty/variables";
+@import '../../application';
+@import "bootswatch/dist/minty/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/morph.scss
+++ b/app/assets/stylesheets/entrypoints/themes/morph.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/morph/variables";
+@import '../../application';
+@import "bootswatch/dist/morph/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/pulse.scss
+++ b/app/assets/stylesheets/entrypoints/themes/pulse.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/pulse/variables";
+@import '../../application';
+@import "bootswatch/dist/pulse/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/quartz.scss
+++ b/app/assets/stylesheets/entrypoints/themes/quartz.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/quartz/variables";
+@import '../../application';
+@import "bootswatch/dist/quartz/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/sandstone.scss
+++ b/app/assets/stylesheets/entrypoints/themes/sandstone.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/sandstone/variables";
+@import '../../application';
+@import "bootswatch/dist/sandstone/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/simplex.scss
+++ b/app/assets/stylesheets/entrypoints/themes/simplex.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/simplex/variables";
+@import '../../application';
+@import "bootswatch/dist/simplex/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/sketchy.scss
+++ b/app/assets/stylesheets/entrypoints/themes/sketchy.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/sketchy/variables";
+@import '../../application';
+@import "bootswatch/dist/sketchy/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/slate.scss
+++ b/app/assets/stylesheets/entrypoints/themes/slate.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/slate/variables";
+@import '../../application';
+@import "bootswatch/dist/slate/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/solar.scss
+++ b/app/assets/stylesheets/entrypoints/themes/solar.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/solar/variables";
+@import '../../application';
+@import "bootswatch/dist/solar/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/spacelab.scss
+++ b/app/assets/stylesheets/entrypoints/themes/spacelab.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/spacelab/variables";
+@import '../../application';
+@import "bootswatch/dist/spacelab/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/superhero.scss
+++ b/app/assets/stylesheets/entrypoints/themes/superhero.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/superhero/variables";
+@import '../../application';
+@import "bootswatch/dist/superhero/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/united.scss
+++ b/app/assets/stylesheets/entrypoints/themes/united.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/united/variables";
+@import '../../application';
+@import "bootswatch/dist/united/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/vapor.scss
+++ b/app/assets/stylesheets/entrypoints/themes/vapor.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/vapor/variables";
+@import '../../application';
+@import "bootswatch/dist/vapor/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/yeti.scss
+++ b/app/assets/stylesheets/entrypoints/themes/yeti.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/yeti/variables";
+@import '../../application';
+@import "bootswatch/dist/yeti/bootswatch";

--- a/app/assets/stylesheets/entrypoints/themes/zephyr.scss
+++ b/app/assets/stylesheets/entrypoints/themes/zephyr.scss
@@ -1,0 +1,3 @@
+@import "bootswatch/dist/zephyr/variables";
+@import '../../application';
+@import "bootswatch/dist/zephyr/bootswatch";

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -57,12 +57,13 @@ class ApplicationController < ActionController::Base
     content_security_policy.connect_src :self
     content_security_policy.frame_ancestors :self
     content_security_policy.frame_src :self
-    content_security_policy.font_src :self, "https://cdn.jsdelivr.net"
+    content_security_policy.font_src :self, "https://cdn.jsdelivr.net", "https://fonts.gstatic.com"
     content_security_policy.img_src(*img_src)
     content_security_policy.object_src :none
     content_security_policy.script_src :self
     content_security_policy.style_src :self
     content_security_policy.style_src_attr :unsafe_inline
+    content_security_policy.style_src_elem :self, "https://fonts.googleapis.com"
     # Add libary origins
     origins = Library.all.filter_map(&:storage_origin)
     content_security_policy.img_src(*origins)

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg bg-body-tertiary">
+<nav class="navbar navbar-expand-lg">
   <div class='container-fluid'>
     <a class="navbar-brand ms-2" href="<%= root_path %>" aria-label="<%= translate ".home" %>">
       <%= image_tag site_icon, alt: site_name, height: "40px", class: "me-2" %>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -1,4 +1,4 @@
-<nav class="navbar navbar-expand-lg">
+<nav class="navbar navbar-expand-lg bg-primary" data-bs-theme="dark">
   <div class='container-fluid'>
     <a class="navbar-brand ms-2" href="<%= root_path %>" aria-label="<%= translate ".home" %>">
       <%= image_tag site_icon, alt: site_name, height: "40px", class: "me-2" %>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,4 +1,4 @@
-<div class="row bg-body-tertiary pt-3 mb-3 text-center">
+<div class="row pt-3 mb-3 text-center">
   <h1 class="d-none d-lg-block"><%= site_name %></h1>
   <p class='lead'><%= site_tagline %></p>
   <% if SiteSettings.demo_mode_enabled? %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,7 +9,7 @@
     <%= tag.link rel: "apple-touch-icon", href: asset_path("square-180.png") %>
     <%= tag.meta name: "apple-mobile-web-app-title", content: site_name %>
     <%= javascript_include_tag "application", nonce: true, defer: true %>
-    <%= stylesheet_link_tag "application", nonce: true %>
+    <%= stylesheet_link_tag "themes/#{ENV.fetch("MANYFOLD_UI_THEME", "default")}", nonce: true %>
     <%= yield :head %>
   </head>
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "autoprefixer": "^10.4.20",
     "bootstrap": "^5.3.3",
     "bootstrap-icons": "^1.11.3",
+    "bootswatch": "^5.3.3",
     "comlink": "^4.4.2",
     "esbuild": "^0.25.0",
     "i18n-js": "^4.5.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "build": "bundle exec i18n export --config=./config/i18n-js.yml && esbuild app/javascript/*.* --minify=true --tree-shaking=true --bundle --sourcemap --outdir=app/assets/builds --public-path=assets",
     "build:css": "yarn build:css:compile && yarn build:css:prefix",
     "build:css:compile": "sass ./app/assets/stylesheets/entrypoints:./app/assets/builds --no-source-map --load-path=node_modules",
-    "build:css:prefix": "postcss ./app/assets/builds/application.css --use=autoprefixer --output=./app/assets/builds/application.css",
+    "build:css:prefix": "postcss ./app/assets/builds/*.css --use=autoprefixer -d ./app/assets/builds/",
     "watch:css": "nodemon --watch ./app/assets/stylesheets/ --ext scss --exec \"yarn build:css\"",
     "typecheck": "bundle exec i18n export --config=./config/i18n-js.yml && tsc --project tsconfig.json"
   },

--- a/spec/support/maintain_test_assets.rb
+++ b/spec/support/maintain_test_assets.rb
@@ -48,7 +48,7 @@ class MaintainTestAssets
   #
   EXPECTED_ASSETS = %w[
     application.js
-    application.css
+    themes/default.css
   ]
 
   # Call this method somewhere at test startup, e.g. in "spec_helper.rb" before

--- a/yarn.lock
+++ b/yarn.lock
@@ -1854,6 +1854,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bootswatch@npm:^5.3.3":
+  version: 5.3.3
+  resolution: "bootswatch@npm:5.3.3"
+  checksum: 38279eb9a514bf48b192cd1adc1722b60c19ad0230e19f5dfd721a5bfd36601a7c188b788bb0c4cbf5a75f081fcd7493401901da3e32cfad40fa5ee999ff79ec
+  languageName: node
+  linkType: hard
+
 "brace-expansion@npm:^1.1.7":
   version: 1.1.11
   resolution: "brace-expansion@npm:1.1.11"
@@ -4348,6 +4355,7 @@ __metadata:
     autoprefixer: ^10.4.20
     bootstrap: ^5.3.3
     bootstrap-icons: ^1.11.3
+    bootswatch: ^5.3.3
     comlink: ^4.4.2
     esbuild: ^0.25.0
     eslint: ^9.20.0


### PR DESCRIPTION
By setting the MANYFOLD_UI_THEME env var to the lowercase name of a [Bootswatch theme](https://bootswatch.com/), we can change the entire appearance easily.

options are:

 * `cerulean`
 * `cosmo`
 * `cyborg`
 * `darkly`
 * `default`
 * `flatly`
 * `journal`
 * `litera`
 * `lumen`
 * `lux`
 * `materia`
 * `minty`
 * `morph`
 * `pulse`
 * `quartz`
 * `sandstone`
 * `simplex`
 * `sketchy`
 * `slate`
 * `solar`
 * `spacelab`
 * `superhero`
 * `united`
 * `vapor`
 * `yeti`
 * `zephyr`

This was spectacularly simple to do. I love coding sometimes.

Resolves #3571 