### PR TITLE
Fix error in ParseMetadataJob for non-model and non-image files

### DIFF
--- a/app/jobs/scan/model_file/parse_metadata_job.rb
+++ b/app/jobs/scan/model_file/parse_metadata_job.rb
@@ -4,12 +4,16 @@ class Scan::ModelFile::ParseMetadataJob < ApplicationJob
 
   def perform(file_id)
     file = ModelFile.find(file_id)
+    # Refresh shrine metadata
+    file.attachment_attacher.refresh_metadata!
+    # Get metadata for specific types
     params = if file.is_image?
       image_metadata(file)
     elsif file.is_3d_model?
       model_metadata(file)
     end
-    file.update!(params.compact)
+    # Store updated data
+    file.update!(params.compact) if params
     # Queue up deeper analysis job
     file.analyse_later
   end

--- a/spec/jobs/scan/model_file/parse_metadata_job_spec.rb
+++ b/spec/jobs/scan/model_file/parse_metadata_job_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Scan::ModelFile::ParseMetadataJob do
   let(:file) { create(:model_file) }
   let(:supported_file) { create(:model_file, filename: "file1_supported.stl") }
   let(:image_file) { create(:model_file, filename: "preview.jpg") }
+  let(:doc_file) { create(:model_file, filename: "README.txt") }
 
   it "detects if file is presupported" do
     described_class.perform_now(supported_file.id)
@@ -31,6 +32,10 @@ RSpec.describe Scan::ModelFile::ParseMetadataJob do
 
   it "queues analysis job" do
     expect { described_class.perform_now(file.id) }.to have_enqueued_job(Analysis::AnalyseModelFileJob).once
+  end
+
+  it "works for non-model and non-image files" do
+    expect { described_class.perform_now(doc_file.id) }.to have_enqueued_job(Analysis::AnalyseModelFileJob).once
   end
 
   it "raises exception if file ID is not found" do


### PR DESCRIPTION
Also refreshes shrine metadata in same job