### PR TITLE
Signed download URLs for model files

### DIFF
--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -139,9 +139,17 @@ class ModelFilesController < ApplicationController
   end
 
   def get_file
-    @file = @model.model_files.find_param(params[:id])
-    authorize @file
+    # Check for signed download URLs
+    if params[:id].length > 20
+      @file = @model.model_files.find_signed!(params[:id], purpose: "download")
+      skip_authorization
+    else
+      @file = @model.model_files.find_param(params[:id])
+      authorize @file
+    end
     @title = @file.name
+  rescue ActiveSupport::MessageVerifier::InvalidSignature
+    raise ActiveRecord::RecordNotFound
   end
 
   def embedded?

--- a/spec/requests/model_files_spec.rb
+++ b/spec/requests/model_files_spec.rb
@@ -12,7 +12,29 @@ require "support/mock_directory"
 
 RSpec.describe "Model Files" do
   context "when signed out" do
-    it "needs testing when multiuser is enabled"
+    context "when downloading via a signed ID", :multiuser do
+      before { create(:admin) }
+
+      let!(:file) { create(:model_file, filename: "test.jpg") }
+
+      it "succeeds with a valid ID" do
+        id = file.signed_id(expires_in: 1.minute, purpose: "download")
+        get "/models/#{file.model.to_param}/model_files/#{id}.jpg?download=true"
+        expect(response).to have_http_status(:success)
+      end
+
+      it "fails if expired" do
+        id = file.signed_id(expires_at: 1.minute.ago, purpose: "download")
+        get "/models/#{file.model.to_param}/model_files/#{id}.jpg?download=true"
+        expect(response).to have_http_status(:not_found)
+      end
+
+      it "fails if purpose doesn't match" do
+        id = file.signed_id(expires_in: 1.minute, purpose: "shenanigans")
+        get "/models/#{file.model.to_param}/model_files/#{id}.jpg?download=true"
+        expect(response).to have_http_status(:not_found)
+      end
+    end
   end
 
   context "when signed in" do


### PR DESCRIPTION
Adds support for Rails's signed_id URLs for model files, with automatic expiry.