### PR TITLE
Add Creator field to Collections and allow Collections to be filtered by Creator

### DIFF
--- a/app/controllers/concerns/filterable.rb
+++ b/app/controllers/concerns/filterable.rb
@@ -20,7 +20,36 @@ module Filterable
     filter_by_search(models, filters[:q])
   end
 
+  def filtered_collections(filters)
+    collections = policy_scope(Collection).includes(:creator)
+    collections = filter_collection_by_collection(collections, filters[:collection])
+    collections = filter_collection_by_creator(collections, filters[:creator])
+    filter_by_search(collections, filters[:q])
+  end
+
   private
+
+  def filter_collection_by_collection(collections, collection)
+    case collection
+    when nil
+      collections
+    when ""
+      collections.where(collection: nil)
+    else
+      collections.where(collection: Collection.find_param(collection))
+    end
+  end
+
+  def filter_collection_by_creator(collections, creator)
+    case creator
+    when nil
+      collections
+    when ""
+      collections.where(creator_id: nil)
+    else
+      collections.where(creator: Creator.find_param(creator))
+    end
+  end
 
   # Filter by library
   def filter_by_library(models, library)

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -21,6 +21,7 @@ class Collection < ApplicationRecord
   has_many :models, dependent: :nullify
   has_many :collections, dependent: :nullify
   belongs_to :collection, optional: true
+  belongs_to :creator, optional: true
   validates :name, uniqueness: {case_sensitive: false}
 
   def name_with_domain
@@ -85,7 +86,7 @@ class Collection < ApplicationRecord
   end
 
   def self.ransackable_associations(_auth_object = nil)
-    ["collection", "collections", "links", "models"]
+    ["collection", "collections", "creator", "links", "models"]
   end
 
   def to_activitypub_object

--- a/app/models/creator.rb
+++ b/app/models/creator.rb
@@ -9,6 +9,7 @@ class Creator < ApplicationRecord
   acts_as_federails_actor username_field: :slug, name_field: :name, profile_url_method: :url_for
 
   has_many :models, dependent: :nullify
+  has_many :collections, dependent: :nullify
   validates :name, uniqueness: {case_sensitive: false}
 
   def name_with_domain
@@ -20,7 +21,7 @@ class Creator < ApplicationRecord
   end
 
   def self.ransackable_associations(_auth_object = nil)
-    ["links", "models"]
+    ["collections", "links", "models"]
   end
 
   def to_param

--- a/app/serializers/activity_pub/collection_serializer.rb
+++ b/app/serializers/activity_pub/collection_serializer.rb
@@ -17,6 +17,7 @@ module ActivityPub
     def cc
       [
         @object.federails_actor.followers_url,
+        @object.creator&.federails_actor&.followers_url,
         @object.collection&.federails_actor&.followers_url
       ].compact
     end

--- a/app/views/collections/_collection.html.erb
+++ b/app/views/collections/_collection.html.erb
@@ -20,6 +20,10 @@
         <br><%= server_indicator collection %>
       </div>
       <div class="col-auto">
+        <% if collection.creator %>
+          <%= icon "person", collection.creator.model_name.human %>
+          <%= link_to collection.creator.name, "collections?creator=" + collection.creator.name, @filters || {} %><br>
+        <% end %>
         <% if collection.collection %>
           <%= icon "collection", collection.model_name.human %>
           <%= link_to collection.collection.name, collection, @filters || {} %><br>

--- a/app/views/collections/_form.html.erb
+++ b/app/views/collections/_form.html.erb
@@ -1,6 +1,11 @@
 <%= form_with model: @collection do |form| %>
   <%= text_input_row form, :name %>
   <div class="row mb-3 input-group">
