### PR TITLE
Decrease upload chunk size to 1M to match nginx default

### DIFF
--- a/app/javascript/src/uploads.ts
+++ b/app/javascript/src/uploads.ts
@@ -34,7 +34,7 @@ document.addEventListener('ManyfoldReady', () => {
       })
       .use(Tus, {
         endpoint: settings.uploadEndpoint ?? '/upload',
-        chunkSize: 5 * 1024 * 1024
+        chunkSize: 1 * 1024 * 1024
       })
     const submitButton = element?.closest('form')?.querySelector("input[type='submit']")
     uppy.on('upload', () => {


### PR DESCRIPTION
To avoid reverse proxy problems, let's decrease the chunk size during upload. Nginx's default is 1M client body size, so let's use that.