### PR TITLE
Require moderator approval for signups by default

### DIFF
--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -18,7 +18,7 @@ class SiteSettings < RailsSettings::Base
   field :analyse_manifold, type: :boolean, default: false
   field :anonymous_usage_id, type: :string, default: nil
   field :default_viewer_role, type: :string, default: "member"
-  field :approve_signups, type: :boolean, default: false
+  field :approve_signups, type: :boolean, default: true
   field :theme, type: :string, default: "default"
   field :default_library, type: :integer, default: nil
   field :show_libraries, type: :boolean, default: false

--- a/spec/requests/users/registrations_spec.rb
+++ b/spec/requests/users/registrations_spec.rb
@@ -277,7 +277,10 @@ RSpec.describe "Users::Registrations" do
       end
 
       describe "POST /users with approval disabled" do
-        before { post "/users", params: post_options }
+        before {
+          allow(SiteSettings).to receive(:approve_signups).and_return(false)
+          post "/users", params: post_options
+        }
 
         it "creates a new user" do
           expect(User.count).to eq 2


### PR DESCRIPTION
As spam prevention, we have changed signup approval to be "on" by default. It can be turned off in settings.