+    <%= form.label :creator_id, class: "col-sm-2 col-form-label" %>
+    <%= form.collection_select :creator_id, @creators, :id, :name_with_domain, {include_blank: true}, {class: "form-control col-auto form-select"} %>
+    <%= link_to t("creators.general.new"), new_creator_path, class: "btn btn-outline-secondary col-auto" if policy(:creator).new? %>
+  </div>
+  <div class="row mb-3 input-group">
     <%= form.label :collection_id, class: "col-sm-2 col-form-label" %>
     <%= form.collection_select :collection_id, @collections, :id, :name_with_domain, {include_blank: true}, {class: "form-control col-auto form-select"} %>
     <%= link_to t("collections.general.new"), new_collection_path, class: "btn btn-outline-secondary col-auto" if policy(:collection).new? %>

--- a/app/views/collections/index.html.erb
+++ b/app/views/collections/index.html.erb
@@ -8,11 +8,14 @@
       <% end %>
     </div>
     <div class="row row-cols-1 row-cols-md-2 row-cols-lg-3 mb-4">
-      <%= render "unassigned" if (!pagination_settings["collections"] || @collections.first_page?) && !@filters[:collection] %>
-      <% if @filters[:collection] && @collection %>
-        <%= render @collection %>
+      <%= render "unassigned" if (!pagination_settings["collections"] || @collections.first_page?) && !(@filters[:collection] || @filters[:creator]) %>
+      <% if @filters[:collection] %>
+        <%= render @collections %>
+      <% elsif @filters[:creator] %>
+        <%= render @collections %>
+      <% else %>
+        <%= render @collections %>        
       <% end %>
-      <%= render @collections %>
     </div>
     <% if pagination_settings["collections"] %>
       <%= paginate @collections %>

--- a/app/views/creators/_creator.html.erb
+++ b/app/views/creators/_creator.html.erb
@@ -15,9 +15,11 @@
       </ul>
       <% if creator.remote? %>
         <%= link_to "#{policy_scope(Model).where(creator: creator).count} #{Model.model_name.human count: policy_scope(Model).where(creator: creator).count}", creator, {class: "btn btn-primary", "aria-label": translate(".models_button.remote_label", name: creator.name)} if policy(creator).show? %>
+        <%= link_to "#{policy_scope(Collection).where(creator: creator).count} #{Collection.model_name.human count: policy_scope(Collection).where(creator: creator).count}", "collections?creator=" + creator.name, {class: "btn btn-primary", "aria-label": translate(".models_button.remote_label", name: creator.name)} if policy(creator).show? %>
         <%= link_to "⁂", creator.federails_actor.profile_url, {class: "btn btn-outline-secondary", "aria-label": translate(".visit_button.label", name: creator.name, target: "new")} %>
       <% else %>
         <%= link_to "#{policy_scope(Model).where(creator: creator).count} #{Model.model_name.human count: policy_scope(Model).where(creator: creator).count}", creator, {class: "btn btn-primary", "aria-label": translate(".models_button.label", name: creator.name)} if policy(creator).show? %>
+        <%= link_to "#{policy_scope(Collection).where(creator: creator).count} #{Collection.model_name.human count: policy_scope(Collection).where(creator: creator).count}", "collections?creator=" + creator.name, {class: "btn btn-primary", "aria-label": translate(".models_button.label", name: creator.name)} if policy(creator).show? %>
         <%= link_to icon("pencil-fill", t(".edit_button.text")), edit_creator_path(creator), {class: "btn btn-outline-secondary", "aria-label": translate(".edit_button.label", name: creator.name)} if policy(creator).edit? %>
       <% end %>
     </div>

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,1 @@
-DataMigrate::Data.define(version: 20241118155027)
+DataMigrate::Data.define(20250222000000)

--- a/db/migrate/20250222000000_add_creator_to_collections.rb
+++ b/db/migrate/20250222000000_add_creator_to_collections.rb
@@ -1,0 +1,5 @@
+class AddCreatorToCollections < ActiveRecord::Migration[7.0]
+  def change
+    add_reference :collections, :creator, null: true, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_22_171731) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_22_000000) do
   create_table "caber_relations", force: :cascade do |t|
     t.string "subject_type"
     t.integer "subject_id"
