### PR TITLE
Add server rules to site settings, with markdown support and automatically shown at signup

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -36,6 +36,7 @@ class SettingsController < ApplicationController
     SiteSettings.site_tagline = settings[:site_tagline]
     SiteSettings.site_icon = settings[:site_icon]
     SiteSettings.theme = settings[:theme]
+    SiteSettings.rules = settings[:rules]
   end
 
   def update_library_settings(settings)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -137,7 +137,7 @@ module ApplicationHelper
         form.label(name, options[:label], class: "col-auto col-form-label"),
         content_tag(:div, class: "col p-0") do
           safe_join [
-            form.text_area(name, class: "form-control col-auto"),
+            form.text_area(name, {class: "form-control col-auto"}.merge(options)),
             errors_for(form.object, name),
             (options[:help] ? content_tag(:span, class: "form-text") { options[:help] } : nil)
           ].compact

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -28,7 +28,7 @@ class SiteSettings < RailsSettings::Base
   field :site_tagline, type: :string, default: ENV.fetch("SITE_TAGLINE", nil)
   field :site_icon, type: :string, default: ENV.fetch("SITE_ICON", nil)
   field :about, type: :text, default: nil
-  field :rules, type: :text, default: nil
+  field :rules, type: :string, default: nil
 
   validates :model_ignored_files, regex_array: {strict: true}
 

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -27,6 +27,8 @@ class SiteSettings < RailsSettings::Base
   field :site_name, type: :string, default: ENV.fetch("SITE_NAME", nil)
   field :site_tagline, type: :string, default: ENV.fetch("SITE_TAGLINE", nil)
   field :site_icon, type: :string, default: ENV.fetch("SITE_ICON", nil)
+  field :about, type: :text, default: nil
+  field :rules, type: :text, default: nil
 
   validates :model_ignored_files, regex_array: {strict: true}
 

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,5 +1,16 @@
 <h1><%= t(".sign_up") %></h1>
 
+<% if SiteSettings.rules.presence %>
+  <h2><%= t(".rules") %></h2>
+  <div class="alert alert-warning">
+    <%= markdownify(SiteSettings.rules) %>
+  </div>
+  <p>
+    <%= t(".rules_agree") %>
+  </p>
+<% end %>
+
+<h2><%= t(".details") %></h2>
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |form| %>
   <%= text_input_row form, :email, autofocus: true, autocomplete: "email" %>
   <%= text_input_row form, :username, autocomplete: "username" %>

--- a/app/views/settings/appearance.html.erb
+++ b/app/views/settings/appearance.html.erb
@@ -41,5 +41,8 @@
       <span class="form-text"><%= t(".theme.help_html") %></span>
     </div>
   </div>
+  <hr>
+  <h4><%= t(".information") %></h4>
+  <%= rich_text_input_row form, "appearance[rules]", label: t(".rules.label"), value: SiteSettings.rules, help: t(".rules.help_html") %>
   <%= render "submit", form: form %>
 <% end %>

--- a/app/views/settings/appearance.html.erb
+++ b/app/views/settings/appearance.html.erb
@@ -3,7 +3,7 @@
   <p class="lead"><%= t(".summary") %></p>
   <%= text_input_row form, "appearance[site_name]", label: t(".site_name.label"), value: SiteSettings.site_name, placeholder: t("application.title"), help: t(".site_name.help") %>
   <%= text_input_row form, "appearance[site_tagline]", label: t(".site_tagline.label"), value: SiteSettings.site_tagline, placeholder: t("application.tagline"), help: t(".site_tagline.help") %>
-  <%= text_input_row form, "appearance[site_icon]", label: t(".site_icon.label"), value: SiteSettings.site_icon, help: t(".site_icon.help") %>
+  <%= url_input_row form, "appearance[site_icon]", label: t(".site_icon.label"), value: SiteSettings.site_icon, help: t(".site_icon.help") %>
   <div class="row mb-3 input-group">
     <%= form.label nil, t(".theme.label"), for: "appearance[theme]", class: "col-auto col-form-label" %>
     <div class="col p-0">

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -107,6 +107,9 @@ en:
           show: Show as normal
       new:
         approval_help: After creating your account, it will be manually reviewed by our moderators. We'll let you know when approval is complete and you can sign in.
+        details: Your Details
+        rules: Server Rules
+        rules_agree: By signing up for an account, you agree to abide by the rules above.
         sign_up: Sign up
       pagination_settings:
         collections:

--- a/config/locales/settings/en.yml
+++ b/config/locales/settings/en.yml
@@ -9,6 +9,10 @@ en:
         label: Detect mesh errors
     appearance:
       heading: Appearance
+      information: Information
+      rules:
+        help_html: Shown at signup; you can use <a href="https://www.markdownguide.org/cheat-sheet/" target="markdown">Markdown</a>.
+        label: Server rules
       site_icon:
         help: Shown at the top left of each page
         label: Logo URL


### PR DESCRIPTION
Just a single markdown field, so you can format it how you like.

<img width="600" alt="Screenshot 2025-03-26 at 23 44 28" src="https://github.com/user-attachments/assets/a1b80ac7-bd4d-477d-b4b8-135fbb5e24bf" />

resolves #3816 