### PR TITLE
Fix search error for contributors and members

### DIFF
--- a/app/controllers/concerns/model_listable.rb
+++ b/app/controllers/concerns/model_listable.rb
@@ -30,6 +30,7 @@ module ModelListable
     end
 
     # Load extra data
-    @models = @models.includes [:library, :model_files, :preview_file, :creator, :collection]
+    @models = @models.includes [:library, :creator, :collection]
+    @models = @models.preload [:model_files, :preview_file] # Use preload query to avoid joining JSON fields
   end
 end


### PR DESCRIPTION
Safer preloading for model files resolves #3331 by removing the extra JOIN that causes incompatibility between permission check and JSON fields in ModelFile