### PR TITLE
Fixes multiple successive downloads race condition

### DIFF
--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -49,7 +49,7 @@ class ModelsController < ApplicationController
           @model.slug,
           params[:selection]
         ].compact.join("-") + ".zip"
-        tmpfile = File.join(tmpdir, "#{@model.updated_at.to_time.to_i}-#{@model.id}-#{params[:selection]}.zip")
+        tmpfile = File.join(tmpdir, "#{SecureRandom.urlsafe_base64}.zip")
         unless File.exist?(tmpfile)
           files = file_list(@model, params[:selection])
           write_archive(tmpfile, files)


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [x] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

This fixes the issue where multiple clicks to the download button would cause incomplete or partial downloads.

## Linked issues

resolves #3075 
<!--
Does this PR resolve an issue? If so, please state "resolves #{number}" here.
Mention any other linked issues or PRs as well, even if this PR doesn't resolve them completely.
-->

## Description of changes

<!--
Please add details of what's been added, removed or fixed.
Describe any choices made, why you did things a certain way.
Are there any expected consequences of this PR?
Include screenshots if applicable.
-->
Previously, the `tmpfile` name would be `#{@model.updated_at.to_time.to_i}-#{@model.id}-#{params[:selection]}`. However, this resulted in temp files that shared a common name. Instead, we can just give it a random string. It makes it slightly harder to troubleshoot at first glance but ensures that rails won't start sending an incomplete file before the other one has completed being written.

I had also tried creating lock files and appending other things like UUIDs but I think this is the simplest solution.
