### PR TITLE
Include preview image/video/html in Activitypub actors

### DIFF
--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -95,4 +95,8 @@ class Collection < ApplicationRecord
   def to_activitypub_object
     ActivityPub::CollectionSerializer.new(self).serialize
   end
+
+  def preview_file
+    models.first&.preview_file
+  end
 end

--- a/app/serializers/activity_pub/application_serializer.rb
+++ b/app/serializers/activity_pub/application_serializer.rb
@@ -7,5 +7,30 @@ module ActivityPub
     def to
       PUBLIC_COLLECTION if @object.public?
     end
+
+    private
+
+    def oembed_to_preview(oembed_data)
+      case oembed_data[:type]
+      when "photo"
+        {
+          type: "Image",
+          url: oembed_data[:url],
+          mediaType: @object.preview_file.mime_type
+        }
+      when "rich"
+        {
+          type: "Document",
+          content: oembed_data[:html],
+          mediaType: "text/html"
+        }
+      when "video"
+        {
+          type: "Video",
+          url: oembed_data[:url],
+          mediaType: @object.preview_file.mime_type.to_s
+        }
+      end
+    end
   end
 end

--- a/app/serializers/activity_pub/collection_serializer.rb
+++ b/app/serializers/activity_pub/collection_serializer.rb
@@ -10,7 +10,8 @@ module ActivityPub
         content: @object.notes,
         "f3di:concreteType": "Collection",
         attachment: @object.links.map { |it| {type: "Link", href: it.url} },
-        context: @object.collection&.federails_actor&.federated_url
+        context: @object.collection&.federails_actor&.federated_url,
+        preview: oembed_to_preview(OEmbed::CollectionSerializer.new(@object).serialize)
       }.merge(address_fields)
     end
 

--- a/app/serializers/activity_pub/model_serializer.rb
+++ b/app/serializers/activity_pub/model_serializer.rb
@@ -16,7 +16,8 @@ module ActivityPub
         tag: hashtags,
         attributedTo: @object.creator&.federails_actor&.federated_url,
         context: @object.collection&.federails_actor&.federated_url,
-        "spdx:license": license
+        "spdx:license": license,
+        preview: oembed_to_preview(OEmbed::ModelSerializer.new(@object).serialize)
       }.compact.merge(address_fields)
     end
 

--- a/app/serializers/o_embed/application_serializer.rb
+++ b/app/serializers/o_embed/application_serializer.rb
@@ -65,6 +65,7 @@ module OEmbed
       EOF
       {
         type: "video",
+        url: Rails.application.routes.url_helpers.model_model_file_url(model_file.model, model_file, format: model_file.extension),
         html: html,
         width: width,
         height: height

--- a/app/serializers/o_embed/collection_serializer.rb
+++ b/app/serializers/o_embed/collection_serializer.rb
@@ -6,7 +6,7 @@ module OEmbed
       }.merge(
         generic_properties,
         author_properties(@object.creator),
-        model_file_properties(@object.models.first&.preview_file)
+        model_file_properties(@object.preview_file)
       )
     end
   end

--- a/app/views/collections/_collection.html.erb
+++ b/app/views/collections/_collection.html.erb
@@ -1,16 +1,13 @@
-<% model = policy_scope(Model).where(collection: collection).first %>
 <div class="col mb-4">
   <div class="card preview-card">
 
-    <% if model && (file = model.preview_file) %>
-      <% if file.is_image? %>
-        <%= content_tag :div, nil, class: "card-img-top card-img-top-background", style: "background-image: url(#{model_model_file_path(model, file, format: file.extension)})" %>
-        <%= image_tag model_model_file_path(model, file, format: file.extension), class: "card-img-top image-preview ", alt: file.name %>
-      <% elsif file.is_renderable? %>
-        <div class="card-img-top">
-          <%= render partial: "object_preview", locals: {model: model, file: file} %>
-        </div>
-      <% end %>
+    <% if collection.preview_file&.is_image? %>
+      <%= content_tag :div, nil, class: "card-img-top card-img-top-background", style: "background-image: url(#{model_model_file_path(model, file, format: collection.preview_file.extension)})" %>
+      <%= image_tag model_model_file_path(model, file, format: collection.preview_file.extension), class: "card-img-top image-preview ", alt: collection.preview_file.name %>
+    <% elsif collection.preview_file&.is_renderable? %>
+      <div class="card-img-top">
+        <%= render partial: "object_preview", locals: {model: model, file: file} %>
+      </div>
     <% else %>
       <div class='preview-empty'> <p><%= t ".no_preview" %></p></div>
     <% end %>

