### PR TITLE
Don't store incoming activities

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -150,7 +150,7 @@ gem "better_content_security_policy", "~> 0.1.4"
 gem "devise_zxcvbn", "~> 6.0"
 
 gem "ransack", "~> 4.3"
-gem "federails", git: "https://gitlab.com/experimentslabs/federails", branch: "manu/rework-local-improved"
+gem "federails", git: "https://gitlab.com/experimentslabs/federails", branch: "main"
 gem "federails-moderation", "~> 0.3"
 gem "caber"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 GIT
   remote: https://gitlab.com/experimentslabs/federails
   revision: 58e4e271c608d7f2a8bbdcf35f45e174f6e199b4
-  branch: manu/rework-local-improved
+  branch: main
   specs:
     federails (0.5.0)
       faraday
@@ -606,7 +606,7 @@ GEM
       bcp47_spec (~> 0.2)
       bigdecimal (~> 3.1, >= 3.1.5)
       link_header (~> 0.0, >= 0.0.8)
-    rdoc (6.13.0)
+    rdoc (6.13.1)
       psych (>= 4.0.0)
     redis (5.4.0)
       redis-client (>= 0.22.0)

--- a/app/services/activity_pub/actor_activity_handler.rb
+++ b/app/services/activity_pub/actor_activity_handler.rb
@@ -16,9 +16,6 @@ class ActivityPub::ActorActivityHandler
     object = Federails::Actor.find_or_create_by_federation_url(attributes[:federated_url]) # rubocop:disable Rails/DynamicFindBy
     object&.update!(attributes)
 
-    # Store activity record
-    Federails::Activity.create! actor: get_actor(activity), action: action, entity: object
-
     if object.entity
       ActivityPub::ApplicationDeserializer.deserializer_for(object)&.update!
     else


### PR DESCRIPTION
Activities are supposed to be transient, the database is really meant for outgoing activities only. So, we shouldn't be storing activities that come in. This will mean we need to rebuild the timeline, but that's for a followup PR.