### PR TITLE
Fix tags with ampersands in bulk edit dropdown remove list

### DIFF
--- a/app/javascript/src/bulk_edit.ts
+++ b/app/javascript/src/bulk_edit.ts
@@ -16,7 +16,7 @@ function getTags (modelId: string): string[] {
   )
   return Array.prototype.slice
     .call(tagLinks)
-    .map((tag: HTMLAnchorElement) => tag.innerHTML)
+    .map((tag: HTMLAnchorElement) => tag.textContent)
 }
 
 function updateTagList (modelId: string, add: boolean): void {


### PR DESCRIPTION
Seems to resolve #3603, along with probably the fix in #3614 