--- a/spec/serializers/activity_pub/collection_serializer_spec.rb
+++ b/spec/serializers/activity_pub/collection_serializer_spec.rb
@@ -12,5 +12,38 @@ RSpec.describe ActivityPub::CollectionSerializer do
     it "includes concrete type" do
       expect(ap[:"f3di:concreteType"]).to eq "Collection"
     end
+
+    it "includes preview images" do # rubocop:disable RSpec/ExampleLength
+      model = create(:model, collection: object)
+      file = create(:model_file, filename: "image.png", model: model)
+      model.update!(preview_file: file)
+      expect(ap[:preview]).to eq({
+        type: "Image",
+        mediaType: "image/png",
+        url: "http://localhost:3214/models/#{model.to_param}/model_files/#{file.to_param}.png"
+      })
+    end
+
+    it "includes preview videos" do # rubocop:disable RSpec/ExampleLength
+      model = create(:model, collection: object)
+      file = create(:model_file, filename: "video.mp4", model: model)
+      model.update!(preview_file: file)
+      expect(ap[:preview]).to eq({
+        type: "Video",
+        mediaType: "video/mp4",
+        url: "http://localhost:3214/models/#{model.to_param}/model_files/#{file.to_param}.mp4"
+      })
+    end
+
+    it "includes preview HTML" do # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+      model = create(:model, collection: object)
+      file = create(:model_file, filename: "model.stl", model: model)
+      model.update!(preview_file: file)
+      expect(ap[:preview]).to include({
+        type: "Document",
+        mediaType: "text/html"
+      })
+      expect(ap[:preview][:content]).to start_with "<iframe"
+    end
   end
 end

--- a/spec/serializers/activity_pub/model_serializer_spec.rb
+++ b/spec/serializers/activity_pub/model_serializer_spec.rb
@@ -24,5 +24,35 @@ RSpec.describe ActivityPub::ModelSerializer do
         href: "http://localhost:3214/models?tag=Tag+%230"
       })
     end
+
+    it "includes preview images" do # rubocop:disable RSpec/ExampleLength
+      file = create(:model_file, filename: "image.png", model: object)
+      object.update!(preview_file: file)
+      expect(ap[:preview]).to eq({
+        type: "Image",
+        mediaType: "image/png",
+        url: "http://localhost:3214/models/#{object.to_param}/model_files/#{file.to_param}.png"
+      })
+    end
+
+    it "includes preview videos" do # rubocop:disable RSpec/ExampleLength
+      file = create(:model_file, filename: "video.mp4", model: object)
+      object.update!(preview_file: file)
+      expect(ap[:preview]).to eq({
+        type: "Video",
+        mediaType: "video/mp4",
+        url: "http://localhost:3214/models/#{object.to_param}/model_files/#{file.to_param}.mp4"
+      })
+    end
+
+    it "includes preview HTML" do # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+      file = create(:model_file, filename: "image.stl", model: object)
+      object.update!(preview_file: file)
+      expect(ap[:preview]).to include({
+        type: "Document",
+        mediaType: "text/html"
+      })
+      expect(ap[:preview][:content]).to start_with "<iframe"
+    end
   end
 end

--- a/spec/serializers/o_embed/model_serializer_spec.rb
+++ b/spec/serializers/o_embed/model_serializer_spec.rb
@@ -56,6 +56,10 @@ RSpec.describe OEmbed::ModelSerializer do
         expect(result[:type]).to eq "video"
       end
 
+      it "includes video url" do
+        expect(result[:url]).to eq "http://localhost:3214/models/#{model.to_param}/model_files/#{model.preview_file.to_param}.mp4"
+      end
+
       it "generates HTML video tag" do
         expect(result[:html]).to start_with "<video"
       end


### PR DESCRIPTION
Generated from oembed content, so that we can provide previews for remote content. Part of #3569