### PR TITLE
Fix error with parameter format on user settings page

### DIFF
--- a/app/views/devise/registrations/_file_list_settings.html.erb
+++ b/app/views/devise/registrations/_file_list_settings.html.erb
@@ -1,12 +1,14 @@
-<div class="card mb-2">
-  <h3 class="card-header"><%= t(".heading") %></h3>
-  <div class="card-body">
-    <p class="lead"><%= t(".summary") %></p>
-    <div class="row">
-      <%= form.label nil, t(".hide_presupported_versions.label"), for: "file_list_settings[hide_presupported_versions]", class: "col col-form-label" %>
-      <div class="col form-check form-switch">
-        <%= form.check_box "file_list_settings[hide_presupported_versions]", checked: file_list_settings["hide_presupported_versions"], class: "form-check-input" %>
+<%= form.fields_for :file_list_settings do |file_list_settings_form| %>
+  <div class="card mb-2">
+    <h3 class="card-header"><%= t(".heading") %></h3>
+    <div class="card-body">
+      <p class="lead"><%= t(".summary") %></p>
+      <div class="row">
+        <%= file_list_settings_form.label nil, t(".hide_presupported_versions.label"), for: :hide_presupported_versions, class: "col col-form-label" %>
+        <div class="col form-check form-switch">
+          <%= file_list_settings_form.check_box :hide_presupported_versions, checked: file_list_settings["hide_presupported_versions"], class: "form-check-input" %>
+        </div>
       </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/devise/registrations/_file_list_settings.html.erb
+++ b/app/views/devise/registrations/_file_list_settings.html.erb
@@ -5,7 +5,7 @@
     <div class="row">
       <%= form.label nil, t(".hide_presupported_versions.label"), for: "file_list_settings[hide_presupported_versions]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
-        <%= form.check_box "file_list_settings[hide_presupported_versions]", checked: @user.file_list_settings["hide_presupported_versions"], class: "form-check-input" %>
+        <%= form.check_box "file_list_settings[hide_presupported_versions]", checked: file_list_settings["hide_presupported_versions"], class: "form-check-input" %>
       </div>
     </div>
   </div>

--- a/app/views/devise/registrations/_general_settings.html.erb
+++ b/app/views/devise/registrations/_general_settings.html.erb
@@ -3,9 +3,9 @@
   <div class="card-body">
 
     <div class="row mb-2">
-      <%= form.label nil, t(".interface_language.label"), for: "interface_language", class: "col col-form-label" %>
+      <%= form.label nil, t(".interface_language.label"), for: :interface_language, class: "col col-form-label" %>
       <div class="col">
-        <%= form.select "interface_language",
+        <%= form.select :interface_language,
               @languages,
               {selected: @user.interface_language},
               {class: "form-select"} %>
@@ -14,9 +14,9 @@
     </div>
 
     <div class="row">
-      <%= form.label nil, t(".sensitive_content.label"), for: "sensitive_content_handling", class: "col col-form-label" %>
+      <%= form.label nil, t(".sensitive_content.label"), for: :sensitive_content_handling, class: "col col-form-label" %>
       <div class="col">
