### PR TITLE
More powerful search syntax

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -202,3 +202,5 @@ gem "turbo-rails", "~> 2.0"
 gem "stimulus-rails", "~> 1.3"
 
 gem "parslet", "~> 2.0"
+
+gem "scoped_search", "~> 4.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -748,6 +748,8 @@ GEM
       logger
     ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
+    scoped_search (4.2.0)
+      activerecord (>= 4.2.0)
     scout_apm (5.6.4)
       parser
     securerandom (0.4.1)
@@ -979,6 +981,7 @@ DEPENDENCIES
   rubocop-rspec
   rubocop-rspec_rails
   rubyzip (~> 2.4)
+  scoped_search (~> 4.2)
   scout_apm
   selenium-webdriver
   shrine (~> 3.6)

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -53,6 +53,11 @@ class Model < ApplicationRecord
   validates :license, spdx: true, allow_nil: true
   validates :public_id, multimodel_uniqueness: {case_sensitive: false, check: FederailsCommon::FEDIVERSE_USERNAMES}
 
+  scoped_search on: :name
+  scoped_search relation: :creator, on: :name
+  scoped_search relation: :collection, on: :name
+  scoped_search relation: :tags, on: :name, default_operator: :eq
+
   def parents
     Pathname.new(path).parent.descend.filter_map do |path|
       library.models.find_by(path: path.to_s)

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -54,8 +54,8 @@ class Model < ApplicationRecord
   validates :public_id, multimodel_uniqueness: {case_sensitive: false, check: FederailsCommon::FEDIVERSE_USERNAMES}
 
   scoped_search on: :name
-  scoped_search relation: :creator, on: :name
-  scoped_search relation: :collection, on: :name
+  scoped_search relation: :creator, on: :name, rename: :creator
+  scoped_search relation: :collection, on: :name, rename: :collection
   scoped_search relation: :tags, on: :name, default_operator: :eq, rename: :tag
 
   def parents

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -56,7 +56,7 @@ class Model < ApplicationRecord
   scoped_search on: :name
   scoped_search relation: :creator, on: :name
   scoped_search relation: :collection, on: :name
-  scoped_search relation: :tags, on: :name, default_operator: :eq
+  scoped_search relation: :tags, on: :name, default_operator: :eq, rename: :tag
 
   def parents
     Pathname.new(path).parent.descend.filter_map do |path|

--- a/app/services/search/model_search_service.rb
+++ b/app/services/search/model_search_service.rb
@@ -5,8 +5,7 @@ class Search::ModelSearchService
 
   def search(query)
     parse_tree = Search::QueryParserService.new.parse(query)
-    @scope.ransack(
-      Search::RansackQueryTransformer.new.apply(parse_tree)
-    ).result(distinct: true)
+    q = Search::ScopedSearchQueryTransformer.new.apply(parse_tree)
+    @scope.search_for(q).distinct
   end
 end

--- a/app/services/search/model_search_service.rb
+++ b/app/services/search/model_search_service.rb
@@ -4,8 +4,6 @@ class Search::ModelSearchService
   end
 
   def search(query)
-    parse_tree = Search::QueryParserService.new.parse(query)
-    q = Search::ScopedSearchQueryTransformer.new.apply(parse_tree)
-    @scope.search_for(q).distinct
+    @scope.search_for(query).distinct
   end
 end

--- a/app/services/search/scoped_search_query_transformer.rb
+++ b/app/services/search/scoped_search_query_transformer.rb
@@ -1,0 +1,4 @@
+class Search::ScopedSearchQueryTransformer < Parslet::Transform
+  rule(term: simple(:term)) { term.to_s }
+  rule(query: sequence(:terms)) { terms.map { |it| "\"#{it}\"" }.join(" or ") }
+end

--- a/spec/services/search/model_search_service_spec.rb
+++ b/spec/services/search/model_search_service_spec.rb
@@ -41,10 +41,17 @@ RSpec.describe Search::ModelSearchService do
   end
 
   it "searches for results with any of the specified terms" do
-    expect(service.search("cat in the hat").pluck(:name)).to eq [
+    expect(service.search("cat or in or the or hat").pluck(:name)).to eq [
       "cat in the hat",
       "hat on the cat",
       "bat on a hat"
+    ]
+  end
+
+  it "searches for results containing two unquoted terms" do
+    expect(service.search("the hat").pluck(:name)).to eq [
+      "cat in the hat",
+      "hat on the cat"
     ]
   end
 
@@ -54,36 +61,75 @@ RSpec.describe Search::ModelSearchService do
     ]
   end
 
