### PR TITLE
Import notes from "README" files

### DIFF
--- a/app/jobs/scan/model/parse_metadata_job.rb
+++ b/app/jobs/scan/model/parse_metadata_job.rb
@@ -47,12 +47,15 @@ class Scan::Model::ParseMetadataJob < ApplicationJob
       tag_list.concat data.delete(:tag_list) if data.key?(:tag_list)
       options.merge! data
     end
+    # Load information from READMEs (but don't overwrite)
+    options.compact_blank!
+    options.reverse_merge! attributes_from_readme(model.model_files.find_by(filename_lower: ["readme.txt", "readme", "readme.md"])) if model.notes.blank?
     # Make sure links are unique
     options[:links_attributes]&.filter! { |it| model.links.map(&:url).exclude?(it[:url]) }
     # Filter stop words
     options[:tag_list] = remove_stop_words(tag_list.uniq)
     # Store new metadata
-    model.update!(options.compact)
+    model.update!(options.compact_blank!)
   end
 
   private
@@ -82,6 +85,13 @@ class Scan::Model::ParseMetadataJob < ApplicationJob
       collection: find_or_create_from_path_component(Collection, components[:collection]),
       name: to_human_name(components[:model_name])
     }.compact
+  end
+
+  def attributes_from_readme(file)
+    return {} if file.nil?
+    {
+      notes: file.attachment.read
+    }
   end
 
   def tags_from_path_template(path)

--- a/app/jobs/scan/model/parse_metadata_job.rb
+++ b/app/jobs/scan/model/parse_metadata_job.rb
@@ -2,6 +2,12 @@ class Scan::Model::ParseMetadataJob < ApplicationJob
   queue_as :scan
   unique :until_executed
 
+  README_FILES = [
+    "readme",
+    "readme.md",
+    "readme.txt"
+  ]
+
   def perform(model_id)
     model = Model.find(model_id)
     return if model.remote?
@@ -49,7 +55,7 @@ class Scan::Model::ParseMetadataJob < ApplicationJob
     end
     # Load information from READMEs (but don't overwrite)
     options.compact_blank!
-    options.reverse_merge! attributes_from_readme(model.model_files.find_by(filename_lower: ["readme.txt", "readme", "readme.md"])) if model.notes.blank?
+    options.reverse_merge! attributes_from_readme(model.model_files.find_by(filename_lower: README_FILES)) if model.notes.blank?
     # Make sure links are unique
     options[:links_attributes]&.filter! { |it| model.links.map(&:url).exclude?(it[:url]) }
     # Filter stop words

--- a/db/migrate/20250423094525_add_lowercase_filename_virtual_field_to_model_files.rb
+++ b/db/migrate/20250423094525_add_lowercase_filename_virtual_field_to_model_files.rb
@@ -1,0 +1,6 @@
+class AddLowercaseFilenameVirtualFieldToModelFiles < ActiveRecord::Migration[8.0]
+  def change
+    add_column :model_files, :filename_lower, :virtual, type: :string, as: "LOWER(filename)", stored: true
+    add_index :model_files, :filename_lower
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_04_09_125753) do
+ActiveRecord::Schema[8.0].define(version: 2025_04_23_094525) do
   create_table "caber_relations", force: :cascade do |t|
     t.string "subject_type"
     t.integer "subject_id"
@@ -229,8 +229,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_04_09_125753) do
     t.integer "presupported_version_id"
     t.json "attachment_data"
     t.string "public_id"
+    t.virtual "filename_lower", type: :string, as: "LOWER(filename)", stored: true
     t.index ["digest"], name: "index_model_files_on_digest"
     t.index ["filename", "model_id"], name: "index_model_files_on_filename_and_model_id", unique: true
+    t.index ["filename_lower"], name: "index_model_files_on_filename_lower"
     t.index ["model_id"], name: "index_model_files_on_model_id"
     t.index ["presupported_version_id"], name: "index_model_files_on_presupported_version_id"
     t.index ["public_id"], name: "index_model_files_on_public_id"


### PR DESCRIPTION
Resolves #3890 

Will import files named "readme.txt", "readme.md", and "readme" into the notes field (ignoring case)