### PR TITLE
Change job iteration method from sidekiq to activejob

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -176,3 +176,5 @@ gem "get_process_mem", "~> 1.0"
 gem "to_regexp", "~> 0.2.1"
 
 gem "activejob-uniqueness", "~> 0.4.0", require: "active_job/uniqueness/sidekiq_patch"
+
+gem "job-iteration", "~> 1.9"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -347,6 +347,8 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jmespath (1.6.2)
+    job-iteration (1.9.0)
+      activejob (>= 5.2)
     jquery-rails (4.6.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
@@ -829,6 +831,7 @@ DEPENDENCIES
   i18n-tasks (~> 1.0)
   i18n_data (~> 1.1.0)
   jbuilder (~> 2.13)
+  job-iteration (~> 1.9)
   jsbundling-rails
   kaminari (~> 1.2)
   kramdown (~> 2.5)

--- a/app/jobs/upgrade/fix_nil_file_size_values.rb
+++ b/app/jobs/upgrade/fix_nil_file_size_values.rb
@@ -1,21 +1,14 @@
 # frozen_string_literal: true
 
-class Upgrade::FixNilFileSizeValues
-  include Sidekiq::IterableJob
+class Upgrade::FixNilFileSizeValues < ApplicationJob
+  include JobIteration::Iteration
+  unique :until_executed
 
-  def on_start
-    logger.info { "Job started: #{self.class.name} (Job id: #{jid})" }
+  def build_enumerator(cursor:)
+    enumerator_builder.active_record_on_records(ModelFile.unscoped.where(size: nil), cursor: cursor)
   end
 
-  def build_enumerator(*args, cursor:)
-    active_record_records_enumerator(ModelFile.where(size: nil), cursor: cursor)
-  end
-
-  def each_iteration(modelfile, *args)
+  def each_iteration(modelfile)
     modelfile.update(size: modelfile.attachment_data["metadata"]["size"]) if modelfile.attachment_data?
-  end
-
-  def on_complete
-    logger.info { "Job completed: #{self.class.name} (Job id: #{jid})" }
   end
 end

--- a/config/initializers/upgrade.rb
+++ b/config/initializers/upgrade.rb
@@ -1,5 +1,5 @@
 Rails.application.config.after_initialize do
-  Upgrade::FixNilFileSizeValues.set(queue: :upgrade).perform_async
+  Upgrade::FixNilFileSizeValues.set(queue: :upgrade).perform_later
   Upgrade::BackfillDataPackages.set(queue: :upgrade).perform_later
 rescue RedisClient::CannotConnectError
 end

--- a/config/initializers/upgrade.rb
+++ b/config/initializers/upgrade.rb
@@ -1,4 +1,7 @@
 Rails.application.config.after_initialize do
+  # Attempt to connect to Redis first before queueing, and fail early
+  Sidekiq.redis { |conn| conn.info }
+  # Queue upgrade jobs if Redis is good to go
   Upgrade::FixNilFileSizeValues.set(queue: :upgrade).perform_later
   Upgrade::BackfillDataPackages.set(queue: :upgrade).perform_later
 rescue RedisClient::CannotConnectError

--- a/spec/jobs/upgrade/fix_nil_file_size_values_spec.rb
+++ b/spec/jobs/upgrade/fix_nil_file_size_values_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Upgrade::FixNilFileSizeValues do
 
   it "updates file with nil size" do
     part.update(size: nil)
-    described_class.perform_sync
+    described_class.perform_now
     part.reload
     expect(part.size).not_to be_nil
   end


### PR DESCRIPTION
@matthewbadeau I found `job-iteration`, which is the activejob gem that the sidekiq iteration design was based on. It's still maintained, so I've swapped the FixNilFileSizeValues job over to that, and then been able to make it unique using the stuff added in #3676.

activejob-status also records job start and finish, so I just removed the on_start and on_complete logging.