### PR TITLE
Removes trailing and leading backslashes from tags

### DIFF
--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -20,9 +20,20 @@ module ActsAsTaggableOn
 
   class CustomParser < GenericParser
     def parse
+      string = @tag_list
+
+      string = string.join(ActsAsTaggableOn.glue) if string.respond_to?(:join)
       TagList.new.tap do |tag_list|
-        tag_list.add @tag_list.map! { |t| t.gsub!(/(^\\*|\\*$)/, "") }
+        string = string.to_s.dup
+        string.gsub!(/(^\\*|\\*$)/, "").gsub!(/(, \\*|\\*, )/, ",")
+
+        tag_list.add(string.split(ActsAsTaggableOn.delimiter))
       end
+    end
+
+    private
+    def delimiter
+
     end
   end
 end

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -17,4 +17,14 @@ module ActsAsTaggableOn
       ["context", "created_at", "id", "tag_id", "taggable_id", "taggable_type", "tagger_id", "tagger_type"]
     end
   end
+
+  class CustomParser < GenericParser
+    def parse
+      TagList.new.tap do |tag_list|
+        tag_list.add @tag_list.map! {|t| t.gsub!(/(^\\*|\\*$)/, "")}
+      end
+    end
+  end
 end
+
+ActsAsTaggableOn.default_parser = ActsAsTaggableOn::CustomParser

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -30,11 +30,6 @@ module ActsAsTaggableOn
         tag_list.add(string.split(ActsAsTaggableOn.delimiter))
       end
     end
-
-    private
-    def delimiter
-
-    end
   end
 end
 

--- a/config/initializers/acts_as_taggable_on.rb
+++ b/config/initializers/acts_as_taggable_on.rb
@@ -21,7 +21,7 @@ module ActsAsTaggableOn
   class CustomParser < GenericParser
     def parse
       TagList.new.tap do |tag_list|
-        tag_list.add @tag_list.map! {|t| t.gsub!(/(^\\*|\\*$)/, "")}
+        tag_list.add @tag_list.map! { |t| t.gsub!(/(^\\*|\\*$)/, "") }
       end
     end
   end

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -73,6 +73,11 @@ RSpec.describe Model do
     expect(model.path).to eq "models/car"
   end
 
+  it "strips leading and trailing backslashes from tags" do
+    model = create(:model, tag_list: ["\\tag1", "tag2\\"])
+    expect(model.tag_list).to eq ["tag1", "tag2"]
+  end
+
   context "with a library on disk" do
     around do |ex|
       MockDirectory.create([


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [x] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

This change will remove leading and trailing backslashes in tags. This fixes invalid tags on saves and updates.

## Linked issues

resolves #3638

## Description of changes

There's a custom parser added to `config/initializers/acts_as_taggable_on.rb`. It's similar to [the documentation on custom parsers](https://github.com/mbleigh/acts-as-taggable-on?tab=readme-ov-file#tag-parsers) but with a slight tweak. I included it in the module overrides because I don't know where else to add it. It should be global, so this seemed as good as a place as any.

From the documentation, `def parse` returns an `ActsAsTaggableOn::TagList` class.

From my testing, when updating a single tag to remove the backslashes, it does not seem to affect the other tags with backslashes. A migration could help here to prevent a split tag scenario. It feels like the scope of this problem is limited though, so a migration is probably not needed.

Instead we can add to the documentation that if they find that tags have leading or trailing backslashes, they can run this rails command to update all tags:

```ruby
ActsAsTaggableOn::Tag.all.each { |t| t.update(name: t.name.gsub!(/(^\\*|\\*$)/, "")) }
```