### PR TITLE
Only show problems to moderators and above

### DIFF
--- a/app/policies/problem_policy.rb
+++ b/app/policies/problem_policy.rb
@@ -1,19 +1,22 @@
 class ProblemPolicy < ApplicationPolicy
   def index?
-    user&.is_contributor?
+    user&.is_moderator?
   end
 
   def show?
-    user&.is_contributor?
+    user&.is_moderator?
   end
 
   def resolve?
-    Pundit::PolicyFinder.new(record.problematic).policy.new(user, record.problematic).send(:"#{record.resolution_strategy}?")
+    all_of(
+      user&.is_moderator?,
+      Pundit::PolicyFinder.new(record.problematic).policy.new(user, record.problematic).send(:"#{record.resolution_strategy}?")
+    )
   end
 
   class Scope < ApplicationPolicy::Scope
     def resolve
-      scope
+      @user.is_moderator? ? scope : scope.none
     end
   end
 end

--- a/spec/requests/problems_spec.rb
+++ b/spec/requests/problems_spec.rb
@@ -9,14 +9,14 @@ RSpec.describe "Problems" do
   end
 
   context "when signed in" do
-    describe "GET /problems", :as_member do
-      it "is denied to members" do
+    describe "GET /problems", :as_contributor do
+      it "is denied to contributors" do
         get "/problems/index"
         expect(response).to have_http_status(:forbidden)
       end
     end
 
-    describe "GET /problems", :as_contributor do
+    describe "GET /problems", :as_moderator do
       before do
         create_list(:problem, 2, category: :inefficient)
         create_list(:problem_on_model, 3, category: :missing)


### PR DESCRIPTION
Resolves #4353

This isn't an ideal resolution, but a quick fix. Restoring access to problems for non-mod object owners is logged as a feature in #4359.
