### PR TITLE
Allow re-parsing of data when a creator is set, without overwriting it.

### DIFF
--- a/app/jobs/scan/model/parse_metadata_job.rb
+++ b/app/jobs/scan/model/parse_metadata_job.rb
@@ -5,11 +5,16 @@ class Scan::Model::ParseMetadataJob < ApplicationJob
   def perform(model_id)
     model = Model.find(model_id)
     return if model.remote?
-    options = {}
+    options = {
+      # Some things are preserved if already set
+      creator: model.creator,
+      collection: model.collection,
+      preview_file: model.preview_file
+    }.compact
     # Set preview file
-    options.merge! identify_preview_file(model) unless model.preview_file
+    options.reverse_merge! identify_preview_file(model)
     # Set path template attributes
-    options.merge! attributes_from_path_template(model.path) unless model.creator
+    options.reverse_merge! attributes_from_path_template(model.path)
     # Build combined tag list
     tag_list =
       model.tag_list +

--- a/spec/jobs/scan/model/parse_metadata_job_spec.rb
+++ b/spec/jobs/scan/model/parse_metadata_job_spec.rb
@@ -249,6 +249,29 @@ RSpec.describe Scan::Model::ParseMetadataJob do
         expect(model.creator).to eq creator
       end
     end
+
+    context "with a creator already assigned" do
+      let(:model) { create(:model, path: "bruce-wayne/toys/model-name", creator: create(:creator, name: "Existing")) }
+
+      before do
+        allow(SiteSettings).to receive_messages(
+          model_path_template: "{creator}/{collection}/{modelName}",
+          parse_metadata_from_path: true
+        )
+      end
+
+      it "doesn't overwrite existing creator" do
+        expect { described_class.perform_now(model.id) }.not_to change { model.reload.creator }
+      end
+
+      it "sets collection" do
+        expect { described_class.perform_now(model.id) }.to change { model.reload.collection }
+      end
+
+      it "sets name" do
+        expect { described_class.perform_now(model.id) }.to change { model.reload.name }
+      end
+    end
   end
 
   context "when parsing collection out of a path" do
@@ -287,6 +310,29 @@ RSpec.describe Scan::Model::ParseMetadataJob do
         described_class.perform_now(model.id)
         model.reload
         expect(model.collection).to eq collection
+      end
+    end
+
+    context "with a creator already assigned" do
+      let(:model) { create(:model, path: "bruce-wayne/toys/model-name", collection: create(:collection, name: "Existing")) }
+
+      before do
+        allow(SiteSettings).to receive_messages(
+          model_path_template: "{creator}/{collection}/{modelName}",
+          parse_metadata_from_path: true
+        )
+      end
+
+      it "sets creator" do
+        expect { described_class.perform_now(model.id) }.to change { model.reload.creator }
+      end
+
+      it "doesn't overwrite existing collection" do
+        expect { described_class.perform_now(model.id) }.not_to change { model.reload.collection }
+      end
+
+      it "sets name" do
+        expect { described_class.perform_now(model.id) }.to change { model.reload.name }
       end
     end
   end


### PR DESCRIPTION
Lots of extra tests here, but the main thing is that before, if the creator was set, nothing would be parsed from the path template. Now, it's parsed and the new info is merged in but won't overwrite creator, collection, (or preview file) if already set.