### PR TITLE
Disambiguate usernames on startup

### DIFF
--- a/app/jobs/upgrade/disambiguate_usernames_job.rb
+++ b/app/jobs/upgrade/disambiguate_usernames_job.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 
 class Upgrade::DisambiguateUsernamesJob < ApplicationJob
+  queue_as :upgrade
+  unique :until_executed
+
   def perform
     duplicates = duplicated_usernames
     return if duplicates.empty?

--- a/app/jobs/upgrade/disambiguate_usernames_job.rb
+++ b/app/jobs/upgrade/disambiguate_usernames_job.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class Upgrade::DisambiguateUsernamesJob < ApplicationJob
+  def perform
+    suffix = 0
+    FederailsCommon::FEDIVERSE_USERNAMES.each_pair do |model_name, attr|
+      model = model_name.to_s.classify.constantize
+      model.unscoped.find_each do |it|
+        it.validate
+        if it.errors.of_kind?(attr, :taken)
+          suffix += 1
+          new_value = "#{it.send(attr)}#{suffix}"
+          it.update_attribute attr, new_value # rubocop:disable Rails/SkipsModelValidations
+        end
+      end
+    end
+  end
+end

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,13 +1,6 @@
 class ApplicationRecord < ActiveRecord::Base
   self.abstract_class = true
 
-  FEDIVERSE_USERNAMES = {
-    user: :username,
-    creator: :slug,
-    collection: :public_id,
-    model: :public_id
-  }
-
   def self.ransackable_symbols
     (ransackable_attributes + ransackable_associations + ransackable_scopes).map(&:to_sym)
   end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -23,7 +23,7 @@ class Collection < ApplicationRecord
   belongs_to :collection, optional: true
   belongs_to :creator, optional: true
   validates :name, uniqueness: {case_sensitive: false}
-  validates :public_id, multimodel_uniqueness: {case_sensitive: false, check: ApplicationRecord::FEDIVERSE_USERNAMES}
+  validates :public_id, multimodel_uniqueness: {case_sensitive: false, check: FederailsCommon::FEDIVERSE_USERNAMES}
 
   def name_with_domain
     remote? ? name + " (#{federails_actor.server})" : name

--- a/app/models/concerns/federails_common.rb
+++ b/app/models/concerns/federails_common.rb
@@ -2,6 +2,14 @@ module FederailsCommon
   extend ActiveSupport::Concern
   include Federails::ActorEntity
 
+  # Listed in increasing order of priority
+  FEDIVERSE_USERNAMES = {
+    collection: :public_id,
+    model: :public_id,
+    creator: :slug,
+    user: :username
+  }
+
   def federails_actor
     act = Federails::Actor.find_by(entity: self)
     if act.nil?

--- a/app/models/creator.rb
+++ b/app/models/creator.rb
@@ -12,7 +12,7 @@ class Creator < ApplicationRecord
   has_many :collections, dependent: :nullify
   validates :name, uniqueness: {case_sensitive: false}
 
-  validates :slug, multimodel_uniqueness: {case_sensitive: false, check: ApplicationRecord::FEDIVERSE_USERNAMES}
+  validates :slug, multimodel_uniqueness: {case_sensitive: false, check: FederailsCommon::FEDIVERSE_USERNAMES}
 
   def name_with_domain
     remote? ? name + " (#{federails_actor.server})" : name

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -48,7 +48,7 @@ class Model < ApplicationRecord
   validate :check_for_submodels, on: :update, if: :need_to_move_files?
   validate :destination_is_vacant, on: :update, if: :need_to_move_files?
   validates :license, spdx: true, allow_nil: true
-  validates :public_id, multimodel_uniqueness: {case_sensitive: false, check: ApplicationRecord::FEDIVERSE_USERNAMES}
+  validates :public_id, multimodel_uniqueness: {case_sensitive: false, check: FederailsCommon::FEDIVERSE_USERNAMES}
 
   def parents
     Pathname.new(path).parent.descend.filter_map do |path|

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@ class User < ApplicationRecord
 
   devise :omniauthable, omniauth_providers: %i[openid_connect] if SiteSettings.oidc_enabled?
 
-  validates :username, multimodel_uniqueness: {case_sensitive: false, check: ApplicationRecord::FEDIVERSE_USERNAMES}
+  validates :username, multimodel_uniqueness: {case_sensitive: false, check: FederailsCommon::FEDIVERSE_USERNAMES}
 
   validates :username,
     presence: true,

--- a/config/initializers/upgrade.rb
+++ b/config/initializers/upgrade.rb
@@ -4,5 +4,6 @@ Rails.application.config.after_initialize do
   # Queue upgrade jobs if Redis is good to go
   Upgrade::FixNilFileSizeValues.set(queue: :upgrade).perform_later
   Upgrade::BackfillDataPackages.set(queue: :upgrade).perform_later
+  Upgrade::DisambiguateUsernamesJob.set(queue: :upgrade).perform_later
 rescue RedisClient::CannotConnectError
 end

--- a/spec/factories/traits.rb
+++ b/spec/factories/traits.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  trait :without_validations do
+    to_create { |instance| instance.save(validate: false) }
+  end
+end

--- a/spec/jobs/upgrade/disambiguate_usernames_job_spec.rb
+++ b/spec/jobs/upgrade/disambiguate_usernames_job_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Upgrade::DisambiguateUsernamesJob do
+  subject(:job) { described_class.new }
+
+  let(:user) { create(:user, username: "conflict") }
+  let(:creator) { create(:creator, :without_validations, slug: user.username) }
+
+  it "confirms test creator is invalid" do
+    expect(creator).not_to be_valid
+  end
+
+  it "modifies creator name to remove duplication" do
+    expect { job.perform_now }.to change { creator.reload.slug }.from("conflict").to("conflict1")
+  end
+
+  it "preserves username" do
+    expect { job.perform_now }.not_to change { user.reload.username }
+  end
+end

--- a/spec/jobs/upgrade/disambiguate_usernames_job_spec.rb
+++ b/spec/jobs/upgrade/disambiguate_usernames_job_spec.rb
@@ -12,6 +12,11 @@ RSpec.describe Upgrade::DisambiguateUsernamesJob do
     expect(creator).not_to be_valid
   end
 
+  it "detects that there is a duplicate" do
+    creator.touch # rubocop:disable Rails/SkipsModelValidations
+    expect(job.send(:duplicated_usernames)).to eq ["conflict"]
+  end
+
   it "modifies creator name to remove duplication" do
     expect { job.perform_now }.to change { creator.reload.slug }.from("conflict").to("conflict1")
   end


### PR DESCRIPTION
Now that we check for duplicate usernames across different tables, we need to disambiguate any existing conflicts. This job that runs at startup does that, by adding a simple integer to the end of conflicts.