### PR TITLE
Reorganise queues by priority

### DIFF
--- a/app/jobs/activity/creator_added_model_job.rb
+++ b/app/jobs/activity/creator_added_model_job.rb
@@ -1,5 +1,5 @@
 class Activity::CreatorAddedModelJob < ApplicationJob
-  queue_as :activity
+  queue_as :default
 
   def perform(model_id)
     model = Model.find(model_id)

--- a/app/jobs/analysis/analyse_model_file_job.rb
+++ b/app/jobs/analysis/analyse_model_file_job.rb
@@ -1,7 +1,7 @@
 require "string/similarity"
 
 class Analysis::AnalyseModelFileJob < ApplicationJob
-  queue_as :analysis
+  queue_as :low
   unique :until_executed
 
   def perform(file_id)

--- a/app/jobs/organize_model_job.rb
+++ b/app/jobs/organize_model_job.rb
@@ -1,5 +1,5 @@
 class OrganizeModelJob < ApplicationJob
-  queue_as :default
+  queue_as :high
 
   def perform(model_id)
     model = Model.find(model_id)

--- a/app/jobs/prepare_download_job.rb
+++ b/app/jobs/prepare_download_job.rb
@@ -1,5 +1,5 @@
 class PrepareDownloadJob < ApplicationJob
-  queue_as :default
+  queue_as :critical
   unique :until_executed
 
   def perform(model_id:, selection:, temp_file:, output_file:)

--- a/app/jobs/process_uploaded_file_job.rb
+++ b/app/jobs/process_uploaded_file_job.rb
@@ -1,5 +1,5 @@
 class ProcessUploadedFileJob < ApplicationJob
-  queue_as :default
+  queue_as :critical
 
   def perform(library_id, uploaded_file, owner: nil, creator_id: nil, collection_id: nil, tags: nil, license: nil, model: nil)
     # Find library

--- a/app/jobs/upgrade/backfill_data_packages.rb
+++ b/app/jobs/upgrade/backfill_data_packages.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Upgrade::BackfillDataPackages < ApplicationJob
-  queue_as :upgrade
+  queue_as :low
   unique :until_executed
 
   def perform

--- a/app/jobs/upgrade/disambiguate_usernames_job.rb
+++ b/app/jobs/upgrade/disambiguate_usernames_job.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class Upgrade::DisambiguateUsernamesJob < ApplicationJob
-  queue_as :upgrade
+  queue_as :low
   unique :until_executed
 
   def perform

--- a/app/jobs/upgrade/update_actors_job.rb
+++ b/app/jobs/upgrade/update_actors_job.rb
@@ -2,7 +2,7 @@
 
 require "federails/maintenance/actors_updater"
 class Upgrade::UpdateActorsJob < ApplicationJob
-  queue_as :upgrade
+  queue_as :low
   unique :until_executed
 
   def perform

--- a/config/workers/default.yml
+++ b/config/workers/default.yml
@@ -1,8 +1,12 @@
 ---
 :concurrency: <%= ENV.fetch("DEFAULT_WORKER_CONCURRENCY", 4) %>
 :queues:
+  - critical
+  - high
   - scan
-  - analysis
   - default
+  - low
+  # legacy queues kept for a while for upgrade compatibility
+  - analysis
   - activity
   - upgrade


### PR DESCRIPTION
uploading and downloading jobs are now `critical` so they get a worker fast. Then `high`, `scan` (legacy), `default`, and `low`.