### PR TITLE
Use metadata from datapackages, both on upload and on scan

### DIFF
--- a/app/deserializers/data_package/model_file_deserializer.rb
+++ b/app/deserializers/data_package/model_file_deserializer.rb
@@ -3,7 +3,6 @@ module DataPackage
     def deserialize
       {
         filename: @object["path"],
-        mime_type: @object["mediatype"],
         caption: @object["caption"],
         notes: @object["description"],
         presupported: @object["presupported"],

--- a/app/jobs/scan/model/parse_metadata_job.rb
+++ b/app/jobs/scan/model/parse_metadata_job.rb
@@ -33,8 +33,10 @@ class Scan::Model::ParseMetadataJob < ApplicationJob
       end
       # match preview file
       data[:preview_file] = model.model_files.find_by(filename: data[:preview_file])
-      # Remove model file data, don't need it until there's something useful in it
-      data.delete(:model_files)
+      # Set file data
+      data.delete(:model_files).each do |file|
+        model_files.where(filename: file.delete(:filename)).update(file)
+      end
       # Merge in to main lists
       tag_list.concat data.delete(:tag_list)
       options.merge! data

--- a/app/jobs/scan/model/parse_metadata_job.rb
+++ b/app/jobs/scan/model/parse_metadata_job.rb
@@ -18,11 +18,19 @@ class Scan::Model::ParseMetadataJob < ApplicationJob
     if (datapackage = model.model_files.find_by(filename: "datapackage.json"))
       data = DataPackage::ModelDeserializer.new(JSON.parse(datapackage.attachment.read)).deserialize
       # match creator
-      data[:creator] = data.dig(:creator, :id) ? Creator.find(data.dig(:creator, :id)) :
-        find_or_create_from_path_component(Creator, data.dig(:creator, :name))
+      creator_data = data.delete(:creator)
+      if creator_data
+        data[:creator] = creator_data[:id] ? Creator.find(creator_data.delete(:id)) :
+          find_or_create_from_path_component(Creator, creator_data[:name])
+        data[:creator].update(creator_data)
+      end
       # match collection
-      data[:collection] = data.dig(:collection, :id) ? Collection.find(data.dig(:collection, :id)) :
-        find_or_create_from_path_component(Collection, data.dig(:collection, :name))
+      collection_data = data.delete(:collection)
+      if collection_data
+        data[:collection] = collection_data[:id] ? Collection.find(collection_data.delete(:id)) :
+          find_or_create_from_path_component(Collection, collection_data[:name])
+        data[:collection].update(collection_data)
+      end
       # match preview file
       data[:preview_file] = model.model_files.find_by(filename: data[:preview_file])
       # Remove model file data, don't need it until there's something useful in it

--- a/app/jobs/scan/model/parse_metadata_job.rb
+++ b/app/jobs/scan/model/parse_metadata_job.rb
@@ -35,7 +35,7 @@ class Scan::Model::ParseMetadataJob < ApplicationJob
       data[:preview_file] = model.model_files.find_by(filename: data[:preview_file])
       # Set file data
       data.delete(:model_files).each do |file|
-        model_files.where(filename: file.delete(:filename)).update(file)
+        model.model_files.find_by(filename: file.delete(:filename))&.update(file)
       end
       # Merge in to main lists
       tag_list.concat data.delete(:tag_list)

--- a/app/jobs/scan/model/parse_metadata_job.rb
+++ b/app/jobs/scan/model/parse_metadata_job.rb
@@ -20,6 +20,9 @@ class Scan::Model::ParseMetadataJob < ApplicationJob
       # match creator
       data[:creator] = data.dig(:creator, :id) ? Creator.find(data.dig(:creator, :id)) :
         find_or_create_from_path_component(Creator, data.dig(:creator, :name))
+      # match collection
+      data[:collection] = data.dig(:collection, :id) ? Collection.find(data.dig(:collection, :id)) :
+        find_or_create_from_path_component(Collection, data.dig(:collection, :name))
       # match preview file
       data[:preview_file] = model.model_files.find_by(filename: data[:preview_file])
       # Remove model file data, don't need it until there's something useful in it

--- a/app/serializers/data_package/model_serializer.rb
+++ b/app/serializers/data_package/model_serializer.rb
@@ -16,7 +16,7 @@ module DataPackage
             path: Spdx.licenses.dig(@object.license, "reference")
           }.compact
         ] : nil),
-        resources: @object.model_files.filter_map { |it| ModelFileSerializer.new(it).serialize },
+        resources: @object.model_files.without_special.map { |it| ModelFileSerializer.new(it).serialize },
         sensitive: @object.sensitive,
         contributors: @object.creator ? [CreatorSerializer.new(@object.creator).serialize] : nil,
         collections: @object.collection ? [CollectionSerializer.new(@object.collection).serialize] : nil,

--- a/spec/deserializers/data_package/model_file_deserializer_spec.rb
+++ b/spec/deserializers/data_package/model_file_deserializer_spec.rb
@@ -20,10 +20,6 @@ RSpec.describe DataPackage::ModelFileDeserializer do
       expect(output[:filename]).to eq "files/test.stl"
     end
 
-    it "parses media type" do
-      expect(output[:mime_type]).to eq "model/stl"
-    end
-
     it "parses notes" do
       expect(output[:notes]).to eq "description goes here"
     end


### PR DESCRIPTION
This enables some level of disaster recovery, by reading our datapackages back off disk.