### PR TITLE
Updates tag cloud sorting setting and adds translation for form field

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -149,7 +149,8 @@ class Users::RegistrationsController < Devise::RegistrationsController
     {
       "threshold" => settings[:threshold].to_i,
       "heatmap" => settings[:heatmap] == "1",
-      "keypair" => settings[:keypair] == "1"
+      "keypair" => settings[:keypair] == "1",
+      "sorting" => settings[:sorting].to_s
     }
   end
 

--- a/app/views/devise/registrations/_tag_cloud_settings.html.erb
+++ b/app/views/devise/registrations/_tag_cloud_settings.html.erb
@@ -19,7 +19,7 @@
         <%= form.select "tag_cloud_settings[sorting]",
               [[t(".sorting.frequency"), nil], [t(".sorting.alphabetical"), "alphabetical"]],
               {selected: @user.tag_cloud_settings["sorting"]},
-              {class: "form-select"} %>
+              class: "form-select" %>
       </div>
     </div>
     <div class="row mb-2">

--- a/app/views/devise/registrations/_tag_cloud_settings.html.erb
+++ b/app/views/devise/registrations/_tag_cloud_settings.html.erb
@@ -4,7 +4,7 @@
     <div class="row">
       <%= form.label nil, t(".threshold.label"), for: "tag_cloud_settings[threshold]", class: "col col-form-label" %>
       <div class="col">
-        <%= form.text_field "tag_cloud_settings[threshold]", value: @user.tag_cloud_settings["threshold"], class: "form-control" %>
+        <%= form.number_field "tag_cloud_settings[threshold]", value: @user.tag_cloud_settings["threshold"], class: "form-control" %>
       </div>
     </div>
     <div class="row">
@@ -16,9 +16,10 @@
     <div class="row">
       <%= form.label nil, t(".sorting.label"), for: "tag_cloud_settings[sorting]", class: "col col-form-label" %>
       <div class="col">
-        <%= form.select "tag_cloud_settings[sorting]", ["frequency", "alphabetical"],
+        <%= form.select "tag_cloud_settings[sorting]",
+              [[t(".sorting.frequency"), nil], [t(".sorting.alphabetical"), "alphabetical"]],
               {selected: @user.tag_cloud_settings["sorting"]},
-              class: "form-select" %>
+              {class: "form-select"} %>
       </div>
     </div>
     <div class="row mb-2">

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -169,6 +169,8 @@ en:
         keypair:
           label: Use delimiter to represent keypairs
         sorting:
+          alphabetical: alphabetical
+          frequency: frequency
           label: Sorting
         threshold:
           label: Minimum count of tag for display


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [x] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

This adds translations for the tag cloud settings sorting form field and restores the ability to save the setting.

## Linked issues

Resolve #3663 

## Description of changes

3 changes included:
* Fixes the save settings to now correctly save the sorting settings
* Adds translations to the sorting fields
* Changes the tag cloud threshold settings to a `number_field` rather than a `text_field`
