### PR TITLE
Delete library button added to library settings

### DIFF
--- a/app/views/libraries/_form.html.erb
+++ b/app/views/libraries/_form.html.erb
@@ -55,4 +55,6 @@
   <% end %>
 
   <%= form.submit translate("general.save"), class: "btn btn-primary" %>
+  <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "), library_path("#{@library.public_id}"), {method: :delete, class: "float-end btn btn-outline-danger", data: {confirm: translate(".confirm_destroy")}} if policy(@library).destroy? %>
+
 <% end %>

--- a/app/views/libraries/_form.html.erb
+++ b/app/views/libraries/_form.html.erb
@@ -55,6 +55,8 @@
   <% end %>
 
   <%= form.submit translate("general.save"), class: "btn btn-primary" %>
-  <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "), library_path("#{@library.public_id}"), {method: :delete, class: "float-end btn btn-outline-danger", data: {confirm: translate(".confirm_destroy")}} if policy(@library).destroy? %>
 
+  <% if @library.persisted? %>
+    <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "), library_path("#{@library.public_id}"), {method: :delete, class: "float-end btn btn-outline-danger", data: {confirm: translate(".confirm_destroy.help")}} if policy(@library).destroy? %>
+  <% end %>
 <% end %>

--- a/app/views/libraries/_form.html.erb
+++ b/app/views/libraries/_form.html.erb
@@ -57,6 +57,6 @@
   <%= form.submit translate("general.save"), class: "btn btn-primary" %>
 
   <% if @library.persisted? %>
-    <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "), library_path("#{@library.public_id}"), {method: :delete, class: "float-end btn btn-outline-danger", data: {confirm: translate(".confirm_destroy.help")}} if policy(@library).destroy? %>
+    <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "), library_path(@library.public_id), {method: :delete, class: "float-end btn btn-outline-danger", data: {confirm: translate(".confirm_destroy.help")}} if policy(@library).destroy? %>
   <% end %>
 <% end %>

--- a/app/views/libraries/_form.html.erb
+++ b/app/views/libraries/_form.html.erb
@@ -57,6 +57,12 @@
   <%= form.submit translate("general.save"), class: "btn btn-primary" %>
 
   <% if @library.persisted? %>
-    <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "), library_path(@library.public_id), {method: :delete, class: "float-end btn btn-outline-danger", data: {confirm: translate(".confirm_destroy.help")}} if policy(@library).destroy? %>
+    <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "),
+          library_path(@library.public_id),
+          {
+            method: :delete,
+            class: "float-end btn btn-outline-danger",
+            data: {confirm: translate(".confirm_destroy.help", count: @library.models.count)}
+          } if policy(@library).destroy? %>
   <% end %>
 <% end %>

--- a/app/views/libraries/_form.html.erb
+++ b/app/views/libraries/_form.html.erb
@@ -57,12 +57,14 @@
   <%= form.submit translate("general.save"), class: "btn btn-primary" %>
 
   <% if @library.persisted? %>
-    <%= link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "),
-          library_path(@library.public_id),
-          {
-            method: :delete,
-            class: "float-end btn btn-outline-danger",
-            data: {confirm: translate(".confirm_destroy.help", count: @library.models.count)}
-          } if policy(@library).destroy? %>
+    <%= if policy(@library).destroy?
+          link_to safe_join([icon("trash", t("general.delete")), t("general.delete")], " "),
+            library_path(@library.public_id),
+            {
+              method: :delete,
+              class: "float-end btn btn-outline-danger",
+              data: {confirm: translate(".confirm_destroy.help", count: @library.models.count)}
+            }
+        end %>
   <% end %>
 <% end %>

--- a/config/locales/libraries/en.yml
+++ b/config/locales/libraries/en.yml
@@ -10,6 +10,8 @@ en:
       add_line: Add Line
       caption:
         help: Optional; shown as a tooltip on library links.
+      confirm_destroy:
+        help: Delete library?
       create_path_if_not_on_disk:
         help: Creates the library folder specified above if it doesn't already exist on disk.
       filesystem_description_html: To use storage on your local filesystem, firstly make sure it is mounted as a <a href="https://docs.docker.com/storage/bind-mounts/">bind mount</a> or other volume inside your Docker container, then enter the Docker path; not the path on your host server! For instance, if you have a folder full of files at <code>/mnt/media/3d/models</code> on your host, and have bound <code>/mnt/media/3d</code> to <code>/libraries</code> in your Docker configuration, the required path would be <code>/libraries/models</code>.
@@ -29,8 +31,6 @@ en:
         help: Disable to use vhost-style bucket URLs. Only used for S3-compatible services, not AWS.
       tag_regex:
         help: Check for models missing tags matching these regex.
-      confirm_destroy:
-        help: Delete library?
     general:
       edit: Edit Library
       new: New Library

--- a/config/locales/libraries/en.yml
+++ b/config/locales/libraries/en.yml
@@ -29,6 +29,8 @@ en:
         help: Disable to use vhost-style bucket URLs. Only used for S3-compatible services, not AWS.
       tag_regex:
         help: Check for models missing tags matching these regex.
+      confirm_destroy:
+        help: Delete library?
     general:
       edit: Edit Library
       new: New Library

--- a/config/locales/libraries/en.yml
+++ b/config/locales/libraries/en.yml
@@ -11,7 +11,7 @@ en:
       caption:
         help: Optional; shown as a tooltip on library links.
       confirm_destroy:
-        help: Delete library?
+        help: Deleting this library will also remove %{count} models and their data. Files on disk will not be removed. Are you sure you want to delete the library?
       create_path_if_not_on_disk:
         help: Creates the library folder specified above if it doesn't already exist on disk.
       filesystem_description_html: To use storage on your local filesystem, firstly make sure it is mounted as a <a href="https://docs.docker.com/storage/bind-mounts/">bind mount</a> or other volume inside your Docker container, then enter the Docker path; not the path on your host server! For instance, if you have a folder full of files at <code>/mnt/media/3d/models</code> on your host, and have bound <code>/mnt/media/3d</code> to <code>/libraries</code> in your Docker configuration, the required path would be <code>/libraries/models</code>.

--- a/spec/requests/libraries_spec.rb
+++ b/spec/requests/libraries_spec.rb
@@ -115,7 +115,13 @@ RSpec.describe "Libraries" do
     end
 
     describe "DELETE /libraries/:id" do
-      before { delete "/libraries/#{library.to_param}" }
+      before do
+        # Add a model and file to test cascading removal
+        model = create(:model, library: library)
+        create(:model_file, model: model)
+        # Remove library
+        delete "/libraries/#{library.to_param}"
+      end
 
       it "removes the library", :as_administrator do
         expect(response).to redirect_to("/settings/libraries")


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [x] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

This adds a delete button to the library edit page.

## Linked issues

This should resolve https://github.com/manyfold3d/manyfold/issues/3595

## Description of changes

This change adds a button to the library edit page.

It uses `if policy(@library).destroy?` similarly to how users can be deleted.
