### PR TITLE
Change "enable signup" environment setting into a settings page option

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -150,7 +150,7 @@ gem "better_content_security_policy", "~> 0.1.4"
 gem "devise_zxcvbn", "~> 6.0"
 
 gem "ransack", "~> 4.3"
-gem "federails", git: "https://gitlab.com/experimentslabs/federails", ref: "58e11556eb357129be1c50fc0d0418557ebcccbd"
+gem "federails", git: "https://gitlab.com/experimentslabs/federails", branch: "open-registrations-proc"
 gem "federails-moderation", "~> 0.3"
 gem "caber"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,8 +16,8 @@ GIT
 
 GIT
   remote: https://gitlab.com/experimentslabs/federails
-  revision: 58e11556eb357129be1c50fc0d0418557ebcccbd
-  ref: 58e11556eb357129be1c50fc0d0418557ebcccbd
+  revision: 2d0f48121c1afb71b3e3cbd210f31d66bfd09ae4
+  branch: open-registrations-proc
   specs:
     federails (0.5.0)
       faraday

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -56,6 +56,7 @@ class SettingsController < ApplicationController
 
   def update_multiuser_settings(settings)
     return unless settings
+    SiteSettings.registration_enabled = (settings[:registration_open])
     SiteSettings.approve_signups = (settings[:approve_signups])
     SiteSettings.default_viewer_role = (settings[:default_viewer_role].presence)
   end

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -22,12 +22,9 @@ class SiteSettings < RailsSettings::Base
   field :theme, type: :string, default: "default"
   field :default_library, type: :integer, default: nil
   field :show_libraries, type: :boolean, default: false
+  field :registration_enabled, type: :boolean, default: (ENV.fetch("REGISTRATION", nil) == "enabled")
 
   validates :model_ignored_files, regex_array: {strict: true}
-
-  def self.registration_enabled?
-    Rails.application.config.manyfold_features[:registration]
-  end
 
   def self.email_configured?
     !Rails.env.production? || ENV.fetch("SMTP_SERVER", false)

--- a/app/views/settings/multiuser.html.erb
+++ b/app/views/settings/multiuser.html.erb
@@ -9,10 +9,6 @@
       <td><%= SiteSettings.multiuser_enabled? ? "✅" : "❌" %></td>
     </tr>
     <tr>
-      <td><%= t(".registration_open") %></td>
-      <td><%= SiteSettings.registration_enabled? ? "✅" : "❌" %></td>
-    </tr>
-    <tr>
       <td><%= t(".federation") %></td>
       <td><%= SiteSettings.federation_enabled? ? "✅" : "❌" %></td>
     </tr>
@@ -29,17 +25,24 @@
     <%= t(".details_html") %>
   </p>
   <hr>
-  <% if SiteSettings.registration_enabled? %>
-    <h3><%= t(".registration") %></h3>
-    <div class="row">
-      <%= form.label nil, t(".approve_signups.label"), for: "multiuser[approve_signups]", class: "col-sm-4 col-form-label" %>
-      <div class="col-sm-8 form-check form-switch">
-        <%= form.check_box "multiuser[approve_signups]", checked: SiteSettings.approve_signups, class: "form-check-input" %>
-        <small><%= t(".approve_signups.help") %></small>
-      </div>
+
+  <h3><%= t(".registration") %></h3>
+  <div class="row">
+    <%= form.label nil, t(".registration_open.label"), for: "multiuser[registration_open]", class: "col-sm-4 col-form-label" %>
+    <div class="col-sm-8 form-check form-switch">
+      <%= form.check_box "multiuser[registration_open]", checked: SiteSettings.registration_enabled, class: "form-check-input" %>
+      <small><%= t(".registration_open.help") %></small>
     </div>
-    <hr>
-  <% end %>
+  </div>
+  <div class="row">
+    <%= form.label nil, t(".approve_signups.label"), for: "multiuser[approve_signups]", class: "col-sm-4 col-form-label" %>
+    <div class="col-sm-8 form-check form-switch">
+      <%= form.check_box "multiuser[approve_signups]", checked: SiteSettings.approve_signups, class: "form-check-input" %>
+      <small><%= t(".approve_signups.help") %></small>
+    </div>
+  </div>
+  <hr>
+
   <h3><%= t(".permissions") %></h3>
   <div class="row">
     <%= form.label nil, t(".default_viewer_role.label"), for: "multiuser[default_viewer_role]", class: "col-sm-4 col-form-label" %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -74,7 +74,6 @@ module Manyfold
     # Some are automatically enabled in test mode because they impact initialization
     config.manyfold_features = {
       multiuser: (ENV.fetch("MULTIUSER", nil) == "enabled"),
-      registration: (ENV.fetch("REGISTRATION", nil) == "enabled"),
       federation: (ENV.fetch("FEDERATION", nil) == "enabled"),
       demo_mode: (ENV.fetch("DEMO_MODE", nil) == "enabled"),
       oidc: ENV.key?("OIDC_CLIENT_ID") && ENV.key?("OIDC_CLIENT_SECRET") && ENV.key?("OIDC_ISSUER")

--- a/config/initializers/federails.rb
+++ b/config/initializers/federails.rb
@@ -12,7 +12,7 @@ Federails.configure do |conf|
   conf.force_ssl = Rails.application.config.force_ssl
 
   conf.enable_discovery = Rails.application.config.manyfold_features[:federation] || Rails.env.test?
-  conf.open_registrations = Rails.application.config.manyfold_features[:registration]
+  conf.open_registrations = -> { SiteSettings.registration_enabled? }
   conf.server_routes_path = "federation"
   conf.client_routes_path = "client"
 

--- a/config/locales/settings/en.yml
+++ b/config/locales/settings/en.yml
@@ -71,7 +71,9 @@ en:
       oidc: OpenID Connect configured?
       permissions: Permissions
       registration: Account registration
-      registration_open: Account registration open?
+      registration_open:
+        help: Lets visitors sign up for accounts.
+        label: Enable signup
       single_user_mode: Manyfold is running in single user mode.
     reporting:
       description_html: If you enable usage tracking, the following information will be sent once a day to <code>%{endpoint}</code>. The <code>id</code> is randomly generated when you enable tracking.

--- a/env.example
+++ b/env.example
@@ -1,4 +1,3 @@
 # MULTIUSER: enabled
-# REGISTRATION: enabled
 # For details of other optional environment variables, including features such
 # as multiuser mode, visit https://manyfold.app/sysadmin/configuration.html


### PR DESCRIPTION
No more REGISTRATION env var, instead the signups can be toggled in the running app, meaning they can be turned off during spam waves, etc.

resolves #3820 