### PR TITLE
Add support to generate screenshots for documentation in specs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ require:
 
 plugins:
   - rubocop-performance
+  - rubocop-capybara
   - rubocop-rails
   - rubocop-rspec
   - rubocop-rspec_rails

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -36,3 +36,6 @@ RSpec/NestedGroups:
   Max: 5
 RSpec/MultipleMemoizedHelpers:
   Max: 6
+RSpec/NoExpectationExample:
+  Exclude:
+    - spec/system/documentation_screenshots_spec.rb

--- a/Gemfile
+++ b/Gemfile
@@ -51,6 +51,7 @@ group :development, :test do
   gem "rubocop-rspec", require: false
   gem "rubocop-rspec_rails", require: false
   gem "rubocop-factory_bot", require: false
+  gem "rubocop-capybara", require: false
   gem "rubocop-i18n", require: false
   gem "rubocop-performance", "~> 1.23", require: false
   gem "rubocop-pundit", github: "manyfold3d/rubocop-pundit", require: false
@@ -58,6 +59,12 @@ group :development, :test do
   gem "i18n-tasks", "~> 1.0"
   gem "simplecov", "~> 0.22.0", require: false
   gem "with_model", "~> 2.2"
+
+  # system tests and custom screenshots
+  gem "capybara"
+  gem "capybara-screenshot", github: "el-cms/capybara-screenshot", branch: "custom-prefixes"
+  gem "image_processing"
+  gem "selenium-webdriver"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,13 @@
 GIT
+  remote: https://github.com/el-cms/capybara-screenshot.git
+  revision: 866841fa662cbe54043cc254be2d76e6511895da
+  branch: custom-prefixes
+  specs:
+    capybara-screenshot (1.0.26)
+      capybara (>= 1.0, < 4)
+      launchy
+
+GIT
   remote: https://github.com/manyfold3d/rubocop-pundit.git
   revision: 10ac81bbec63a9abd3d58be84dc47d9c490b29c6
   specs:
@@ -182,6 +191,15 @@ GEM
     byebug (12.0.0)
     caber (0.4.0)
       rails (>= 7.1.4)
+    capybara (3.40.0)
+      addressable
+      matrix
+      mini_mime (>= 0.1.3)
+      nokogiri (~> 1.11)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     chunky_png (1.4.0)
     climate_control (1.2.0)
     cocooned (2.4.1)
@@ -348,6 +366,9 @@ GEM
       terminal-table (>= 1.5.1)
     i18n_data (1.1.0)
       simple_po_parser (~> 1.1)
+    image_processing (1.13.0)
+      mini_magick (>= 4.9.5, < 5)
+      ruby-vips (>= 2.0.17, < 3)
     inherited_resources (1.14.0)
       actionpack (>= 6.0)
       has_scope (>= 0.6)
@@ -438,8 +459,10 @@ GEM
       net-pop
       net-smtp
     marcel (1.0.4)
+    matrix (0.4.2)
     memoist (0.16.2)
     method_source (1.1.0)
+    mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.8)
     minitest (5.25.5)
@@ -691,6 +714,9 @@ GEM
     rubocop-ast (1.44.0)
       parser (>= 3.3.7.2)
       prism (~> 1.4)
+    rubocop-capybara (2.22.1)
+      lint_roller (~> 1.1)
+      rubocop (~> 1.72, >= 1.72.1)
     rubocop-factory_bot (2.27.1)
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
@@ -715,11 +741,20 @@ GEM
       rubocop (~> 1.72, >= 1.72.1)
       rubocop-rspec (~> 3.5)
     ruby-progressbar (1.13.0)
+    ruby-vips (2.2.2)
+      ffi (~> 1.12)
+      logger
     ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
     scout_apm (5.6.2)
       parser
     securerandom (0.4.1)
+    selenium-webdriver (4.28.0)
+      base64 (~> 0.2)
+      logger (~> 1.4)
+      rexml (~> 3.2, >= 3.2.5)
+      rubyzip (>= 1.2.2, < 3.0)
+      websocket (~> 1.0)
     shellany (0.0.1)
     shrine (3.6.0)
       content_disposition (~> 1.0)
@@ -830,12 +865,15 @@ GEM
       faraday (~> 2.0)
       faraday-follow_redirects
     webrick (1.9.1)
+    websocket (1.2.11)
     websocket-driver (0.7.7)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     with_model (2.2.0)
       activerecord (>= 7.0)
+    xpath (3.2.0)
+      nokogiri (~> 1.8)
     zeitwerk (2.7.2)
     zxcvbn (0.1.10)
 
@@ -860,6 +898,8 @@ DEPENDENCIES
   bullet (~> 8.0)
   byebug
   caber