-        <%= form.select "sensitive_content_handling",
+        <%= form.select :sensitive_content_handling,
               [
                 [t(".sensitive_content.show"), nil],
                 [t(".sensitive_content.mask"), "mask"],

--- a/app/views/devise/registrations/_pagination_settings.html.erb
+++ b/app/views/devise/registrations/_pagination_settings.html.erb
@@ -9,25 +9,25 @@
     <div class="row">
       <%= form.label nil, t(".models.label"), for: "pagination_settings[models]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
-        <%= form.check_box "pagination_settings[models]", checked: @user.pagination_settings["models"], class: "form-check-input" %>
+        <%= form.check_box "pagination_settings[models]", checked: pagination_settings["models"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
       <%= form.label nil, t(".creators.label"), for: "pagination_settings[creators]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
-        <%= form.check_box "pagination_settings[creators]", checked: @user.pagination_settings["creators"], class: "form-check-input" %>
+        <%= form.check_box "pagination_settings[creators]", checked: pagination_settings["creators"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
       <%= form.label nil, t(".collections.label"), for: "pagination_settings[collections]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
-        <%= form.check_box "pagination_settings[collections]", checked: @user.pagination_settings["collections"], class: "form-check-input" %>
+        <%= form.check_box "pagination_settings[collections]", checked: pagination_settings["collections"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
       <%= form.label nil, t(".per_page.label"), for: "pagination_settings[per_page]", class: "col col-form-label" %>
       <div class="col">
-        <%= form.number_field "pagination_settings[per_page]", value: @user.pagination_settings["per_page"], in: 1..100, class: "form-control" %>
+        <%= form.number_field "pagination_settings[per_page]", value: pagination_settings["per_page"], in: 1..100, class: "form-control" %>
       </div>
     </div>
   </div>

--- a/app/views/devise/registrations/_pagination_settings.html.erb
+++ b/app/views/devise/registrations/_pagination_settings.html.erb
@@ -1,34 +1,36 @@
-<div class="card mb-2">
-  <h3 class="card-header"><%= t(".heading") %></h3>
-  <div class="card-body">
+<%= form.fields_for :pagination_settings do |pagination_settings_form| %>
+  <div class="card mb-2">
+    <h3 class="card-header"><%= t(".heading") %></h3>
+    <div class="card-body">
 
-    <p class='lead'>
-      <%= t(".description") %>
-    </p>
+      <p class='lead'>
+        <%= t(".description") %>
+      </p>
 
-    <div class="row">
-      <%= form.label nil, t(".models.label"), for: "pagination_settings[models]", class: "col col-form-label" %>
-      <div class="col form-check form-switch">
-        <%= form.check_box "pagination_settings[models]", checked: pagination_settings["models"], class: "form-check-input" %>
+      <div class="row">
+        <%= pagination_settings_form.label nil, t(".models.label"), for: :models, class: "col col-form-label" %>
+        <div class="col form-check form-switch">
+          <%= pagination_settings_form.check_box :models, checked: pagination_settings["models"], class: "form-check-input" %>
+        </div>
       </div>
-    </div>
-    <div class="row">
-      <%= form.label nil, t(".creators.label"), for: "pagination_settings[creators]", class: "col col-form-label" %>
-      <div class="col form-check form-switch">
-        <%= form.check_box "pagination_settings[creators]", checked: pagination_settings["creators"], class: "form-check-input" %>
+      <div class="row">
+        <%= pagination_settings_form.label nil, t(".creators.label"), for: :creators, class: "col col-form-label" %>
+        <div class="col form-check form-switch">
+          <%= pagination_settings_form.check_box :creators, checked: pagination_settings["creators"], class: "form-check-input" %>
+        </div>
       </div>
-    </div>
-    <div class="row">
-      <%= form.label nil, t(".collections.label"), for: "pagination_settings[collections]", class: "col col-form-label" %>
-      <div class="col form-check form-switch">
-        <%= form.check_box "pagination_settings[collections]", checked: pagination_settings["collections"], class: "form-check-input" %>
+      <div class="row">
+        <%= pagination_settings_form.label nil, t(".collections.label"), for: :collections, class: "col col-form-label" %>
+        <div class="col form-check form-switch">
+          <%= pagination_settings_form.check_box :collections, checked: pagination_settings["collections"], class: "form-check-input" %>
+        </div>
       </div>
-    </div>
-    <div class="row">
-      <%= form.label nil, t(".per_page.label"), for: "pagination_settings[per_page]", class: "col col-form-label" %>
-      <div class="col">
-        <%= form.number_field "pagination_settings[per_page]", value: pagination_settings["per_page"], in: 1..100, class: "form-control" %>
+      <div class="row">
+        <%= pagination_settings_form.label nil, t(".per_page.label"), for: :per_page, class: "col col-form-label" %>
+        <div class="col">
+          <%= pagination_settings_form.number_field :per_page, value: pagination_settings["per_page"], in: 1..100, class: "form-control" %>
+        </div>
       </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/devise/registrations/_problem_settings.html.erb
+++ b/app/views/devise/registrations/_problem_settings.html.erb
@@ -1,22 +1,24 @@
-<div class="card mb-2">
-  <h3 class="card-header"><%= t(".title") %></h3>
-  <div class="card-body">
-    <p class='lead'>
-      <%= t(".description") %>
-    </p>
-    <% Problem::CATEGORIES.each do |category| %>
-      <% next if Problem::DEFAULT_SEVERITIES[category].nil? # Skip deprecated categories; they don't appear in the defaults list %>
-      <div class="row">
-        <%= form.label nil, t("problems.categories.%{c}" % {c: category}),
-              for: "problem_settings[#{category}]",
-              class: "col col-form-label" %>
-        <div class="col">
-          <%= form.select "problem_settings[#{category}]",
-                Problem::SEVERITIES.map { |s| [t("problems.severities.%{s}" % {s: s}), s] },
-                {selected: @user.problem_severity(category)},
-                class: "form-select" %>
+<%= form.fields_for :problem_settings do |problem_settings_form| %>
+  <div class="card mb-2">
+    <h3 class="card-header"><%= t(".title") %></h3>
+    <div class="card-body">
+      <p class='lead'>
+        <%= t(".description") %>
+      </p>
+      <% Problem::CATEGORIES.each do |category| %>
+        <% next if Problem::DEFAULT_SEVERITIES[category].nil? # Skip deprecated categories; they don't appear in the defaults list %>
+        <div class="row">
+          <%= problem_settings_form.label nil, t("problems.categories.%{c}" % {c: category}),
+                for: category,
+                class: "col col-form-label" %>
+          <div class="col">
+            <%= problem_settings_form.select category,
+                  Problem::SEVERITIES.map { |s| [t("problems.severities.%{s}" % {s: s}), s] },
+                  {selected: @user.problem_severity(category)},
+                  class: "form-select" %>
+          </div>
         </div>
-      </div>
-    <% end %>
+      <% end %>
+    </div>
   </div>
-</div>
+<% end %>

--- a/app/views/devise/registrations/_renderer_settings.html.erb
+++ b/app/views/devise/registrations/_renderer_settings.html.erb
@@ -1,66 +1,68 @@
-<div class="card mb-2">
-  <h3 class="card-header"><%= t(".heading") %></h3>
-  <div class="card-body">
-    <p class='lead'>
-      <%= t(".description") %>
-    </p>
-    <div class="row">
-      <%= form.label nil, t(".auto_load_max_size.label"), for: "renderer_settings[auto_load_max_size]", class: "col col-form-label" %>
-      <div class="col">
-        <%= form.select "renderer_settings[auto_load_max_size]",
-              [
-                [t(".auto_load_max_size.never"), 0],
-                [t(".auto_load_max_size.under_2"), 2],
-                [t(".auto_load_max_size.under_4"), 4],
-                [t(".auto_load_max_size.under_8"), 8],
-                [t(".auto_load_max_size.under_16"), 16],
-                [t(".auto_load_max_size.under_32"), 32],
-                [t(".auto_load_max_size.under_64"), 64],
-                [t(".auto_load_max_size.under_128"), 128],
-                [t(".auto_load_max_size.under_256"), 256],
-                [t(".auto_load_max_size.under_512"), 512],
-                [t(".auto_load_max_size.under_1024"), 1024],
-                [t(".auto_load_max_size.always"), 9_999_999]
-              ],
-              {selected: renderer_settings["auto_load_max_size"] || 9_999_999},
-              {class: "form-select"} %>
+<%= form.fields_for :renderer_settings do |renderer_settings_form| %>
+  <div class="card mb-2">
+    <h3 class="card-header"><%= t(".heading") %></h3>
+    <div class="card-body">
+      <p class='lead'>
+        <%= t(".description") %>
+      </p>
+      <div class="row">
+        <%= renderer_settings_form.label nil, t(".auto_load_max_size.label"), for: :auto_load_max_size, class: "col col-form-label" %>
+        <div class="col">
+          <%= renderer_settings_form.select :auto_load_max_size,
+                [
+                  [t(".auto_load_max_size.never"), 0],
+                  [t(".auto_load_max_size.under_2"), 2],
+                  [t(".auto_load_max_size.under_4"), 4],
+                  [t(".auto_load_max_size.under_8"), 8],
+                  [t(".auto_load_max_size.under_16"), 16],
+                  [t(".auto_load_max_size.under_32"), 32],
+                  [t(".auto_load_max_size.under_64"), 64],
+                  [t(".auto_load_max_size.under_128"), 128],
+                  [t(".auto_load_max_size.under_256"), 256],
+                  [t(".auto_load_max_size.under_512"), 512],
+                  [t(".auto_load_max_size.under_1024"), 1024],
+                  [t(".auto_load_max_size.always"), 9_999_999]
+                ],
+                {selected: renderer_settings["auto_load_max_size"] || 9_999_999},
+                {class: "form-select"} %>
+        </div>
       </div>
-    </div>
-    <div class="row">
-      <%= form.label nil, t(".show_grid.label"), for: "renderer_settings[show_grid]", class: "col col-form-label" %>
-      <div class="col form-check form-switch">
-        <%= form.check_box "renderer_settings[show_grid]", checked: renderer_settings["show_grid"], class: "form-check-input" %>
+      <div class="row">
+        <%= renderer_settings_form.label nil, t(".show_grid.label"), for: :show_grid, class: "col col-form-label" %>
+        <div class="col form-check form-switch">
+          <%= renderer_settings_form.check_box :show_grid, checked: renderer_settings["show_grid"], class: "form-check-input" %>
+        </div>
       </div>
-    </div>
-    <div class="row">
-      <%= form.label nil, t(".grid_width.label"), for: "renderer_settings[grid_width]", class: "col col-form-label" %>
-      <div class="col">
-        <%= form.number_field "renderer_settings[grid_width]", value: renderer_settings["grid_width"], class: "form-control" %>
+      <div class="row">
+        <%= renderer_settings_form.label nil, t(".grid_width.label"), for: :grid_width, class: "col col-form-label" %>
+        <div class="col">
+          <%= renderer_settings_form.number_field :grid_width, value: renderer_settings["grid_width"], class: "form-control" %>
+        </div>
       </div>
-    </div>
-    <div class="row">
-      <%= form.label nil, t(".enable_pan_zoom.label"), for: "renderer_settings[enable_pan_zoom]", class: "col col-form-label" %>
-      <div class="col form-check form-switch">
-        <%= form.check_box "renderer_settings[enable_pan_zoom]", checked: renderer_settings["enable_pan_zoom"], class: "form-check-input" %>
+      <div class="row">
+        <%= renderer_settings_form.label nil, t(".enable_pan_zoom.label"), for: :enable_pan_zoom, class: "col col-form-label" %>
+        <div class="col form-check form-switch">
+          <%= renderer_settings_form.check_box :enable_pan_zoom, checked: renderer_settings["enable_pan_zoom"], class: "form-check-input" %>
+        </div>
       </div>
-    </div>
-    <div class="row">
-      <%= form.label nil, t(".background_colour.label"), for: "renderer_settings[background_colour]", class: "col col-form-label" %>
-      <div class="col">
-        <%= form.color_field "renderer_settings[background_colour]", value: renderer_settings["background_colour"], class: "form-control" %>
+      <div class="row">
+        <%= renderer_settings_form.label nil, t(".background_colour.label"), for: :background_colour, class: "col col-form-label" %>
+        <div class="col">
+          <%= renderer_settings_form.color_field :background_colour, value: renderer_settings["background_colour"], class: "form-control" %>
+        </div>
       </div>
-    </div>
-    <div class="row">
-      <%= form.label nil, t(".render_style.label"), for: "renderer_settings[render_style]", class: "col col-form-label" %>
-      <div class="col">
-        <%= form.select "renderer_settings[render_style]", [[t(".render_style.normals"), "normals"], [t(".render_style.lambert"), "lambert"], [t(".render_style.shadowed"), "shadowed"]], {selected: renderer_settings["render_style"]}, {class: "form-select"} %>
+      <div class="row">
+        <%= renderer_settings_form.label nil, t(".render_style.label"), for: :render_style, class: "col col-form-label" %>
+        <div class="col">
+          <%= renderer_settings_form.select :render_style, [[t(".render_style.normals"), "normals"], [t(".render_style.lambert"), "lambert"], [t(".render_style.shadowed"), "shadowed"]], {selected: renderer_settings["render_style"]}, {class: "form-select"} %>
+        </div>
       </div>
-    </div>
-    <div class="row">
-      <%= form.label nil, t(".object_colour.label"), for: "renderer_settings[object_colour]", class: "col col-form-label" %>
-      <div class="col">
-        <%= form.color_field "renderer_settings[object_colour]", value: renderer_settings["object_colour"], class: "form-control" %>
+      <div class="row">
+        <%= renderer_settings_form.label nil, t(".object_colour.label"), for: :object_colour, class: "col col-form-label" %>
+        <div class="col">
+          <%= renderer_settings_form.color_field :object_colour, value: renderer_settings["object_colour"], class: "form-control" %>
+        </div>
       </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/devise/registrations/_renderer_settings.html.erb
+++ b/app/views/devise/registrations/_renderer_settings.html.erb
@@ -22,44 +22,44 @@
                 [t(".auto_load_max_size.under_1024"), 1024],
                 [t(".auto_load_max_size.always"), 9_999_999]
               ],
-              {selected: @user.renderer_settings["auto_load_max_size"] || 9_999_999},
+              {selected: renderer_settings["auto_load_max_size"] || 9_999_999},
               {class: "form-select"} %>
       </div>
     </div>
     <div class="row">
       <%= form.label nil, t(".show_grid.label"), for: "renderer_settings[show_grid]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
-        <%= form.check_box "renderer_settings[show_grid]", checked: @user.renderer_settings["show_grid"], class: "form-check-input" %>
+        <%= form.check_box "renderer_settings[show_grid]", checked: renderer_settings["show_grid"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
       <%= form.label nil, t(".grid_width.label"), for: "renderer_settings[grid_width]", class: "col col-form-label" %>
       <div class="col">
-        <%= form.number_field "renderer_settings[grid_width]", value: @user.renderer_settings["grid_width"], class: "form-control" %>
+        <%= form.number_field "renderer_settings[grid_width]", value: renderer_settings["grid_width"], class: "form-control" %>
       </div>
     </div>
     <div class="row">
       <%= form.label nil, t(".enable_pan_zoom.label"), for: "renderer_settings[enable_pan_zoom]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
-        <%= form.check_box "renderer_settings[enable_pan_zoom]", checked: @user.renderer_settings["enable_pan_zoom"], class: "form-check-input" %>
+        <%= form.check_box "renderer_settings[enable_pan_zoom]", checked: renderer_settings["enable_pan_zoom"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
       <%= form.label nil, t(".background_colour.label"), for: "renderer_settings[background_colour]", class: "col col-form-label" %>
       <div class="col">
-        <%= form.color_field "renderer_settings[background_colour]", value: @user.renderer_settings["background_colour"], class: "form-control" %>
+        <%= form.color_field "renderer_settings[background_colour]", value: renderer_settings["background_colour"], class: "form-control" %>
       </div>
     </div>
     <div class="row">
       <%= form.label nil, t(".render_style.label"), for: "renderer_settings[render_style]", class: "col col-form-label" %>
       <div class="col">
-        <%= form.select "renderer_settings[render_style]", [[t(".render_style.normals"), "normals"], [t(".render_style.lambert"), "lambert"], [t(".render_style.shadowed"), "shadowed"]], {selected: @user.renderer_settings["render_style"]}, {class: "form-select"} %>
+        <%= form.select "renderer_settings[render_style]", [[t(".render_style.normals"), "normals"], [t(".render_style.lambert"), "lambert"], [t(".render_style.shadowed"), "shadowed"]], {selected: renderer_settings["render_style"]}, {class: "form-select"} %>
       </div>
     </div>
     <div class="row">
       <%= form.label nil, t(".object_colour.label"), for: "renderer_settings[object_colour]", class: "col col-form-label" %>
       <div class="col">
-        <%= form.color_field "renderer_settings[object_colour]", value: @user.renderer_settings["object_colour"], class: "form-control" %>
+        <%= form.color_field "renderer_settings[object_colour]", value: renderer_settings["object_colour"], class: "form-control" %>
       </div>
     </div>
   </div>

--- a/app/views/devise/registrations/_tag_cloud_settings.html.erb
+++ b/app/views/devise/registrations/_tag_cloud_settings.html.erb
@@ -1,32 +1,34 @@
-<div class="card mb-2">
-  <h3 class="card-header"><%= t(".heading") %></h3>
-  <div class="card-body">
-    <div class="row">
-      <%= form.label nil, t(".threshold.label"), for: "tag_cloud_settings[threshold]", class: "col col-form-label" %>
-      <div class="col">
-        <%= form.number_field "tag_cloud_settings[threshold]", value: tag_cloud_settings["threshold"], class: "form-control" %>
+<%= form.fields_for :tag_cloud_settings do |tag_cloud_settings_form| %>
+  <div class="card mb-2">
+    <h3 class="card-header"><%= t(".heading") %></h3>
+    <div class="card-body">
+      <div class="row">
+        <%= tag_cloud_settings_form.label nil, t(".threshold.label"), for: :threshold, class: "col col-form-label" %>
+        <div class="col">
+          <%= tag_cloud_settings_form.number_field :threshold, value: tag_cloud_settings["threshold"], class: "form-control" %>
+        </div>
       </div>
-    </div>
-    <div class="row">
-      <%= form.label nil, t(".heatmap.label"), for: "tag_cloud_settings[heatmap]", class: "col col-form-label" %>
-      <div class="col form-check form-switch">
-        <%= form.check_box "tag_cloud_settings[heatmap]", checked: tag_cloud_settings["heatmap"], class: "form-check-input" %>
+      <div class="row">
+        <%= tag_cloud_settings_form.label nil, t(".heatmap.label"), for: :heatmap, class: "col col-form-label" %>
+        <div class="col form-check form-switch">
+          <%= tag_cloud_settings_form.check_box :heatmap, checked: tag_cloud_settings["heatmap"], class: "form-check-input" %>
+        </div>
       </div>
-    </div>
-    <div class="row">
-      <%= form.label nil, t(".sorting.label"), for: "tag_cloud_settings[sorting]", class: "col col-form-label" %>
-      <div class="col">
-        <%= form.select "tag_cloud_settings[sorting]",
-              [[t(".sorting.frequency"), nil], [t(".sorting.alphabetical"), "alphabetical"]],
-              {selected: tag_cloud_settings["sorting"]},
-              class: "form-select" %>
+      <div class="row">
+        <%= tag_cloud_settings_form.label nil, t(".sorting.label"), for: :sorting, class: "col col-form-label" %>
+        <div class="col">
+          <%= tag_cloud_settings_form.select :sorting,
+                [[t(".sorting.frequency"), nil], [t(".sorting.alphabetical"), "alphabetical"]],
+                {selected: tag_cloud_settings["sorting"]},
+                class: "form-select" %>
+        </div>
       </div>
-    </div>
-    <div class="row mb-2">
-      <%= form.label nil, t(".keypair.label"), for: "tag_cloud_settings[keypair]", class: "col col-form-label" %>
-      <div class="col form-check form-switch">
-        <%= form.check_box "tag_cloud_settings[keypair]", checked: tag_cloud_settings["keypair"], class: "form-check-input" %>
+      <div class="row mb-2">
+        <%= tag_cloud_settings_form.label nil, t(".keypair.label"), for: :keypair, class: "col col-form-label" %>
+        <div class="col form-check form-switch">
+          <%= tag_cloud_settings_form.check_box :keypair, checked: tag_cloud_settings["keypair"], class: "form-check-input" %>
+        </div>
       </div>
     </div>
   </div>
-</div>
+<% end %>

--- a/app/views/devise/registrations/_tag_cloud_settings.html.erb
+++ b/app/views/devise/registrations/_tag_cloud_settings.html.erb
@@ -4,13 +4,13 @@
     <div class="row">
       <%= form.label nil, t(".threshold.label"), for: "tag_cloud_settings[threshold]", class: "col col-form-label" %>
       <div class="col">
-        <%= form.number_field "tag_cloud_settings[threshold]", value: @user.tag_cloud_settings["threshold"], class: "form-control" %>
+        <%= form.number_field "tag_cloud_settings[threshold]", value: tag_cloud_settings["threshold"], class: "form-control" %>
       </div>
     </div>
     <div class="row">
       <%= form.label nil, t(".heatmap.label"), for: "tag_cloud_settings[heatmap]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
-        <%= form.check_box "tag_cloud_settings[heatmap]", checked: @user.tag_cloud_settings["heatmap"], class: "form-check-input" %>
+        <%= form.check_box "tag_cloud_settings[heatmap]", checked: tag_cloud_settings["heatmap"], class: "form-check-input" %>
       </div>
     </div>
     <div class="row">
@@ -18,14 +18,14 @@
       <div class="col">
         <%= form.select "tag_cloud_settings[sorting]",
               [[t(".sorting.frequency"), nil], [t(".sorting.alphabetical"), "alphabetical"]],
-              {selected: @user.tag_cloud_settings["sorting"]},
+              {selected: tag_cloud_settings["sorting"]},
               class: "form-select" %>
       </div>
     </div>
     <div class="row mb-2">
       <%= form.label nil, t(".keypair.label"), for: "tag_cloud_settings[keypair]", class: "col col-form-label" %>
       <div class="col form-check form-switch">
-        <%= form.check_box "tag_cloud_settings[keypair]", checked: @user.tag_cloud_settings["keypair"], class: "form-check-input" %>
+        <%= form.check_box "tag_cloud_settings[keypair]", checked: tag_cloud_settings["keypair"], class: "form-check-input" %>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Use `fields_for` instead of the nested square-bracket strings that I had before.

Resolves #4100, as well as the duplicates #4108 and #4104.