### PR TITLE
Add "previewable" setting to files

### DIFF
--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -136,7 +136,8 @@ class ModelFilesController < ApplicationController
   def bulk_update_params
     params.permit(
       :presupported,
-      :y_up
+      :y_up,
+      :previewable
     ).compact_blank
   end
 

--- a/app/views/model_files/_form.html.erb
+++ b/app/views/model_files/_form.html.erb
@@ -4,6 +4,7 @@
     <%= checkbox_input_row form, :printed, checked: current_user.printed?(@file) %>
     <%= checkbox_input_row form, :presupported %>
     <%= checkbox_input_row form, :y_up %>
+    <%= checkbox_input_row form, :previewable %>
 
     <% unless @file.presupported %>
       <div class="row mb-3 input-group">

--- a/app/views/model_files/bulk_edit.html.erb
+++ b/app/views/model_files/bulk_edit.html.erb
@@ -13,6 +13,7 @@
       <th><%= ModelFile.human_attribute_name(:printed) %></th>
       <th><%= ModelFile.human_attribute_name(:presupported) %></th>
       <th><%= ModelFile.human_attribute_name(:y_up) %></th>
+      <th><%= ModelFile.human_attribute_name(:previewable) %></th>
     </tr>
     <% @files.each do |file| %>
       <tr>
@@ -22,6 +23,7 @@
         <td><%= icon "check-circle-fill", ModelFile.human_attribute_name(:printed) if current_user.printed?(file) %></td>
         <td><%= icon "check-circle-fill", ModelFile.human_attribute_name(:presupported) if file.presupported %></td>
         <td><%= icon "check-circle-fill", ModelFile.human_attribute_name(:y_up) if file.y_up %></td>
+        <td><%= icon "check-circle-fill", ModelFile.human_attribute_name(:previewable) if file.previewable %></td>
       </tr>
     <% end %>
   </table>
@@ -41,6 +43,7 @@
   <%= checkbox_input_row form, :printed, label: ModelFile.human_attribute_name(:printed) %>
   <%= checkbox_input_row form, :presupported, label: ModelFile.human_attribute_name(:presupported) %>
   <%= checkbox_input_row form, :y_up, label: ModelFile.human_attribute_name(:y_up) %>
+  <%= checkbox_input_row form, :previewable, label: ModelFile.human_attribute_name(:previewable) %>
 
   <%= form.submit translate(".submit"), class: "btn btn-primary" %>
   <%= form.submit translate(".split"), name: "split", class: "btn btn-warning" %>

--- a/db/migrate/20250520111046_add_preview_to_model_file.rb
+++ b/db/migrate/20250520111046_add_preview_to_model_file.rb
@@ -1,0 +1,5 @@
+class AddPreviewToModelFile < ActiveRecord::Migration[8.0]
+  def change
+    add_column :model_files, :previewable, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_04_25_104619) do
+ActiveRecord::Schema[8.0].define(version: 2025_05_20_111046) do
   create_table "caber_relations", force: :cascade do |t|
     t.string "subject_type"
     t.integer "subject_id"
@@ -231,6 +231,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_04_25_104619) do
     t.json "attachment_data"
     t.string "public_id"
     t.virtual "filename_lower", type: :string, as: "LOWER(filename)", stored: true
+    t.boolean "previewable", default: false, null: false
     t.index ["digest"], name: "index_model_files_on_digest"
     t.index ["filename", "model_id"], name: "index_model_files_on_filename_and_model_id", unique: true
     t.index ["filename_lower"], name: "index_model_files_on_filename_lower"

--- a/spec/jobs/scan/model_file/parse_metadata_job_spec.rb
+++ b/spec/jobs/scan/model_file/parse_metadata_job_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe Scan::ModelFile::ParseMetadataJob do
   let(:file) { create(:model_file) }
   let(:supported_file) { create(:model_file, filename: "file1_supported.stl") }
+  let(:image_file) { create(:model_file, filename: "preview.jpg") }
 
   it "detects if file is presupported" do
     described_class.perform_now(supported_file.id)
@@ -14,6 +15,18 @@ RSpec.describe Scan::ModelFile::ParseMetadataJob do
     described_class.perform_now(file.id)
     file.reload
     expect(file.presupported).to be false
+  end
+
+  it "sets images as previewable" do
+    described_class.perform_now(image_file.id)
+    image_file.reload
+    expect(image_file.previewable).to be true
+  end
+
+  it "defaults models to not be previewable" do
+    described_class.perform_now(file.id)
+    file.reload
+    expect(file.previewable).to be false
   end
 
   it "queues analysis job" do


### PR DESCRIPTION
This will enable just these files to be visible when the user has "preview" permission on a model. Images are set as previewable by default.