### PR TITLE
Show download readiness state on download buttons

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -14,6 +14,7 @@ $ra-font-path: "https://cdn.jsdelivr.net/npm/@infinizhen/rpg-awesome-continued@1
 @import 'src/links';
 @import 'src/models';
 @import 'src/model_files';
+@import 'src/effects';
 
 @import '@selectize/selectize/dist/css/selectize.bootstrap5';
 

--- a/app/assets/stylesheets/src/effects.scss
+++ b/app/assets/stylesheets/src/effects.scss
@@ -1,0 +1,25 @@
+.icon-flip::before {
+	animation: flip 5s ease-in-out infinite;
+}
+
+@keyframes flip {
+	0% {
+		transform: rotate(0deg);
+	}
+
+	10% {
+		transform: rotate(180deg);
+	}
+
+	50% {
+		transform: rotate(180deg);
+	}
+
+	60% {
+		transform: rotate(360deg);
+	}
+
+	100% {
+		transform: rotate(360deg);
+	}
+}

--- a/app/components/download_button.rb
+++ b/app/components/download_button.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+class Components::DownloadButton < Components::Base
+  include Phlex::Rails::Helpers::LinkTo
+
+  def initialize(model:, format: :zip)
+    @model = model
+    @format = format
+  end
+
+  def before_template
+    @extensions = @model.file_extensions.excluding("json")
+    @has_supported_and_unsupported = @model.has_supported_and_unsupported?
+    @downloaders = {
+      nil => ArchiveDownloadService.new(model: @model, selection: nil)
+    }
+  end
+
+  def view_template
+    div class: "btn-group ml-auto mr-auto" do
+      link_to model_path(@model, format: @format), class: "btn btn-lg btn-primary", download: "download" do # i18n-tasks-use t('components.download_button.label')
+        icon("cloud-download", "")
+        whitespace
+        span { t("components.download_button.label") }
+      end
+      button(type: "button",
+        class: "btn btn-lg btn-primary dropdown-toggle dropdown-toggle-split",
+        "data-bs-toggle": "dropdown",
+        "aria-expanded": "false") do
+        span class: "visually-hidden" do
+          t("components.download_button.menu_header") # i18n-tasks-use t('components.download_button.menu_header')
+        end
+      end
+      ul class: "dropdown-menu" do
+        li class: "dropdown-header" do
+          t("components.download_button.menu_header") # i18n-tasks-use t('components.download_button.menu_header')
+        end
+        if @has_supported_and_unsupported
+          li do
+            link_to model_path(@model, format: @format, selection: "supported"), class: "dropdown-item", download: "download" do # i18n-tasks-use t('components.download_button.supported')
+              t("components.download_button.supported")
+            end
+          end
+          li do
+            link_to model_path(@model, format: @format, selection: "unsupported"), class: "dropdown-item", download: "download" do # i18n-tasks-use t('components.download_button.unsupported')
+              t("components.download_button.unsupported")
+            end
+          end
+          li { hr class: "dropdown-divider" }
+        end
+        @extensions&.compact&.map do |type|
+          li do
+            link_to model_path(@model, format: @format, selection: type), class: "dropdown-item", download: "download" do # i18n-tasks-use t('components.download_button.file_type')
+              t("components.download_button.file_type", type: type.upcase)
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/components/download_button.rb
+++ b/app/components/download_button.rb
@@ -11,14 +11,11 @@ class Components::DownloadButton < Components::Base
   def before_template
     @extensions = @model.file_extensions.excluding("json")
     @has_supported_and_unsupported = @model.has_supported_and_unsupported?
-    @downloaders = {
-      nil => ArchiveDownloadService.new(model: @model, selection: nil)
-    }
   end
 
   def view_template
     div class: "btn-group ml-auto mr-auto" do
