### PR TITLE
Upgrade jobs no longer run as part of rails console init

### DIFF
--- a/config/initializers/upgrade.rb
+++ b/config/initializers/upgrade.rb
@@ -2,8 +2,8 @@ Rails.application.config.after_initialize do
   # Attempt to connect to Redis first before queueing, and fail early
   Sidekiq.redis { |conn| conn.info }
   # Queue upgrade jobs if Redis is good to go
-  #
-  if Rails.const_defined?( "Server" )
+  # and if in server mode
+  if Rails.const_defined?(:Server)
     Upgrade::FixNilFileSizeValues.set(queue: :upgrade).perform_later
     Upgrade::BackfillDataPackages.set(queue: :upgrade).perform_later
     Upgrade::DisambiguateUsernamesJob.set(queue: :upgrade).perform_later


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [x] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

This changes the Upgrade job initializer to only run if it's a server. When running in the rails console, this initializer should not run.

## Linked issues

Discussed in Matrix as this is a problem

## Description of changes

This adds a simple check to the upgrade job initializer. It checks if it's run in server mode (vs console).
Credit goes to [StackOverflow](https://stackoverflow.com/questions/13506690/how-to-determine-if-rails-is-running-from-cli-console-or-as-server/53963584#53963584) for the answer here.
