### PR TITLE
Require license and public creator when making models public

### DIFF
--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -345,6 +345,7 @@ class Model < ApplicationRecord
       # Check required fields
       errors.add :license, :blank if license.nil?
       errors.add :creator, :blank if creator.nil?
+      errors.add :creator, :private if creator && !creator.public?
     end
   end
 end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -53,6 +53,8 @@ class Model < ApplicationRecord
   validates :license, spdx: true, allow_nil: true
   validates :public_id, multimodel_uniqueness: {case_sensitive: false, check: FederailsCommon::FEDIVERSE_USERNAMES}
 
+  validate :validate_publishable
+
   scoped_search on: [:name, :caption]
   scoped_search on: :notes, aliases: [:description], only_explicit: true
   scoped_search relation: :library, on: :name, rename: :library, only_explicit: true, default_operator: :eq
@@ -335,5 +337,14 @@ class Model < ApplicationRecord
       "public_id",
       "name_lower"
     ]).empty?
+  end
+
+  def validate_publishable
+    # If the model will be public
+    if caber_relations.find { |it| it.subject.nil? }
+      # Check required fields
+      errors.add :license, :blank if license.nil?
+      errors.add :creator, :blank if creator.nil?
+    end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -106,6 +106,12 @@ en:
         username: Account name
     errors:
       models:
+        collection:
+          attributes:
+            collection:
+              private: must be public
+            creator:
+              private: must be public
         doorkeeper/application:
           attributes:
             redirect_uri:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -127,6 +127,8 @@ en:
               unsafe: cannot be a privileged system path
         model:
           attributes:
+            creator:
+              private: must be public
             library:
               nested: can't be changed, model contains other models
             license:

--- a/spec/factories/model.rb
+++ b/spec/factories/model.rb
@@ -45,7 +45,7 @@ FactoryBot.define do
 
     trait :public do
       caber_relations_attributes { [{subject: nil, permission: "view"}] }
-      creator
+      creator factory: [:creator, :public]
     end
   end
 end

--- a/spec/factories/model.rb
+++ b/spec/factories/model.rb
@@ -45,6 +45,7 @@ FactoryBot.define do
 
     trait :public do
       caber_relations_attributes { [{subject: nil, permission: "view"}] }
+      creator
     end
   end
 end

--- a/spec/models/collection_spec.rb
+++ b/spec/models/collection_spec.rb
@@ -26,4 +26,29 @@ RSpec.describe Collection do
       }.to have_enqueued_job(Activity::CollectionPublishedJob).once
     end
   end
+
+  context "when making a collection public" do
+    let!(:collection) { create(:collection) }
+
+    before do
+      collection.update(
+        caber_relations_attributes: [{subject: nil, permission: "view"}],
+        creator: create(:creator),
+        collection: create(:collection)
+      )
+      collection.validate
+    end
+
+    it "requires creator to be public if set" do
+      expect(collection.errors[:creator]).to include "must be public"
+    end
+
+    it "requires collection to be public if set" do
+      expect(collection.errors[:collection]).to include "must be public"
+    end
+
+    it "doesn't make collection public if validation failed" do
+      expect(collection.reload.public?).to be false
+    end
+  end
 end

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Comment do
 
   context "with non-public commenter" do
     let(:commenter) { create(:creator) }
-    let(:commentable) { create(:model, :public, creator: commenter) }
+    let(:commentable) { create(:model, :public) }
 
     it "Does not post a Federails Activity on creation" do
       expect { create(:comment, commenter: commenter, commentable: commentable) }.not_to change(Federails::Activity, :count)

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -516,6 +516,11 @@ RSpec.describe Model do
       expect(model.errors[:creator]).to include "can't be blank"
     end
 
+    it "requires a public creator" do
+      model.update(creator: create(:creator))
+      expect(model.errors[:creator]).to include "must be public"
+    end
+
     it "requires a license" do
       expect(model.errors[:license]).to include "can't be blank"
     end
@@ -526,7 +531,7 @@ RSpec.describe Model do
   end
 
   context "when updating a private model" do
-    let!(:model) { create(:model, creator: create(:creator)) }
+    let!(:model) { create(:model, creator: create(:creator, :public)) }
 
     before do
       model.clear_changes_information
@@ -568,12 +573,6 @@ RSpec.describe Model do
       expect {
         model.update!(creator: create(:creator, :public))
       }.to have_enqueued_job(Activity::ModelPublishedJob).once
-    end
-
-    it "queues normal update activity job if the creator was changed to a private one" do
-      expect {
-        model.update!(creator: create(:creator))
-      }.to have_enqueued_job(Activity::ModelUpdatedJob).once
     end
 
     it "queues collected activity job if the collection was changed to a public one" do

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -503,8 +503,30 @@ RSpec.describe Model do
     end
   end
 
+  context "when making a model public" do
+    let!(:model) { create(:model, license: nil) }
+
+    before do
+      model.clear_changes_information
+      model.update(caber_relations_attributes: [{subject: nil, permission: "view"}])
+      model.validate
+    end
+
+    it "requires a creator" do
+      expect(model.errors[:creator]).to include "can't be blank"
+    end
+
+    it "requires a license" do
+      expect(model.errors[:license]).to include "can't be blank"
+    end
+
+    it "doesn't make model public if validation failed" do
+      expect(model.reload.public?).to be false
+    end
+  end
+
   context "when updating a private model" do
-    let!(:model) { create(:model) }
+    let!(:model) { create(:model, creator: create(:creator)) }
 
     before do
       model.clear_changes_information


### PR DESCRIPTION
Also, make sure collection creators and parent collections are public.

Resolves #4340