-  it "searches for results which don't have an excluded term", pending: "awaiting implementation" do
-    expect(service.search("hat -cat").pluck(:name)).to eq [
+  it "searches for results which don't have an excluded term" do
+    expect(service.search("hat and not cat").pluck(:name)).to eq [
+      "bat on a hat"
+    ]
+  end
+
+  it "searches for AND combination of exclusions" do
+    expect(service.search("not cat and not hat").pluck(:name)).to eq [
       "bat on a mat"
     ]
   end
 
-  it "searches for results which have a compulsory word", pending: "awaiting implementation" do
-    expect(service.search("hat +on").pluck(:name)).to eq [
-      "hat on the cat",
+  it "searches for OR combination of exclusions" do
+    expect(service.search("not cat or not hat").pluck(:name)).to eq [
       "bat on a mat",
       "bat on a hat"
     ]
   end
 
-  it "searches for results which have a specific tag", pending: "awaiting implementation" do
-    expect(service.search("tag:cat").pluck(:name)).to eq [
+  it "searches for complex combinations" do
+    expect(service.search("(cat or hat) and not on").pluck(:name)).to eq [
       "cat in the hat"
     ]
   end
 
-  it "searches for results which don't have the specified tag", pending: "awaiting implementation" do
-    expect(service.search("-tag:frog").pluck(:name)).to eq [
+  it "searches for other complex combinations" do
+    expect(service.search("(cat or hat) and on").pluck(:name)).to eq [
+      "hat on the cat",
+      "bat on a hat"
+    ]
+  end
+
+  it "searches for results which have all the words" do
+    expect(service.search("hat on").pluck(:name)).to eq [
+      "hat on the cat",
+      "bat on a hat"
+    ]
+  end
+
+  it "searches for results which have a specific tag" do
+    expect(service.search("hat tag=cat").pluck(:name)).to eq [
+      "cat in the hat"
+    ]
+  end
+
+  it "searches for results which don't have the specified tag" do
+    expect(service.search("on tag != frog").pluck(:name)).to eq [
       "hat on the cat",
       "bat on a mat"
     ]
   end
 
-  it "finds results which have a required word and a required tag", pending: "awaiting implementation" do
-    expect(service.search("+on +tag:bat").pluck(:name)).to eq [
+  it "finds results which have a required word and a required tag" do
+    expect(service.search("on tag=frog").pluck(:name)).to eq [
       "bat on a hat"
+    ]
+  end
+
+  it "finds results with a combination of tags" do
+    expect(service.search("tag=frog tag=dog").pluck(:name)).to eq [
+      "cat in the hat"
+    ]
+  end
+
+  it "finds results with an OR combination of tags" do
+    expect(service.search("tag=frog or tag=dog").pluck(:name)).to eq [
+      "cat in the hat",
+      "bat on a hat",
+      "hat on the cat"
     ]
   end
 end

--- a/spec/services/search/model_search_service_spec.rb
+++ b/spec/services/search/model_search_service_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Search::ModelSearchService do
   end
 
   it "searches in collection names" do
-    expect(service.search("chiroptera").pluck(:name)).to eq [
+    expect(service.search("chiro").pluck(:name)).to eq [
       "bat on a mat",
       "bat on a hat"
     ]
@@ -130,6 +130,18 @@ RSpec.describe Search::ModelSearchService do
       "cat in the hat",
       "bat on a hat",
       "hat on the cat"
+    ]
+  end
+
+  it "search specifically by creator name" do
+    expect(service.search("on creator~dr").pluck(:name)).to eq [
+      "hat on the cat"
+    ]
+  end
+
+  it "filter specifically by collection name" do
+    expect(service.search("hat collection~chiro").pluck(:name)).to eq [
+      "bat on a hat"
     ]
   end
 end


### PR DESCRIPTION
We now use `scoped_search` syntax directly; see https://github.com/wvanbergen/scoped_search/wiki/Query-language. This is much much more powerful than the simple text match we had before.

Resolves #4178
Resolves #2398 
Resolves #2573 