### PR TITLE
Remove ability to generate long-lived bearer tokens

### DIFF
--- a/app/views/doorkeeper_applications/show.html.erb
+++ b/app/views/doorkeeper_applications/show.html.erb
@@ -22,20 +22,6 @@
     <td><%= Doorkeeper::Application.human_attribute_name :redirect_uri %></td>
     <td><code><%= @application.redirect_uri %></code></td>
   </tr>
-  <tr>
-    <td><%= Doorkeeper::Application.human_attribute_name :access_token %></td>
-    <td>
-      <% if @plaintext_token %>
-        <div class="alert alert-outline alert-warning bg-default">
-          <p><%= t(".plaintext_token.help") %></p>
-          <%= text_field :access_token, {}, value: @plaintext_token, readonly: true, class: "form-control" %>
-        </div>
-      <% else %>
-        <%= t(".access_token.expiry", how_long: time_ago_in_words(@access_token.expires_at)) if @access_token %>
-        <%= link_to t(".access_token.generate"), doorkeeper_application_path(@application, "doorkeeper_application[generate_token]": "1"), method: :patch, class: "ms-5 btn btn-sm btn-outline-warning" %>
-      <% end %>
-    </td>
-  </tr>
 </table>
 
 <%= link_to t(".edit"), edit_doorkeeper_application_path(@application), class: "btn btn-primary" %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -316,13 +316,8 @@ en:
     new:
       title: New application
     show:
-      access_token:
-        expiry: Expires in %{how_long}
-        generate: Create new access token
       destroy: Delete
       edit: Edit
-      plaintext_token:
-        help: This token will only be shown once. If you lose it, you will need to generate a new one, which will automatically revoke all existing tokens.
       title: Application details
     update:
       failure: An error occurred, and the application could not be saved.

--- a/spec/swagger_helper.rb
+++ b/spec/swagger_helper.rb
@@ -40,7 +40,7 @@ RSpec.configure do |config|
         securitySchemes: {
           client_credentials: {
             type: :oauth2,
-            description: "Authentication with the OAuth2 Client Credentials grant flow. You can generate a client app and a long-lived bearer token at /oauth/applications.",
+            description: "Authentication with the OAuth2 Client Credentials grant flow. You can generate client app credentials at /oauth/applications.",
             flows: {
               clientCredentials: {
                 tokenUrl: "/oauth/token",


### PR DESCRIPTION
Proper OAuth flow is demonstrated in the API docs now, so we don't need to introduce the security hole that would be a long-lived bearer token.