### PR TITLE
Removes deprecated devise sign_in bypass method

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -40,7 +40,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     authorize current_user
     if @first_use
       if current_user.update(account_update_params.merge(reset_password_token: nil))
-        sign_in(current_user, bypass: true)
+        bypass_sign_in current_user
         redirect_to root_path, notice: t("devise.registrations.update.setup_complete")
       else
         render "first_use"


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [x] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

Devise [deprecated](https://github.com/heartcombo/devise/blob/main/lib/devise/controllers/sign_in_out.rb#L41-L48) the previous way of bypassing sign in. With Rails 8, this will throw a 500 error when starting in single-user mode for the first time.

## Linked issues

<!--
Does this PR resolve an issue? If so, please state "resolves #{number}" here.
Mention any other linked issues or PRs as well, even if this PR doesn't resolve them completely.
-->

## Description of changes

<!--
Please add details of what's been added, removed or fixed.
Describe any choices made, why you did things a certain way.
Are there any expected consequences of this PR?
Include screenshots if applicable.
-->
