### PR TITLE
Add bin/manyfold management tool for advanced tasks

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,8 @@ AllCops:
   NewCops: enable
   Exclude:
     - db/schema.rb
-    - bin/*
+    - bin/bundle
+    - bin/yarn
     - "node_modules/**/*"
     - "tmp/**/*"
     - "vendor/**/*"
@@ -32,6 +33,7 @@ I18n/RailsI18n:
   Enabled: true
   Exclude:
     - "spec/**/*"
+    - "bin/manyfold"
 RSpec/NestedGroups:
   Max: 5
 RSpec/MultipleMemoizedHelpers:

--- a/bin/manyfold
+++ b/bin/manyfold
@@ -1,0 +1,59 @@
+#!/usr/bin/env ruby
+require "thor"
+require File.expand_path("../../config/environment", __FILE__)
+
+class CollectionCLI < Thor
+  desc "prune", "removes all empty collections"
+  def prune
+    Collection.find_each { |it| it.destroy if it.models.empty? && it.collections.empty? }
+  end
+end
+
+class CreatorCLI < Thor
+  desc "prune", "removes all creators that aren't associated with any models"
+  def prune
+    Creator.find_each { |it| it.destroy if it.models.empty? }
+  end
+end
+
+class ProblemCLI < Thor
+  desc "prune", "removes any problems without an associated problematic object"
+  def prune
+    Problem.find_each { |it| it.destroy if it.problematic.nil? }
+  end
+
+  desc "purge", "removes all problem records"
+  option :type, required: false, type: :string, default: nil, aliases: :t
+  option :class, required: false, type: :string, default: nil, aliases: :c
+  def purge
+    scope = problem
+    scope = scope.where(type: options[:type]) if options[:type]
+    scope = scope.where(problematic_type: options[:class]) if options[:class]
+    Problem.destroy_all
+  end
+end
+
+class TagCLI < Thor
+  desc "purge", "removes all tags"
+  def purge
+    ActsAsTaggableOn::Tagging.destroy_all
+    ActsAsTaggableOn::Tag.destroy_all
+  end
+end
+
+class ManyfoldCLI < Thor
+  desc "creators", "manage creators"
+  subcommand "creators", CreatorCLI
+
+  desc "collections", "manage collections"
+  subcommand "collections", CollectionCLI
+
+  desc "problems", "manage problems"
+  subcommand "problems", ProblemCLI
+
+  desc "tags", "manage tags"
+  subcommand "tags", TagCLI
+end
+
+
+ManyfoldCLI.start(ARGV)

--- a/bin/manyfold
+++ b/bin/manyfold
@@ -26,10 +26,10 @@ class ProblemCLI < Thor
   option :type, required: false, type: :string, default: nil, aliases: :t
   option :class, required: false, type: :string, default: nil, aliases: :c
   def purge
-    scope = problem
+    scope = Problem
     scope = scope.where(type: options[:type]) if options[:type]
     scope = scope.where(problematic_type: options[:class]) if options[:class]
-    Problem.destroy_all
+    scope.destroy_all
   end
 end
 
@@ -54,6 +54,5 @@ class ManyfoldCLI < Thor
   desc "tags", "manage tags"
   subcommand "tags", TagCLI
 end
-
 
 ManyfoldCLI.start(ARGV)

--- a/bin/manyfold
+++ b/bin/manyfold
@@ -26,6 +26,7 @@ class ProblemCLI < Thor
   option :type, required: false, type: :string, default: nil, aliases: :t
   option :class, required: false, type: :string, default: nil, aliases: :c
   def purge
+    return unless ask("Are you sure you want to remove all problems", limited_to: %w[y n]) == "y"
     scope = Problem
     scope = scope.where(type: options[:type]) if options[:type]
     scope = scope.where(problematic_type: options[:class]) if options[:class]
@@ -36,6 +37,7 @@ end
 class TagCLI < Thor
   desc "purge", "removes all tags"
   def purge
+    return unless ask("Are you sure you want to remove all tags?", limited_to: %w[y n]) == "y"
     ActsAsTaggableOn::Tagging.destroy_all
     ActsAsTaggableOn::Tag.destroy_all
   end


### PR DESCRIPTION
Using thor, we can easily make a helpful command line tool for things that are in the advanced tasks page of the website.

This adds the commands:

* `manyfold collections prune` : removes empty collections
* `manyfold creators prune` : removes creators without any models
* `manyfold problems prune` : remove broken problems that don't have an associated problematic object
* `manyfold problems purge` : remove all problems. `-t {type}` specifies a particular problem type, `-c {class}` specifies a particular problematic class.
* `manyfold tags purge` : remove all tags

Resolves #3435 