@@ -34,7 +34,9 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_22_171731) do
     t.string "slug"
     t.string "public_id"
     t.virtual "name_lower", type: :string, as: "LOWER(name)", stored: true
+    t.integer "creator_id"
     t.index ["collection_id"], name: "index_collections_on_collection_id"
+    t.index ["creator_id"], name: "index_collections_on_creator_id"
     t.index ["name"], name: "index_collections_on_name", unique: true
     t.index ["name_lower"], name: "index_collections_on_name_lower"
     t.index ["public_id"], name: "index_collections_on_public_id"
@@ -121,7 +123,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_22_171731) do
     t.integer "entity_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.string "entity_type", default: "User"
+    t.string "entity_type"
     t.text "public_key"
     t.text "private_key"
     t.string "uuid"
@@ -320,11 +322,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_22_171731) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "username", null: false
-    t.json "pagination_settings", default: {"models"=>true, "creators"=>true, "collections"=>true, "per_page"=>12}
-    t.json "renderer_settings", default: {"grid_width"=>200, "grid_depth"=>200, "show_grid"=>true, "enable_pan_zoom"=>false, "background_colour"=>"#000000", "object_colour"=>"#cccccc", "render_style"=>"normals"}
-    t.json "tag_cloud_settings", default: {"threshold"=>2, "heatmap"=>true, "keypair"=>true, "sorting"=>"frequency"}
-    t.json "problem_settings", default: {"missing"=>"danger", "empty"=>"info", "nesting"=>"warning", "inefficient"=>"info", "duplicate"=>"warning", "no_image"=>"silent", "no_3d_model"=>"silent", "non_manifold"=>"warning", "inside_out"=>"warning", "no_license"=>"silent", "no_links"=>"silent", "no_creator"=>"silent", "no_tags"=>"silent"}
-    t.json "file_list_settings", default: {"hide_presupported_versions"=>true}
+    t.json "pagination_settings", default: {"models" => true, "creators" => true, "collections" => true, "per_page" => 12}
+    t.json "renderer_settings", default: {"grid_width" => 200, "grid_depth" => 200, "show_grid" => true, "enable_pan_zoom" => false, "background_colour" => "#000000", "object_colour" => "#cccccc", "render_style" => "normals"}
+    t.json "tag_cloud_settings", default: {"threshold" => 2, "heatmap" => true, "keypair" => true, "sorting" => "frequency"}
+    t.json "problem_settings", default: {"missing" => "danger", "empty" => "info", "nesting" => "warning", "inefficient" => "info", "duplicate" => "warning", "no_image" => "silent", "no_3d_model" => "silent", "non_manifold" => "warning", "inside_out" => "warning", "no_license" => "silent", "no_links" => "silent", "no_creator" => "silent", "no_tags" => "silent"}
+    t.json "file_list_settings", default: {"hide_presupported_versions" => true}
     t.string "reset_password_token"
     t.datetime "remember_created_at"
     t.datetime "reset_password_sent_at"
@@ -351,6 +353,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_22_171731) do
   end
 
   add_foreign_key "collections", "collections"
+  add_foreign_key "collections", "creators"
   add_foreign_key "comments", "federails_actors"
   add_foreign_key "federails_activities", "federails_actors", column: "actor_id"
   add_foreign_key "federails_followings", "federails_actors", column: "actor_id"


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [ ] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [ ] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [x] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

I ended up with quite a lot of Collections and thought it might be nice to be able to browse them by Creator. 

## Linked issues

<!--
Does this PR resolve an issue? If so, please state "resolves #{number}" here.
Mention any other linked issues or PRs as well, even if this PR doesn't resolve them completely.
-->

## Description of changes

Add creator_id column to collection table
Add Creator input field to new / edit collection form
Add # Collections button to Creator card
Allow filtering via collections?creator= url and param
