### PR TITLE
Fix extra slash on rpg-awesome path

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -6,7 +6,7 @@ $table-bg-scale: -90%;
 $bootstrap-icons-font-dir: "https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.3/font/fonts";
 @import 'bootstrap-icons/font/bootstrap-icons';
 
-$ra-font-path: "https://cdn.jsdelivr.net/npm/@infinizhen/rpg-awesome-continued@1.0.6/fonts/";
+$ra-font-path: "https://cdn.jsdelivr.net/npm/@infinizhen/rpg-awesome-continued@1.0.6/fonts";
 @import '@infinizhen/rpg-awesome-continued/scss/rpg-awesome-continued';
 
 @import 'src/layout';


### PR DESCRIPTION
Fixing: https://github.com/manyfold3d/manyfold/issues/3826

## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [x] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

Fixes a bug in RPG Awesome fonts not resolving due to a trailing slash in the font path

## Linked issues

resolves #3826

## Description of changes

Just removing the trailing slash.
