### PR TITLE
Ignore datapackage.json when generating filesystem change lists

### DIFF
--- a/app/jobs/scan/detect_filesystem_changes_job.rb
+++ b/app/jobs/scan/detect_filesystem_changes_job.rb
@@ -9,7 +9,7 @@ class Scan::DetectFilesystemChangesJob < ApplicationJob
 
   # Get a list of all the existing filenames
   def known_filenames(library)
-    library.model_files.reload.map(&:path_within_library)
+    library.model_files.without_special.reload.map(&:path_within_library)
   end
 
   def filter_out_common_subfolders(folders)


### PR DESCRIPTION
Resolves #3807 - because datapackages were being included in the list of known files, every folder was coming up for a rescan.