### PR TITLE
Force binding to IPv6 address

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,3 +1,3 @@
-rails: bundle exec rails server -p $PORT
+rails: bundle exec rails server -p $PORT -b [::]
 default_worker: bundle exec sidekiq -C config/workers/default.yml
 performance_worker: bundle exec sidekiq -C config/workers/performance.yml

--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,4 +1,4 @@
-rails: SCOUT_DEV_TRACE=false bin/rails server -p $PORT
+rails: SCOUT_DEV_TRACE=false bin/rails server -p $PORT -b [::]
 default_worker: bundle exec sidekiq -C config/workers/default.yml
 performance_worker: bundle exec sidekiq -C config/workers/performance.yml
 js: yarn build --watch


### PR DESCRIPTION
Automatically allows IPv4 fallback, so there shouldn't be any problems if there isn't an IPv6 network available.

Resolves #3528