### PR TITLE
Fix foreign key errors by removing default scope on files

### DIFF
--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -64,13 +64,13 @@ class ModelFilesController < ApplicationController
   end
 
   def bulk_edit
-    @files = policy_scope(ModelFile).where(model: @model)
+    @files = policy_scope(ModelFile).without_special.where(model: @model)
   end
 
   def bulk_update
     hash = bulk_update_params
     ids_to_update = params[:model_files].keep_if { |key, value| value == "1" }.keys
-    files = policy_scope(ModelFile).where(model: @model, public_id: ids_to_update)
+    files = policy_scope(ModelFile).without_special.where(model: @model, public_id: ids_to_update)
     files.each do |file|
       ActiveRecord::Base.transaction do
         current_user.set_list_state(file, :printed, params[:printed] === "1")

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -21,7 +21,7 @@ class ModelsController < ApplicationController
   def show
     respond_to do |format|
       format.html do
-        files = @model.model_files
+        files = @model.model_files.without_special
         @images = files.select(&:is_image?)
         @images.unshift(@model.preview_file) if @images.delete(@model.preview_file)
         if helpers.file_list_settings["hide_presupported_versions"]

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -247,7 +247,7 @@ class ModelsController < ApplicationController
   end
 
   def file_list(model, selection)
-    scope = model.model_files.including_special
+    scope = model.model_files
     case selection
     when nil
       scope

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -248,7 +248,7 @@ module ApplicationHelper
   end
 
   def model_file_count
-    policy_scope(ModelFile).count
+    policy_scope(ModelFile).without_special.count
   end
 
   def oembed_params

--- a/app/jobs/update_datapackage_job.rb
+++ b/app/jobs/update_datapackage_job.rb
@@ -4,7 +4,7 @@ class UpdateDatapackageJob < ApplicationJob
 
   def perform(model_id)
     model = Model.find(model_id)
-    file = model.model_files.including_special.find_or_initialize_by(filename: "datapackage.json")
+    file = model.model_files.find_or_initialize_by(filename: "datapackage.json")
     file.update!(attachment: LibraryUploader.upload(
       StringIO.new(
         JSON.pretty_generate(DataPackage::ModelSerializer.new(model).serialize)

--- a/app/jobs/upgrade/backfill_data_packages.rb
+++ b/app/jobs/upgrade/backfill_data_packages.rb
@@ -7,7 +7,7 @@ class Upgrade::BackfillDataPackages < ApplicationJob
   def perform
     # Find models that don't have a datapackage and enqueue their generation
     Model.where.not(
-      id: ModelFile.including_special.where(filename: "datapackage.json").select(:model_id)
+      id: ModelFile.where(filename: "datapackage.json").select(:model_id)
     ).pluck(:id).each do |id|
       UpdateDatapackageJob.perform_later(id)
     end

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -33,7 +33,6 @@ class ModelFile < ApplicationRecord
 
   after_commit :clear_presupported_relation, on: :update, if: :presupported_previously_changed?
 
-  default_scope { excluding_special.order(:filename) }
   scope :excluding_special, -> { where.not(filename: SPECIAL_FILES) }
   scope :including_special, -> { unscope(where: :filename) }
   scope :unsupported, -> { where(presupported: false) }

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -33,8 +33,7 @@ class ModelFile < ApplicationRecord
 
   after_commit :clear_presupported_relation, on: :update, if: :presupported_previously_changed?
 
-  scope :excluding_special, -> { where.not(filename: SPECIAL_FILES) }
-  scope :including_special, -> { unscope(where: :filename) }
+  scope :without_special, -> { where.not(filename: SPECIAL_FILES) }
   scope :unsupported, -> { where(presupported: false) }
   scope :presupported, -> { where(presupported: true) }
 

--- a/spec/jobs/model_scan_job_spec.rb
+++ b/spec/jobs/model_scan_job_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe ModelScanJob do
 
     it "detects model files" do # rubocop:todo RSpec/MultipleExpectations
       expect { described_class.perform_now(model.id) }.to change { model.model_files.count }.to(2)
-      expect(model.model_files.map(&:filename)).to eq ["part_1.lys", "part_2.obj"]
+      expect(model.model_files.map(&:filename).sort).to eq ["part_1.lys", "part_2.obj"].sort
     end
 
     it "sets the preview file to the first renderable scanned file by default" do # rubocop:todo RSpec/MultipleExpectations

--- a/spec/jobs/update_datapackage_job_spec.rb
+++ b/spec/jobs/update_datapackage_job_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe UpdateDatapackageJob do
   let(:model) { create(:model) }
-  let(:datapackage_json) { JSON.parse(model.model_files.including_special.find_by(filename: "datapackage.json").attachment.read) }
+  let(:datapackage_json) { JSON.parse(model.model_files.find_by(filename: "datapackage.json").attachment.read) }
 
   it "raises exception if model ID is not found" do
     expect { described_class.perform_now(nil) }.to raise_error(ActiveRecord::RecordNotFound)
@@ -10,7 +10,7 @@ RSpec.describe UpdateDatapackageJob do
 
   context "when creating first datapackage" do
     it "creates file if there isn't one already" do
-      expect { described_class.perform_now(model.id) }.to change { ModelFile.including_special.count }.from(0).to(1)
+      expect { described_class.perform_now(model.id) }.to change { ModelFile.count }.from(0).to(1)
     end
 
     it "doesn't include datapackage in resources" do
@@ -26,7 +26,7 @@ RSpec.describe UpdateDatapackageJob do
     end
 
     it "uses existing file if one already exists" do
-      expect { described_class.perform_now(model.id) }.not_to change { ModelFile.including_special.count }
+      expect { described_class.perform_now(model.id) }.not_to change { ModelFile.count }
     end
 
     it "doesn't include datapackage in resources" do

--- a/spec/jobs/update_datapackage_job_spec.rb
+++ b/spec/jobs/update_datapackage_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe UpdateDatapackageJob do
 
   context "when creating first datapackage" do
     it "creates file if there isn't one already" do
-      expect { described_class.perform_now(model.id) }.to change { ModelFile.count }.from(0).to(1)
+      expect { described_class.perform_now(model.id) }.to change(ModelFile, :count).from(0).to(1)
     end
 
     it "doesn't include datapackage in resources" do
@@ -26,7 +26,7 @@ RSpec.describe UpdateDatapackageJob do
     end
 
     it "uses existing file if one already exists" do
-      expect { described_class.perform_now(model.id) }.not_to change { ModelFile.count }
+      expect { described_class.perform_now(model.id) }.not_to change(ModelFile, :count)
     end
 
     it "doesn't include datapackage in resources" do

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -404,7 +404,7 @@ RSpec.describe Model do
     it "calls destroy on files" do # rubocop:todo RSpec/ExampleLength
       file = create(:model_file, model: model, filename: "part_1.3mf", digest: "1234")
       allow(file).to receive(:delete_from_disk_and_destroy)
-      mock = double(including_special: [file]) # rubocop:disable RSpec/VerifiedDoubles
+      mock = [file]
       without_partial_double_verification do
         allow(mock).to receive(:update_all).and_return(true)
       end


### PR DESCRIPTION
We were getting FK errors because of datapackage files being excluded, so let's just include them by default and only filter them out where we really don't want to see them.