### PR TITLE
Improve download creation process

### DIFF
--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -41,7 +41,7 @@ class ModelsController < ApplicationController
         render layout: "card_list_page"
       end
       format.zip do
-        download = ArchiveDownloadService.new(model: @model, selection: params[:selection])
+        download = ArchiveDownloadService.new(model: @model, selection: params[:selection].gsub(/\W/, ""))
         download.prepare
         download.wait_until_ready # synchronous wait for archive to be ready, for now
         send_file(download.pathname, filename: download.filename, type: :zip, disposition: :attachment)

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -41,7 +41,7 @@ class ModelsController < ApplicationController
         render layout: "card_list_page"
       end
       format.zip do
-        download = ArchiveDownloadService.new(model: @model, selection: params[:selection].gsub(/\W/, ""))
+        download = ArchiveDownloadService.new(model: @model, selection: params[:selection])
         download.prepare
         download.wait_until_ready # synchronous wait for archive to be ready, for now
         send_file(download.pathname, filename: download.filename, type: :zip, disposition: :attachment)

--- a/app/services/archive_download_service.rb
+++ b/app/services/archive_download_service.rb
@@ -3,7 +3,7 @@ class ArchiveDownloadService
 
   def initialize(model:, selection:)
     @model = model
-    @selection = selection
+    @selection = sanitize selection
     @tmpdir = LibraryUploader.find_storage(:cache).directory
     @pathname = File.join(@tmpdir, "#{@model.updated_at.to_time.to_i}-#{@model.id}-#{@selection}.zip")
     @tmpfile = File.join(@tmpdir, Digest::SHA256.hexdigest(@pathname))
@@ -40,6 +40,10 @@ class ArchiveDownloadService
   end
 
   private
+
+  def sanitize(selection)
+    selection.gsub(/\W/, "")
+  end
 
   def file_list(model, selection)
     scope = model.model_files

--- a/app/services/archive_download_service.rb
+++ b/app/services/archive_download_service.rb
@@ -1,0 +1,75 @@
+require "digest/sha1"
+
+class ArchiveDownloadService
+  attr_reader :pathname
+
+  def initialize(model:, selection:)
+    @model = model
+    @selection = selection
+    @tmpdir = LibraryUploader.find_storage(:cache).directory
+    @pathname = File.join(@tmpdir, "#{@model.updated_at.to_time.to_i}-#{@model.id}-#{@selection}.zip")
+    @tmpfile = File.join(@tmpdir, Digest::SHA1.hexdigest(@pathname))
+  end
+
+  def filename
+    [
+      @model.slug,
+      @selection
+    ].compact.join("-") + ".zip"
+  end
+
+  def ready?
+    File.exist?(@pathname)
+  end
+
+  def preparing?
+    File.exist?(@tmpfile)
+  end
+
+  def prepare
+    return if ready? || preparing?
+
+    tmpfile = File.join(@tmpdir, "#{SecureRandom.urlsafe_base64}.zip")
+    write_archive(tmpfile, file_list(@model, @selection))
+    FileUtils.mv(tmpfile, @pathname)
+  end
+
+  def wait_until_ready
+    loop do
+      break if ready?
+      sleep(1)
+    end
+  end
+
+  private
+
+  def file_list(model, selection)
+    scope = model.model_files
+    case selection
+    when nil
+      scope
+    when "supported"
+      scope.where(presupported: true)
+    when "unsupported"
+      scope.where(presupported: false)
+    else
+      scope.select { |f| f.extension == selection }
+    end
+  end
+
+  def write_archive(filename, files)
+    Archive.write_open_filename(filename, Archive::COMPRESSION_COMPRESS, Archive::FORMAT_ZIP) do |archive|
+      files.each do |file|
+        archive.new_entry do |entry|
+          entry.pathname = file.filename
+          entry.size = file.size
+          entry.filetype = Archive::Entry::FILE
+          entry.mtime = file.mtime
+          entry.ctime = file.ctime
+          archive.write_header entry
+          archive.write_data file.attachment.read
+        end
+      end
+    end
+  end
+end

--- a/app/services/archive_download_service.rb
+++ b/app/services/archive_download_service.rb
@@ -1,5 +1,3 @@
-require "digest/sha1"
-
 class ArchiveDownloadService
   attr_reader :pathname
 
@@ -8,7 +6,7 @@ class ArchiveDownloadService
     @selection = selection
     @tmpdir = LibraryUploader.find_storage(:cache).directory
     @pathname = File.join(@tmpdir, "#{@model.updated_at.to_time.to_i}-#{@model.id}-#{@selection}.zip")
-    @tmpfile = File.join(@tmpdir, Digest::SHA1.hexdigest(@pathname))
+    @tmpfile = File.join(@tmpdir, Digest::SHA256.hexdigest(@pathname))
   end
 
   def filename


### PR DESCRIPTION
Resolves #4033 

Recently we did a quick fix for broken downloads, which made every download a separate process and removed the caching. This PR reinstates that caching with fixes for concurrent downloads, along with a refactor of download creation into a service object. 

In a followup PR, we will then turn that archive creation into a background job, and show current state of the download (request, preparing, ready) in the UI.