### PR TITLE
add MANYFOLD_LOG_LEVEL env var to control log verbosity

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -54,7 +54,7 @@ Rails.application.configure do
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).
-  config.log_level = :info
+  config.log_level = ENV.fetch("MANYFOLD_LOG_LEVEL", "info").to_sym
 
   # Prepend all log lines with the following tags.
   config.log_tags = [:request_id]


### PR DESCRIPTION
In order of decreasing verbosity, set to `debug`, `info` (the default), `warn`, `error`, `fatal` or `unknown`.