-      download_link html_class: "btn btn-lg btn-primary", icon_name: "cloud-download"
+      download_link html_class: "btn btn-lg btn-primary"
       button(type: "button",
         class: "btn btn-lg btn-primary dropdown-toggle dropdown-toggle-split",
         "data-bs-toggle": "dropdown",
@@ -39,12 +36,17 @@ class Components::DownloadButton < Components::Base
     end
   end
 
-  def download_link(selection: nil, file_type: nil, html_class: "dropdown-item", icon_name: nil)
+  def download_link(selection: nil, file_type: nil, html_class: "dropdown-item")
+    downloader = ArchiveDownloadService.new(model: @model, selection: selection || file_type)
     link_to model_path(@model, format: @format, selection: selection || file_type), class: html_class, download: "download" do
-      if icon_name
-        icon(icon_name, "")
-        whitespace
+      if downloader.ready?
+        icon("cloud-download", t("components.download_button.download.ready"))
+      elsif downloader.preparing?
+        icon("hourglass-split", t("components.download_button.download.preparing"))
+      else
+        icon("hourglass-top", t("components.download_button.download.missing"))
       end
+      whitespace
       span do
         if file_type
           t("components.download_button.file_type", type: file_type.upcase)

--- a/app/components/download_button.rb
+++ b/app/components/download_button.rb
@@ -38,7 +38,19 @@ class Components::DownloadButton < Components::Base
 
   def download_link(selection: nil, file_type: nil, html_class: "dropdown-item")
     downloader = ArchiveDownloadService.new(model: @model, selection: selection || file_type)
-    link_to model_path(@model, format: @format, selection: selection || file_type), class: html_class, download: (downloader.ready? ? "download" : nil) do
+    link_options = {
+      class: html_class,
+      download: (downloader.ready? ? "download" : nil)
+    }
+    if downloader.preparing?
+      link_options.merge!(
+        disabled: true,
+        "aria-disabled": "true",
+        tabindex: -1,
+        class: html_class + " disabled"
+      )
+    end
+    link_to model_path(@model, format: @format, selection: selection || file_type), link_options do
       if downloader.ready?
         icon("cloud-download", t("components.download_button.download.ready"))
       elsif downloader.preparing?

--- a/app/components/download_button.rb
+++ b/app/components/download_button.rb
@@ -18,42 +18,42 @@ class Components::DownloadButton < Components::Base
 
   def view_template
     div class: "btn-group ml-auto mr-auto" do
-      link_to model_path(@model, format: @format), class: "btn btn-lg btn-primary", download: "download" do # i18n-tasks-use t('components.download_button.label')
-        icon("cloud-download", "")
-        whitespace
-        span { t("components.download_button.label") }
-      end
+      download_link html_class: "btn btn-lg btn-primary", icon_name: "cloud-download"
       button(type: "button",
         class: "btn btn-lg btn-primary dropdown-toggle dropdown-toggle-split",
         "data-bs-toggle": "dropdown",
         "aria-expanded": "false") do
-        span class: "visually-hidden" do
-          t("components.download_button.menu_header") # i18n-tasks-use t('components.download_button.menu_header')
-        end
+        span(class: "visually-hidden") { t("components.download_button.menu_header") }
       end
       ul class: "dropdown-menu" do
-        li class: "dropdown-header" do
-          t("components.download_button.menu_header") # i18n-tasks-use t('components.download_button.menu_header')
-        end
+        li(class: "dropdown-header") { t("components.download_button.menu_header") }
         if @has_supported_and_unsupported
-          li do
-            link_to model_path(@model, format: @format, selection: "supported"), class: "dropdown-item", download: "download" do # i18n-tasks-use t('components.download_button.supported')
-              t("components.download_button.supported")
-            end
-          end
-          li do
-            link_to model_path(@model, format: @format, selection: "unsupported"), class: "dropdown-item", download: "download" do # i18n-tasks-use t('components.download_button.unsupported')
-              t("components.download_button.unsupported")
-            end
-          end
+          li { download_link selection: "supported" }
+          li { download_link selection: "unsupported" }
           li { hr class: "dropdown-divider" }
         end
         @extensions&.compact&.map do |type|
-          li do
-            link_to model_path(@model, format: @format, selection: type), class: "dropdown-item", download: "download" do # i18n-tasks-use t('components.download_button.file_type')
-              t("components.download_button.file_type", type: type.upcase)
-            end
-          end
+          li { download_link file_type: type }
+        end
+      end
+    end
+  end
+
+  def download_link(selection: nil, file_type: nil, html_class: "dropdown-item", icon_name: nil)
+    link_to model_path(@model, format: @format, selection: selection || file_type), class: html_class, download: "download" do
+      if icon_name
+        icon(icon_name, "")
+        whitespace
+      end
+      span do
+        if file_type
+          t("components.download_button.file_type", type: file_type.upcase)
+        elsif selection
+          # i18n-tasks-use t('components.download_button.supported')
+          # i18n-tasks-use t('components.download_button.unsupported')
+          t("components.download_button.%{selection}" % {selection: selection})
+        else
+          t("components.download_button.label")
         end
       end
     end

--- a/app/components/download_button.rb
+++ b/app/components/download_button.rb
@@ -42,7 +42,7 @@ class Components::DownloadButton < Components::Base
       if downloader.ready?
         icon("cloud-download", t("components.download_button.download.ready"))
       elsif downloader.preparing?
-        icon("hourglass-split", t("components.download_button.download.preparing"))
+        icon("hourglass-split", t("components.download_button.download.preparing"), effect: "icon-flip")
       else
         icon("hourglass-top", t("components.download_button.download.missing"))
       end

--- a/app/components/download_button.rb
+++ b/app/components/download_button.rb
@@ -38,7 +38,7 @@ class Components::DownloadButton < Components::Base
 
   def download_link(selection: nil, file_type: nil, html_class: "dropdown-item")
     downloader = ArchiveDownloadService.new(model: @model, selection: selection || file_type)
-    link_to model_path(@model, format: @format, selection: selection || file_type), class: html_class, download: "download" do
+    link_to model_path(@model, format: @format, selection: selection || file_type), class: html_class, download: (downloader.ready? ? "download" : nil) do
       if downloader.ready?
         icon("cloud-download", t("components.download_button.download.ready"))
       elsif downloader.preparing?

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -35,9 +35,6 @@ class ModelsController < ApplicationController
         files = files.includes(:presupported_version, :problems)
         files = files.reject(&:is_image?)
         @groups = helpers.group(files)
-        @extensions = @model.file_extensions.excluding("json")
-        @has_supported_and_unsupported = @model.has_supported_and_unsupported?
-        @download_format = :zip
         render layout: "card_list_page"
       end
       format.zip do

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -11,13 +11,13 @@ module ApplicationHelper
     SiteSettings.site_icon.presence || "roundel.svg"
   end
 
-  def icon(icon, label, id: nil)
+  def icon(icon, label, id: nil, effect: nil)
     prefix = "bi"
     if icon.starts_with? "ra-"
       prefix = "ra"
       icon = icon.gsub("ra-", "")
     end
-    tag.i class: "#{prefix} #{prefix}-#{icon}", role: "img", title: label, id: id
+    tag.i class: "#{prefix} #{prefix}-#{icon} #{effect}", role: "img", title: label, id: id
   end
 
   def icon_for(klass)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,7 +17,8 @@ module ApplicationHelper
       prefix = "ra"
       icon = icon.gsub("ra-", "")
     end
-    tag.i class: "#{prefix} #{prefix}-#{icon} #{effect}", role: "img", title: label, id: id
+    classes = [prefix, "#{prefix}-#{icon}", effect].compact.join(" ")
+    tag.i class: classes, role: "img", title: label, id: id
   end
 
   def icon_for(klass)

--- a/app/services/archive_download_service.rb
+++ b/app/services/archive_download_service.rb
@@ -26,6 +26,7 @@ class ArchiveDownloadService
 
   def prepare
     return if ready? || preparing?
+    FileUtils.touch(@tmpfile)
     PrepareDownloadJob.perform_later(
       model_id: @model.id,
       selection: @selection,

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -111,23 +111,7 @@
   <% end %>
 
   <div class="mb-3 w-100 text-center">
-    <div class="btn-group ml-auto mr-auto">
-      <%= link_to safe_join([icon("cloud-download", ""), t(".download.label")], " "), model_path(@model, format: @download_format), class: "btn btn-lg btn-primary", download: "download" %>
-      <button type="button" class="btn btn-lg btn-primary dropdown-toggle dropdown-toggle-split" data-bs-toggle="dropdown" aria-expanded="false">
-        <span class="visually-hidden">Download options</span>
-      </button>
-      <ul class="dropdown-menu">
-        <li class="dropdown-header"><%= t(".download.menu_header") %></li>
-        <% if @has_supported_and_unsupported %>
-          <%= content_tag(:li) { link_to t(".download.supported"), model_path(@model, format: @download_format, selection: "supported"), class: "dropdown-item", download: "download" } %>
-          <%= content_tag(:li) { link_to t(".download.unsupported"), model_path(@model, format: @download_format, selection: "unsupported"), class: "dropdown-item", download: "download" } %>
-          <li><hr class="dropdown-divider"></li>
-        <% end %>
-        <% @extensions&.compact&.each do |type| %>
-          <%= content_tag(:li) { link_to t(".download.file_type", type: type.upcase), model_path(@model, format: @download_format, selection: type), class: "dropdown-item", download: "download" } %>
-        <% end %>
-      </ul>
-    </div>
+    <%= render Components::DownloadButton.new(model: @model) %>
   </div>
 
   <%= card :secondary, t("layouts.card_list_page.actions_heading") do %>

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -307,6 +307,12 @@ cs:
       skip_tags: Přeskočit seznam štítků
     title: Manyfold
   components:
+    download_button:
+      file_type: 'Pouze soubory %{type} '
+      label: Stáhnout vše
+      menu_header: Možnosti stažení
+      supported: Pouze podporované soubory
+      unsupported: Pouze nepodporované soubory
     follow_button:
       follow: Sledovat %{name}
       pending: Požadováno

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -307,6 +307,12 @@ de:
       skip_tags: Tag-Liste überspringen
     title: Manyfold
   components:
+    download_button:
+      file_type: "%{type} Dateien"
+      label: Alle herunterladen
+      menu_header: Download optionen
+      supported: Nur Dateien mit Support Struktur
+      unsupported: Nur Dateien ohne Support Struktur
     follow_button:
       follow: Folge %{name}
       pending: Angefordert

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -308,6 +308,12 @@ en:
       skip_tags: Skip tag list
     title: Manyfold
   components:
+    download_button:
+      file_type: "%{type} Files Only"
+      label: Download All
+      menu_header: Download Options
+      supported: Supported Files Only
+      unsupported: Unsupported Files Only
     follow_button:
       follow: Follow %{name}
       pending: Requested

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -309,6 +309,10 @@ en:
     title: Manyfold
   components:
     download_button:
+      download:
+        missing: Request download
+        preparing: Preparing download, please wait
+        ready: Ready to download
       file_type: "%{type} Files Only"
       label: Download All
       menu_header: Download Options

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -309,6 +309,12 @@ es:
       skip_tags: Saltar lista de etiquetas
     title: Manyfold
   components:
+    download_button:
+      file_type: Solo archivos %{type}
+      label: Descargar modelo
+      menu_header: Opciones de Descarga
+      supported: Sólo archivos compatibles
+      unsupported: Sólo archivos no compatibles
     follow_button:
       follow: Seguir %{name}
       pending: Requerido

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -307,6 +307,12 @@ fr:
       skip_tags: Sauter la liste des balises
     title: Manyfold
   components:
+    download_button:
+      file_type: Fichiers %{type} uniquement
+      label: Télécharger tout
+      menu_header: Options de téléchargement
+      supported: Fichiers pris en charge uniquement
+      unsupported: Fichiers non pris en charge uniquement
     follow_button:
       follow: Suivre %{name}
       pending: Demandé

--- a/config/locales/models/cs.yml
+++ b/config/locales/models/cs.yml
@@ -63,12 +63,6 @@ cs:
     scan:
       success: Spuštěna kontrola modelu.
     show:
-      download:
-        file_type: 'Pouze soubory %{type} '
-        label: Stáhnout vše
-        menu_header: Možnosti stažení
-        supported: Pouze podporované soubory
-        unsupported: Pouze nepodporované soubory
       files: Soubory
       files_card:
         bulk_edit: Upravit všechny soubory

--- a/config/locales/models/de.yml
+++ b/config/locales/models/de.yml
@@ -63,12 +63,6 @@ de:
     scan:
       success: Modell-Scan gestartet
     show:
-      download:
-        file_type: "%{type} Dateien"
-        label: Alle herunterladen
-        menu_header: Download optionen
-        supported: Nur Dateien mit Support Struktur
-        unsupported: Nur Dateien ohne Support Struktur
       files: Dateien
       files_card:
         bulk_edit: Alle Dateien bearbeiten

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -64,12 +64,6 @@ en:
     scan:
       success: Model scan started
     show:
-      download:
-        file_type: "%{type} Files Only"
-        label: Download All
-        menu_header: Download Options
-        supported: Supported Files Only
-        unsupported: Unsupported Files Only
       files: Files
       files_card:
         bulk_edit: Edit all files

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -64,6 +64,8 @@ en:
     scan:
       success: Model scan started
     show:
+      download_preparing: Download is being prepared, please wait.
+      download_requested: Download requested and will be ready soon, please wait.
       files: Files
       files_card:
         bulk_edit: Edit all files

--- a/config/locales/models/es.yml
+++ b/config/locales/models/es.yml
@@ -63,12 +63,6 @@ es:
     scan:
       success: Escaneo de modelos iniciado
     show:
-      download:
-        file_type: Solo archivos %{type}
-        label: Descargar modelo
-        menu_header: Opciones de Descarga
-        supported: Sólo archivos compatibles
-        unsupported: Sólo archivos no compatibles
       files: Archivos
       files_card:
         bulk_edit: Editar todos los archivos

--- a/config/locales/models/fr.yml
+++ b/config/locales/models/fr.yml
@@ -63,12 +63,6 @@ fr:
     scan:
       success: Début de l'analyse du modèle
     show:
-      download:
-        file_type: Fichiers %{type} uniquement
-        label: Télécharger tout
-        menu_header: Options de téléchargement
-        supported: Fichiers pris en charge uniquement
-        unsupported: Fichiers non pris en charge uniquement
       files: Fichiers
       files_card:
         bulk_edit: Modifier tous les fichiers

--- a/config/locales/models/nl.yml
+++ b/config/locales/models/nl.yml
@@ -63,12 +63,6 @@ nl:
     scan:
       success: Modelscan gestart
     show:
-      download:
-        file_type: Alleen %{type} Bestanden
-        label: Alles Downloaden
-        menu_header: Download Opties
-        supported: Alleen Ondersteunde Bestanden
-        unsupported: Alleen Niet-ondersteunde Bestanden
       files: Bestanden
       files_card:
         bulk_edit: Alle bestanden bewerken

--- a/config/locales/models/pl.yml
+++ b/config/locales/models/pl.yml
@@ -63,12 +63,6 @@ pl:
     scan:
       success: Rozpoczęto skanowanie modelów
     show:
-      download:
-        file_type: Tylko Pliki %{type}
-        label: Pobierz Wszystko
-        menu_header: Opcje Pobierania
-        supported: Tylko Obsługiwane Pliki
-        unsupported: Tylko Nieobsługiwane Pliki
       files: Pliki
       files_card:
         bulk_edit: Edytuj wszystkie pliki

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -307,6 +307,12 @@ nl:
       skip_tags: Taglijst overslaan
     title: Manyfold
   components:
+    download_button:
+      file_type: Alleen %{type} Bestanden
+      label: Alles Downloaden
+      menu_header: Download Opties
+      supported: Alleen Ondersteunde Bestanden
+      unsupported: Alleen Niet-ondersteunde Bestanden
     follow_button:
       follow: Volg %{name}
       pending:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -307,6 +307,12 @@ pl:
       skip_tags: Pomiń listę tagów
     title: Manyfold
   components:
+    download_button:
+      file_type: Tylko Pliki %{type}
+      label: Pobierz Wszystko
+      menu_header: Opcje Pobierania
+      supported: Tylko Obsługiwane Pliki
+      unsupported: Tylko Nieobsługiwane Pliki
     follow_button:
       follow: Obserwuj %{name}
       pending: Żądane


### PR DESCRIPTION
Resolves #4031 

Makes download generation async, makes download buttons into a "request download" if not available yet, and provides feedback messages.