### PR TITLE
Move site name, icon, and tagline into site settings appearance page

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -50,8 +50,7 @@ class ApplicationController < ActionController::Base
   end
 
   def img_src
-    url = ENV.fetch "SITE_ICON", nil
-    url ? URI.parse(url).host : nil
+    url = SiteSettings.site_icon ? URI.parse(SiteSettings.site_icon).host : nil
     [:self, :data, url, "https://cdn.jsdelivr.net"].compact
   end
 

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -32,6 +32,9 @@ class SettingsController < ApplicationController
 
   def update_appearance_settings(settings)
     return unless settings
+    SiteSettings.site_name = settings[:site_name]
+    SiteSettings.site_tagline = settings[:site_tagline]
+    SiteSettings.site_icon = settings[:site_icon]
     SiteSettings.theme = settings[:theme]
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,14 +1,14 @@
 module ApplicationHelper
   def site_name
-    ENV.fetch("SITE_NAME", translate("application.title"))
+    SiteSettings.site_name.presence || translate("application.title")
   end
 
   def site_tagline
-    ENV.fetch("SITE_TAGLINE", t("application.tagline"))
+    SiteSettings.site_tagline.presence || t("application.tagline")
   end
 
   def site_icon
-    ENV.fetch("SITE_ICON", "roundel.svg")
+    SiteSettings.site_icon.presence || "roundel.svg"
   end
 
   def icon(icon, label, id: nil)

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -24,6 +24,10 @@ class SiteSettings < RailsSettings::Base
   field :show_libraries, type: :boolean, default: false
   field :registration_enabled, type: :boolean, default: (ENV.fetch("REGISTRATION", nil) == "enabled")
 
+  field :site_name, type: :string, default: ENV.fetch("SITE_NAME", nil)
+  field :site_tagline, type: :string, default: ENV.fetch("SITE_TAGLINE", nil)
+  field :site_icon, type: :string, default: ENV.fetch("SITE_ICON", nil)
+
   validates :model_ignored_files, regex_array: {strict: true}
 
   def self.email_configured?

--- a/app/views/settings/appearance.html.erb
+++ b/app/views/settings/appearance.html.erb
@@ -1,6 +1,9 @@
 <%= form_with url: settings_path, method: :patch do |form| %>
   <h3><%= t(".heading") %></h3>
   <p class="lead"><%= t(".summary") %></p>
+  <%= text_input_row form, "appearance[site_name]", label: t(".site_name.label"), value: SiteSettings.site_name, placeholder: t("application.title"), help: t(".site_name.help") %>
+  <%= text_input_row form, "appearance[site_tagline]", label: t(".site_tagline.label"), value: SiteSettings.site_tagline, placeholder: t("application.tagline"), help: t(".site_tagline.help") %>
+  <%= text_input_row form, "appearance[site_icon]", label: t(".site_icon.label"), value: SiteSettings.site_icon, help: t(".site_icon.help") %>
   <div class="row">
     <%= form.label nil, t(".theme.label"), for: "appearance[theme]", class: "col-sm-4 col-form-label" %>
     <div class="col-sm-8">

--- a/app/views/settings/appearance.html.erb
+++ b/app/views/settings/appearance.html.erb
@@ -4,9 +4,9 @@
   <%= text_input_row form, "appearance[site_name]", label: t(".site_name.label"), value: SiteSettings.site_name, placeholder: t("application.title"), help: t(".site_name.help") %>
   <%= text_input_row form, "appearance[site_tagline]", label: t(".site_tagline.label"), value: SiteSettings.site_tagline, placeholder: t("application.tagline"), help: t(".site_tagline.help") %>
   <%= text_input_row form, "appearance[site_icon]", label: t(".site_icon.label"), value: SiteSettings.site_icon, help: t(".site_icon.help") %>
-  <div class="row">
-    <%= form.label nil, t(".theme.label"), for: "appearance[theme]", class: "col-sm-4 col-form-label" %>
-    <div class="col-sm-8">
+  <div class="row mb-3 input-group">
+    <%= form.label nil, t(".theme.label"), for: "appearance[theme]", class: "col-auto col-form-label" %>
+    <div class="col p-0">
       <%= form.select "appearance[theme]",
             [
               "cerulean",
@@ -38,7 +38,7 @@
             ].map { |it| [it.titleize, it] },
             {selected: SiteSettings.theme},
             {class: "form-select"} %>
-      <small><%= t(".theme.help_html") %></small>
+      <span class="form-text"><%= t(".theme.help_html") %></span>
     </div>
   </div>
   <%= render "submit", form: form %>

--- a/config/locales/settings/en.yml
+++ b/config/locales/settings/en.yml
@@ -9,6 +9,15 @@ en:
         label: Detect mesh errors
     appearance:
       heading: Appearance
+      site_icon:
+        help: Shown at the top left of each page
+        label: Logo URL
+      site_name:
+        help: The name of your site. Used in navigation and on the homepage.
+        label: Site name
+      site_tagline:
+        help: A few words to introduce your site, shown on the homepage.
+        label: Tagline
       summary: Customise the visual style of your instance.
       theme:
         help_html: Affects all users. Visit <a href="https://bootswatch.com">Bootswatch</a> to see previews.

--- a/config/locales/settings/en.yml
+++ b/config/locales/settings/en.yml
@@ -18,7 +18,7 @@ en:
       site_tagline:
         help: A few words to introduce your site, shown on the homepage.
         label: Tagline
-      summary: Customise the visual style of your instance.
+      summary: Customise your instance.
       theme:
         help_html: Affects all users. Visit <a href="https://bootswatch.com">Bootswatch</a> to see previews.
         label: Theme


### PR DESCRIPTION
No more environment variables for them (though env var values will be used as defaults for unset settings).