### PR TITLE
Use DISTINCT ON for joining tables during search on PostgreSQL

### DIFF
--- a/app/services/search/model_search_service.rb
+++ b/app/services/search/model_search_service.rb
@@ -4,6 +4,14 @@ class Search::ModelSearchService
   end
 
   def search(query)
-    @scope.search_for(query).distinct
+    if ApplicationRecord.connection.adapter_name == "PostgreSQL"
+      @scope.where(
+        Model.select("DISTINCT ON (models.id) models.*") # rubocop:disable Pundit/UsePolicyScope
+          .search_for(query)
+          .pluck(:id) # rubocop:todo Rails/PluckInWhere
+      )
+    else
+      @scope.search_for(query).distinct
+    end
   end
 end


### PR DESCRIPTION
Hopefully resolves #4184. PostgreSQL errors if you do DISTINCT on a query that includes JSON fields; https://github.com/wvanbergen/scoped_search/issues/228 outlines the problem, where the joined SELECT includes too much, but PostgreSQL *does* have DISTINCT ON, which lets you specify a column for the distinct check, rather than using them all. This PR uses a gem to add this functionality, and should only used it databases that support it.