### PR TITLE
Make file removal safer

### DIFF
--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -93,7 +93,7 @@ class ModelFilesController < ApplicationController
 
   def destroy
     authorize @file
-    @file.destroy
+    @file.delete_from_disk_and_destroy
     if request.referer && (URI.parse(request.referer).path == model_model_file_path(@model, @file))
       # If we're coming from the file page itself, we can't go back there
       redirect_to model_path(@model), notice: t(".success")

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -101,7 +101,7 @@ class ProblemsController < ApplicationController
     when "Model"
       problem.problematic.delete_from_disk_and_destroy
     when "ModelFile"
-      problem.problematic.destroy
+      problem.problematic.delete_from_disk_and_destroy
     else
       raise NotImplementedError
     end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -87,7 +87,7 @@ class Model < ApplicationRecord
     # This will go away later when we do proper file relationships rather than linking the tables directly
     model_files.update_all(presupported_version_id: nil) # rubocop:disable Rails/SkipsModelValidations
     # Trigger deletion for each file separately, to make sure cleanup happens
-    model_files.including_special.each { |f| f.destroy }
+    model_files.including_special.each { |f| f.delete_from_disk_and_destroy }
     # Remove tags first - sometimes this causes problems if we don't do it beforehand
     update!(tags: [])
     # Delete directory corresponding to model

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -229,7 +229,7 @@ class Model < ApplicationRecord
 
   def move_files
     # Move all the files
-    model_files.each(&:reattach!)
+    model_files.including_special.each(&:reattach!)
     # Remove the old folder if it's still there
     previous_library.storage.delete_prefixed(previous_path)
   end

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -170,7 +170,12 @@ class ModelFile < ApplicationRecord
 
   def reattach!
     if attachment.id != path_within_library || attachment.storage_key != model.library.storage_key
+      old_path = attachment.id
+      old_storage = attachment.storage
+      # Reattach
       attachment_attacher.attach attachment, storage: model.library.storage_key
+      # Remove previous file
+      old_storage.delete old_path
       save!
     end
   end
@@ -181,6 +186,11 @@ class ModelFile < ApplicationRecord
 
   def loadable?
     loader.present?
+  end
+
+  def delete_from_disk_and_destroy
+    model.library.storage.delete path_within_library
+    destroy
   end
 
   private

--- a/app/uploaders/library_uploader.rb
+++ b/app/uploaders/library_uploader.rb
@@ -6,6 +6,7 @@ class LibraryUploader < Shrine
   plugin :activerecord
   plugin :refresh_metadata
   plugin :metadata_attributes, size: "size"
+  plugin :keep_files
   plugin :determine_mime_type
   plugin :rack_response
   plugin :dynamic_storage

--- a/spec/models/model_file_spec.rb
+++ b/spec/models/model_file_spec.rb
@@ -111,14 +111,14 @@ RSpec.describe ModelFile do
       expect(file.errors[:filename].first).to eq "cannot be a case-only change"
     end
 
-    it "removes original file from disk" do
-      expect { file.destroy }.to(
+    it "removes original file from disk when explicitly told to" do
+      expect { file.delete_from_disk_and_destroy }.to(
         change { File.exist?(File.join(library.path, file.path_within_library)) }.from(true).to(false)
       )
     end
 
-    it "does not remove original file from disk when deleted, not destroyed" do
-      expect { file.delete }.not_to(
+    it "does not remove original file from disk when destroyed" do
+      expect { file.destroy }.not_to(
         change { File.exist?(File.join(library.path, file.path_within_library)) }
       )
     end

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -403,14 +403,14 @@ RSpec.describe Model do
 
     it "calls destroy on files" do # rubocop:todo RSpec/ExampleLength
       file = create(:model_file, model: model, filename: "part_1.3mf", digest: "1234")
-      allow(file).to receive(:destroy)
+      allow(file).to receive(:delete_from_disk_and_destroy)
       mock = double(including_special: [file]) # rubocop:disable RSpec/VerifiedDoubles
       without_partial_double_verification do
         allow(mock).to receive(:update_all).and_return(true)
       end
       allow(model).to receive(:model_files).and_return(mock)
       model.delete_from_disk_and_destroy
-      expect(file).to have_received(:destroy).once
+      expect(file).to have_received(:delete_from_disk_and_destroy).once
     end
   end
 


### PR DESCRIPTION
Using the Shrine `keep_files` plugin, we can make sure files are never removed during standard destroy. Instead, files will *only* be removed when we explicitly do it ourselves.