+  capybara
+  capybara-screenshot!
   climate_control (~> 1.2)
   cocooned (~> 2.4)
   cssbundling-rails (~> 1.4)
@@ -882,6 +922,7 @@ DEPENDENCIES
   i18n-js (~> 4.2)
   i18n-tasks (~> 1.0)
   i18n_data (~> 1.1.0)
+  image_processing
   jbuilder (~> 2.13)
   job-iteration (~> 1.10)
   jsbundling-rails
@@ -920,6 +961,7 @@ DEPENDENCIES
   rolify (~> 6.0)
   rspec-rails
   rswag (~> 2.16)
+  rubocop-capybara
   rubocop-factory_bot
   rubocop-i18n
   rubocop-performance (~> 1.23)
@@ -929,6 +971,7 @@ DEPENDENCIES
   rubocop-rspec_rails
   rubyzip (~> 2.4)
   scout_apm
+  selenium-webdriver
   shrine (~> 3.6)
   shrine-tus (~> 2.1)
   sidekiq (~> 7.3)

--- a/README.md
+++ b/README.md
@@ -101,6 +101,17 @@ You can run the test suite as a one off with the command `bundle exec rake`, or 
 
 Tests are run automatically when pushed to our repository using GitHub Actions.
 
+Generation of screenshots for the documentation is made with system specs and is not run by default. 
+To generate screenshots, set `DOC_SCREENSHOT=true`: 
+
+```sh
+# All specs and documentation
+DOC_SCREENSHOT=true bundle exec rspec
+# Only documentation specs
+DOC_SCREENSHOT=true bundle exec rspec -t @documentation
+```
+
+
 ### Internationalisation & Translation
 
 Manyfold uses [Rails' I18n framework](https://guides.rubyonrails.org/i18n.html) to handle all text content.

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -94,7 +94,7 @@ class ApplicationController < ActionController::Base
     content_security_policy.style_src :self
     content_security_policy.style_src_attr :unsafe_inline
     content_security_policy.style_src_elem :self, "https://fonts.googleapis.com"
-    # Add libary origins
+    # Add library origins
     origins = Library.all.filter_map(&:storage_origin) # rubocop:disable Pundit/UsePolicyScope
     content_security_policy.img_src(*origins)
     content_security_policy.connect_src(*origins)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -82,6 +82,8 @@ class ApplicationController < ActionController::Base
   end
 
   def configure_content_security_policy
+    return if Rails.env.test?
+
     # Standard security policy
     content_security_policy.default_src :self
     content_security_policy.connect_src :self

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -14,6 +14,8 @@ require "rspec/rails"
 require "rake"
 Rails.application.load_tasks
 
+Capybara::Screenshot.prune_strategy = :keep_last_run
+
 Rails.root.glob("spec/support/**/*.rb").sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -65,6 +65,8 @@ RSpec.configure do |config|
     end
   end
 
+  config.filter_run_excluding :documentation unless ENV.fetch("DOC_SCREENSHOT", false) === "true"
+
   config.include ScreenshotHelpers, type: :system
 end
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -64,6 +64,8 @@ RSpec.configure do |config|
       config.filter_run_excluding case_sensitive: true
     end
   end
+
+  config.include ScreenshotHelpers, type: :system
 end
 
 # Copy parsers into integration tests - this doesn't happen automatically for some reason

--- a/spec/support/screenshot_helpers.rb
+++ b/spec/support/screenshot_helpers.rb
@@ -1,0 +1,282 @@
+# frozen_string_literal: true
+
+module ScreenshotHelpers
+  module Constants # rubocop:disable Metrics/ModuleLength
+    COLOR = "#ef2929"
+    DOTS_STYLE = <<~CSS.squish
+      .documentation-dot {
+          position: absolute;
+          z-index: 1000;
+          display: block;
+          width: 1.5rem;
+          height: 1.5rem;
+          background-color: #{COLOR};
+          content: '';
+      }
+
+      .documentation-dot--top {
+          border-radius: 0.75rem 0.75rem 0.1rem 0.75rem;
+          transform: translateX(-50%) translateY(-100%) rotate(45deg);
+      }
+
+      .documentation-dot--right {
+          border-radius: 0.75rem 0.75rem 0.75rem 0.1rem;
+          transform: translateX(0%) translateY(-50%) rotate(45deg);
+      }
+
+      .documentation-dot--bottom {
+          border-radius: 0.1rem 0.75rem 0.75rem 0.75rem;
+          transform: translateX(-50%) rotate(45deg);
+      }
+
+      .documentation-dot--left {
+          border-radius: 0.75rem 0.1rem 0.75rem 0.75rem;
+          transform: translateX(-100%) translateY(-50%) rotate(45deg);
+      }
+
+      .documentation-dot__counter {
+        background-color: white;
+        border-radius: 0.75rem;
+        border: 2px solid #{COLOR};
+        color: #{COLOR};
+        font-family: monospace;
+        font-size: 0.8rem;
+        height: 1.5rem;
+        line-height: 0.8rem;
+        padding: 0.3rem 0;
+        text-align: center;
+        transform: rotate(-45deg);
+        width: 1.5rem;
+      }
+    CSS
+
+    CIRCLES_STYLE = <<~CSS.squish
+      .documentation-circle{
+        position: absolute;
+        z-index: 1000;
+        display: block;
+        width: 2rem;
+        height: 2rem;
+        padding: 0.3rem 0;
+        border: 2px solid #{COLOR};
+        border-radius: 1rem;
+        transform: translateX(-50%) translateY(-50%);
+      }
+    CSS
+
+    OUTLINES_STYLE = <<~CSS.squish
+      .documentation-outline{
+        position: absolute;
+        z-index: 1000;
+        display: block;
+        border: 2px solid #{COLOR};
+      }
+    CSS
+
+    BOX_SHADOW = "0 0 0 2px #{COLOR}".freeze
+
+    COMMON_JAVASCRIPT = <<~JS.squish
+      if(!window.test_getElementPosition) {
+        window.test_getElementPosition = function(element) {
+          var width = element.offsetWidth;
+          var height = element.offsetHeight;
+          var top = 0, left = 0;
+          do {
+            top += element.offsetTop  || 0;
+            left += element.offsetLeft || 0;
+            element = element.offsetParent;
+          } while(element);
+
+          return {top: top,left: left, width: width, height: height};
+        };
+      }
+    JS
+
+    DOTS_JAVASCRIPT = <<~JS.squish
+      if(!window.test_addDot){
+        window.test_addDot = function(target, {counter = 1, offsetX = null, offsetY = null, position= 'top'}){
+          var elementPosition = test_getElementPosition(target);
+          elementPosition.bottom = elementPosition.top + elementPosition.height;
+          elementPosition.right = elementPosition.left + elementPosition.width;
+
+          console.log(position, elementPosition);
+
+          var element = document.createElement('div');
+          var counterElement = document.createElement('div');
+          counterElement.innerHTML = counter;
+          element.appendChild(counterElement);
+
+          counterElement.classList.add("documentation-dot__counter");
+          element.classList.add("documentation-dot");
+          element.classList.add("documentation-dot--" + position);
+
+          var transform = [];
+          if(offsetX) transform.push('translateX('+offsetX+')');
+          if(offsetY) transform.push('translateY('+offsetY+')');
+          element.style.transform = transform.join(' ');
+
+          if(position === 'top' || position === 'bottom'){
+            element.style.top = elementPosition[position] + 'px';
+            element.style.left = (elementPosition.left + elementPosition.width / 2) + 'px';
+          }
+
+          if(position === 'left' || position === 'right'){
+            element.style.left = elementPosition[position] + 'px';
+            element.style.top = (elementPosition.top + elementPosition.height / 2) + 'px';
+          }
+          document.body.appendChild(element);
+        };
+
+        var style = document.createElement('style');
+        style.innerHTML = "#{DOTS_STYLE}";
+        document.body.appendChild(style);
+      }
+    JS
+
+    CIRCLES_JAVASCRIPT = <<~JS.squish
+      if(!window.test_addCircle) {
+        window.test_addCircle = function(target){
+          var position = test_getElementPosition(target);
+          var element = document.createElement('div');
+
+          element.classList.add("documentation-circle");
+
+          element.style.top = position.top + (position.height/2) + 'px';
+          element.style.left = position.left + (position.width/2) + 'px';
+          document.body.appendChild(element);
+        };
+
+        var style = document.createElement('style');
+        style.innerHTML = "#{CIRCLES_STYLE}";
+        document.body.appendChild(style);
+      }
+    JS
+
+    OUTLINES_JAVASCRIPT = <<~JS.squish
+      if(!window.test_addOutline) {
+        window.test_addOutline = function(target){
+          var position = test_getElementPosition(target);
+          var element = document.createElement('div');
+          element.classList.add("documentation-outline");
+          element.style.top = position.top - 2 + 'px';
+          element.style.left = position.left - 2 + 'px';
+          element.style.width = position.width + 4 + 'px';
+          element.style.height = position.height + 4 + 'px';
+          document.body.appendChild(element);
+        };
+
+        var style = document.createElement('style');
+        style.innerHTML = "#{OUTLINES_STYLE}";
+        document.body.appendChild(style);
+      }
+    JS
+
+    BOX_SHADOW_JAVASCRIPT = <<~JS.squish
+      if(!window.test_addBoxShadow) {
+        window.test_boxShadows = [];
+        window.test_addBoxShadow = function(target) {
+          var boxShadow = target.style.boxShadow;
+          window.test_boxShadows.push({element: target, boxShadow: boxShadow});
+          if (boxShadow.length > 0) target.style.boxShadow += "#{BOX_SHADOW}";
+          else target.style.boxShadow = "#{BOX_SHADOW}";
+        };
+      }
+    JS
+  end
+
+  def inject_dots(nodes = [], counter: 1, offset_x: nil, offset_y: nil, position: :top) # rubocop:disable Metrics/MethodLength
+    execute_script Constants::COMMON_JAVASCRIPT
+    execute_script Constants::DOTS_JAVASCRIPT
+
+    nodes.each do |node|
+      node = find(node) if node.is_a? String
+      node.execute_script <<~JS.squish
+        test_addDot(this, { counter: #{counter},
+                            offsetX: #{offset_x ? "'#{offset_x}'" : "null"},
+                            offsetX: #{offset_y ? "'#{offset_y}'" : "null"},
+                            position: '#{position}'
+        });
+      JS
+      counter += 1
+    end
+  end
+
+  def inject_circles(nodes = [])
+    execute_script Constants::COMMON_JAVASCRIPT
+    execute_script Constants::CIRCLES_JAVASCRIPT
+
+    nodes.each do |node|
+      node = find(node) if node.is_a? String
+      node.execute_script "test_addCircle(this)"
+    end
+  end
+
+  # Adds a box around the nodes, with a small margin
+  def inject_outlines(nodes = [])
+    execute_script Constants::COMMON_JAVASCRIPT
+    execute_script Constants::OUTLINES_JAVASCRIPT
+
+    nodes.each do |node|
+      node = find(node) if node.is_a? String
+      node.execute_script "test_addOutline(this)"
+    end
+  end
+
+  def inject_outlined_dots(nodes = [], counter: 1, style: :rectangle)
+    case style
+    when :rectangle
+      inject_outlines nodes
+    else
+      outline_elements nodes
+    end
+
+    inject_dots nodes, counter: counter
+  end
+
+  # Adds a box shadow outlining the nodes. It will be really close to the nodes,
+  # following their shapes.
+  def outline_elements(nodes = [])
+    execute_script Constants::COMMON_JAVASCRIPT
+    execute_script Constants::BOX_SHADOW_JAVASCRIPT
+
+    nodes.each do |node|
+      node = find(node) if node.is_a? String
+      node.execute_script "test_addBoxShadow(this)"
+    end
+  end
+
+  def remove_injected_elements
+    execute_script Constants::COMMON_JAVASCRIPT
+    execute_script <<~JS.squish
+      document.querySelectorAll('.documentation-dot').forEach(function(element){element.remove()});
+      document.querySelectorAll('.documentation-circle').forEach(function(element){element.remove()});
+      document.querySelectorAll('.documentation-outline').forEach(function(element){element.remove()});
+      if (window.test_boxShadows) {
+        window.test_boxShadows.forEach(function (node) {node.element.style.boxShadow = node.boxShadow});
+        window.test_boxShadows = [];
+      }
+    JS
+  end
+
+  def take_and_crop_screenshot(name, top: 0, left: 0, width: nil, height: nil)
+    name += "_#{I18n.locale}"
+
+    paths = screenshot_and_save_page prefix: name, html: false
+    path = File.join(Capybara::Screenshot.capybara_tmp_path, "#{name}.png")
+    FileUtils.mv paths[:image], path
+
+    processed = ImageProcessing::MiniMagick.source(path).crop!(left, top, width, height)
+    FileUtils.mv processed, path
+  end
+
+  def reload_page
+    execute_script "window.location.reload()"
+  end
+
+  def resize_window(width: nil, height: nil)
+    size = Capybara.page.driver.browser.manage.window.size
+    width ||= size.width
+    height ||= size.height
+    Capybara.page.driver.browser.manage.window.resize_to(width, height)
+  end
+end

--- a/spec/system/documentation_screenshots_spec.rb
+++ b/spec/system/documentation_screenshots_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe "Documentation screenshots", :documentation do
+  before do
+    driven_by :selenium
+  end
+
+  describe "home page" do
+    it "contains things" do
+      visit "/"
+
+      inputs = find_all "input"
+      inject_outlines inputs
+      inject_dots inputs
+
+      take_and_crop_screenshot "home_page"
+    end
+  end
+end


### PR DESCRIPTION
Uses `gem "capybara-screenshot"; branch from "el-cms/capybara-screenshot#custom-prefixes" (ahead of upstream with support for new options. Sadly, not yet merged upstream)

Adds a spec helper that injects and executes JS in the current page (`spec/support/screenshot_helpers.rb`).

CSP are disabled in test env (commit `---FIXME`); let me know if you want to do this another way.