### PR TITLE
Merge any set of models

### DIFF
--- a/app/assets/stylesheets/src/models.scss
+++ b/app/assets/stylesheets/src/models.scss
@@ -125,3 +125,18 @@ div.form-control.tag-container {
   left: 0;
   z-index: 999;
 }
+
+.radio-option {
+
+  input[type="radio"] {
+    display: none
+  }
+
+  &:has(input[type="radio"]:checked) {
+    @extend .bg-success;
+  }
+
+  label {
+    display: block;
+  }
+}

--- a/app/components/model_summary.rb
+++ b/app/components/model_summary.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+class Components::ModelSummary < Components::Base
+  def initialize(model:)
+    @model = model
+  end
+
+  def view_template
+    div class: "card" do
+      div class: "card-body" do
+        code(class: "float-end") { @model.path }
+        div do
+          span(class: "fs-4") { @model.name }
+          whitespace
+          span(class: "text-secondary") { t("components.model_summary.byline", creator: @model.creator.name) } if @model.creator
+        end
+        div(class: "float-end") { @model.tags.map { |it| Tag(tag: it) } }
+        div do
+          span { @model.model_files.count }
+          whitespace
+          span { ModelFile.model_name.human count: @model.model_files.count }
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/models_controller/merge.rb
+++ b/app/controllers/concerns/models_controller/merge.rb
@@ -2,7 +2,7 @@ module ModelsController::Merge
   extend ActiveSupport::Concern
 
   included do
-    # skip_before_action :get_model, only: [:merge, :configure_merge]
+    skip_before_action :get_model, only: [:merge, :configure_merge]
 
     before_action :get_merge_params, only: [:merge, :configure_merge]
     before_action :get_merging_models, only: [:merge, :configure_merge]
@@ -11,6 +11,7 @@ module ModelsController::Merge
   end
 
   def configure_merge
+    skip_authorization
   end
 
   def merge
@@ -23,6 +24,7 @@ module ModelsController::Merge
       end
     else
       skip_authorization
+      redirect_to configure_merge_models_path(models: @models.map(&:public_id))
     end
   end
 

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -125,10 +125,10 @@ class ModelsController < ApplicationController
 
   def merge
     if params[:target] && (target = (@model.parents.find { |it| it.public_id == params[:target] }))
-      @model.merge_into! target
+      target.merge! @model
       redirect_to target, notice: t(".success")
     elsif params[:all] && @model.contains_other_models?
-      @model.merge_all_children!
+      @model.merge!(@model.contained_models)
       redirect_to @model, notice: t(".success")
     else
       head :bad_request

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -124,11 +124,11 @@ class ModelsController < ApplicationController
   end
 
   def merge
-    if params[:target] && (target = (@model.parents.find { |it| it.public_id == params[:target] }))
-      target.merge! @model
-      redirect_to target, notice: t(".success")
-    elsif params[:all] && @model.contains_other_models?
-      @model.merge!(@model.contained_models)
+    model_ids = params.permit(models: [])[:models]
+    if !model_ids.empty?
+      @model.merge!(
+        policy_scope(Model, policy_scope_class: ApplicationPolicy::UpdateScope).local.where(public_id: model_ids)
+      )
       redirect_to @model, notice: t(".success")
     else
       head :bad_request

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -123,6 +123,9 @@ class ModelsController < ApplicationController
   end
 
   def merge
+    if params[:models].respond_to?(:keys)
+      params[:models] = params[:models].select { |k, v| v == "1" }.keys
+    end
     p = params.permit(
       :target,
       models: []

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -3,7 +3,6 @@ require "fileutils"
 class ModelsController < ApplicationController
   include ModelListable
   include Permittable
-  include ModelsController::Merge
 
   rate_limit to: 10, within: 3.minutes, only: :create
 
@@ -16,6 +15,8 @@ class ModelsController < ApplicationController
   before_action -> { set_indexable @model if @model }
 
   after_action :verify_policy_scoped, only: [:bulk_edit, :bulk_update]
+
+  include ModelsController::Merge
 
   def index
     @models = filtered_models @filters

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -12,7 +12,7 @@ class ModelsController < ApplicationController
   before_action :clear_returnable, only: [:bulk_update, :update, :create]
   before_action :get_filters, only: [:bulk_edit, :bulk_update, :index, :show] # rubocop:todo Rails/LexicallyScopedActionFilter
   before_action :get_model, except: [:bulk_edit, :bulk_update, :index, :new, :create, :merge]
-  before_action -> { set_indexable @model }, except: [:bulk_edit, :bulk_update, :index, :new, :create, :merge]
+  before_action :configure_indexable
 
   after_action :verify_policy_scoped, only: [:bulk_edit, :bulk_update, :merge]
 

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -127,20 +127,20 @@ class ModelsController < ApplicationController
       :target,
       models: []
     )
-    target = Model.find_param(p[:target])
     if p[:models].blank?
       skip_authorization
       skip_policy_scope
       head :bad_request and return
     end
-    model_list = policy_scope(Model, policy_scope_class: ApplicationPolicy::UpdateScope)
+    @models = policy_scope(Model, policy_scope_class: ApplicationPolicy::UpdateScope)
       .local
       .where(public_id: p[:models])
       .where.not(public_id: p[:target])
-    if model_list.count != p[:models].count
+    if @models.count != p[:models].count
       skip_authorization
       head :forbidden
-    elsif target
+    elsif p[:target]
+      target = Model.find_param(p[:target])
       authorize(target)
       if target && !model_list.empty?
         target.merge!(model_list)
@@ -148,7 +148,6 @@ class ModelsController < ApplicationController
       end
     else
       skip_authorization
-      head :bad_request
     end
   end
 

--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -115,7 +115,7 @@ class ProblemsController < ApplicationController
     case problem.problematic_type
     when "Model"
       problem.update(in_progress: true)
-      problem.problematic.merge_all_children!
+      problem.problematic.merge!(problem.problematic.contained_models)
     else
       raise NotImplementedError
     end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -111,6 +111,9 @@ class Model < ApplicationRecord
   end
 
   def merge!(*models)
+    # If we've got one argument and it's enumerable, use it directly
+    models = models[0] if models.length == 1 && models[0].is_a?(Enumerable)
+    # Go through the list
     models.each do |other|
       # Work out path to the other target from here
       relative_path = contains?(other) ? Pathname.new(other.path).relative_path_from(Pathname.new(path)) : nil

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -75,6 +75,26 @@ class Model < ApplicationRecord
     !previous_changes.empty?
   end
 
+  def self.common_root(*models)
+    # If there are different libraries, there is no common root
+    return nil unless models.map(&:library_id).uniq.count == 1
+    # Get each path, split, and working from the front, find the common elements
+
+    first, *remainder = models.map { |it| it.path.split(File::SEPARATOR).without(".") }
+    parts = first.zip(*remainder)
+    common = parts.map { |it| (it.uniq.length == 1) ? it.first : nil }
+    common = common.first(common.index(nil) || 99999)
+    common.empty? ? nil : File.join(common)
+  end
+
+  def disjoint?(other)
+    Model.common_root(self, other).nil?
+  end
+
+  def contains?(other)
+    Model.common_root(self, other) == path
+  end
+
   def merge_into!(target)
     return unless target
 

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -114,7 +114,7 @@ class Model < ApplicationRecord
     return unless target
 
     # Work out path to this model from the target
-    relative_path = Pathname.new(path).relative_path_from(Pathname.new(target.path))
+    relative_path = target.contains?(self) ? Pathname.new(path).relative_path_from(Pathname.new(target.path)) : nil
     # Remove datapackage
     datapackage&.destroy
     # Move files

--- a/app/policies/model_policy.rb
+++ b/app/policies/model_policy.rb
@@ -3,6 +3,10 @@ class ModelPolicy < ApplicationPolicy
     super && !(user&.sensitive_content_handling == "hide" && record.sensitive)
   end
 
+  def configure_merge?
+    merge?
+  end
+
   def merge?
     all_of(
       update?,

--- a/app/views/models/bulk_edit.html.erb
+++ b/app/views/models/bulk_edit.html.erb
@@ -61,7 +61,7 @@
       <%= form.hidden_field :creator, value: @filters[:creator] if @filters[:creator] %>
       <%= form.submit translate(".submit"), class: "btn btn-primary" %>
       <%= form.submit translate(".update_all", count: @models.total_count), class: "btn btn-secondary", name: "update_all" %>
-
+      <%= form.submit translate(".merge"), class: "btn btn-outline-warning", formaction: merge_models_path, formmethod: :post, name: "merge" %>
     </div>
     <% if !@filters.empty? %>
       <div class="col col-md-3">

--- a/app/views/models/configure_merge.html.erb
+++ b/app/views/models/configure_merge.html.erb
@@ -4,7 +4,20 @@
   <%= t(".description") %>
 </p>
 
-<%= form_with url: merge_models_path do |form| %>
+<div class="container">
+  <%= form_with url: merge_models_path do |form| %>
+    <% @models.each do |it| %>
+      <div class="row p-2 radio-option rounded">
+        <%= form.hidden_field "models[]", value: it.public_id %>
+        <%= form.radio_button :target, it.public_id, id: it.public_id %>
+        <label for="<%= it.public_id %>">
+          <%= render Components::ModelSummary.new(model: it) %>
+        </label>
+      </div>
+    <% end %>
 
-  <%= form.submit %>
-<% end %>
+    <div class="mt-3">
+      <%= form.submit %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/models/configure_merge.html.erb
+++ b/app/views/models/configure_merge.html.erb
@@ -1,10 +1,10 @@
 <h1><%= t(".heading") %></h1>
 
 <p class="lead">
-	<%= t(".description") %>
+  <%= t(".description") %>
 </p>
 
 <%= form_with url: merge_models_path do |form| %>
 
-	<%= form.submit %>
+  <%= form.submit %>
 <% end %>

--- a/app/views/models/merge.html.erb
+++ b/app/views/models/merge.html.erb
@@ -1,0 +1,10 @@
+<h1><%= t(".heading") %></h1>
+
+<p class="lead">
+	<%= t(".description") %>
+</p>
+
+<%= form_with url: merge_models_path do |form| %>
+
+	<%= form.submit %>
+<% end %>

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -142,7 +142,7 @@
           </p>
           <strong><%= t(".merge.with") %>:</strong>
           <% @model.parents.each do |parent| %>
-            <%= render Components::DoButton.new(icon: "union", label: parent.name, href: merge_model_path(parent, models: [@model.public_id]), method: :post, variant: "danger") %>
+            <%= render Components::DoButton.new(icon: "union", label: parent.name, href: merge_models_path(target: parent.public_id, models: [@model.public_id]), method: :post, variant: "danger") %>
           <% end %>
         <% end %>
       <% end %>

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -141,8 +141,8 @@
             <%= t(".merge.warning") %>
           </p>
           <strong><%= t(".merge.with") %>:</strong>
-          <% @model.parents.each do |target| %>
-            <%= link_to target.name, merge_model_path(@model, target: target), class: "btn btn-danger", method: :post %>
+          <% @model.parents.each do |parent| %>
+            <%= render Components::DoButton.new(icon: "union", label: parent.name, href: merge_model_path(parent, models: [@model.public_id]), method: :post, variant: "danger") %>
           <% end %>
         <% end %>
       <% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -369,6 +369,8 @@ en:
       open_button:
         label: Open model %{name}
         text: Open
+    model_summary:
+      byline: by %{creator}
     search_help:
       boolean: Use "or" to find models that match any of the terms.
       federation: Search for any Fediverse username to follow it.

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -4,6 +4,7 @@ en:
     bulk_edit:
       description: 'Select models to change:'
       form_subtitle: 'Select changes to make:'
+      merge: Merge selected models
       needs_organizing: Needs organizing
       remove_tags: Remove tags
       select: Select model '%{name}'
@@ -15,6 +16,9 @@ en:
       add_tags: Add tags
     bulk_update:
       success: Models updated successfully.
+    configure_merge:
+      description: Choose how you want to merge these models
+      heading: Merge models
     create:
       success: File(s) uploaded successfully.
     destroy:

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -17,7 +17,7 @@ en:
     bulk_update:
       success: Models updated successfully.
     configure_merge:
-      description: Choose how you want to merge these models
+      description: Select one of the models to merge the others into, or create a new one.
       heading: Merge models
     create:
       success: File(s) uploaded successfully.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -102,6 +102,7 @@ Rails.application.routes.draw do
     end
     collection do
       post "merge"
+      get "merge", action: "configure_merge", as: "configure_merge"
       get "edit", action: "bulk_edit"
       patch "/update", action: "bulk_update"
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,10 +98,10 @@ Rails.application.routes.draw do
     concerns :commentable, commentable_class: "Model"
     concerns :reportable, reportable_class: "Model"
     member do
-      post "merge"
       post "scan"
     end
     collection do
+      post "merge"
       get "edit", action: "bulk_edit"
       patch "/update", action: "bulk_update"
     end

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -105,11 +105,15 @@ RSpec.describe Model do
     end
   end
 
-  it "does not find a common root in different libraries" do
-    library = create(:library)
-    m1 = create(:model, path: "shared/common/folder", library: library)
-    m2 = create(:model, path: "shared/parent/folder", library: create(:library))
-    expect(described_class.common_root(m1, m2)).to be_nil
+  context "with models in different libraries" do
+    let(:library_a) { create(:library) }
+    let(:library_b) { create(:library) }
+
+    it "does not find a common root for models" do
+      m1 = create(:model, path: "shared/common/folder", library: library_a)
+      m2 = create(:model, path: "shared/parent/folder", library: library_b)
+      expect(described_class.common_root(m1, m2)).to be_nil
+    end
   end
 
   context "with a common root" do

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -137,8 +137,7 @@ RSpec.describe Model do
       let!(:new_model) { create(:model, library: library, path: "common/root") }
 
       before do
-        model_two.merge_into! new_model
-        model_one.merge_into! new_model
+        new_model.merge! model_one, model_two
       end
 
       it "moves files" do
@@ -186,7 +185,7 @@ RSpec.describe Model do
 
     context "when merging into an existing model" do
       before do
-        model_two.merge_into! model_one
+        model_one.merge! model_two
       end
 
       it "moves files" do
@@ -254,7 +253,7 @@ RSpec.describe Model do
     context "when merging a child model into a parent" do
       it "moves files" do # rubocop:todo RSpec/MultipleExpectations
         file = create(:model_file, model: child, filename: "child_part.stl")
-        child.merge_into! parent
+        parent.merge! child
         file.reload
         expect(file.filename).to eql "child/child_part.stl"
         expect(file.model).to eql parent
@@ -262,7 +261,7 @@ RSpec.describe Model do
 
       it "deletes merged model" do
         expect {
-          child.merge_into! parent
+          parent.merge! child
         }.to change(described_class, :count).from(2).to(1)
       end
     end
@@ -277,17 +276,17 @@ RSpec.describe Model do
 
       it "removes duplicated file" do
         expect {
-          child.merge_into! parent
+          parent.merge! child
         }.to change(ModelFile, :count).by(-1)
       end
 
       it "rehomes distinct file" do
-        child.merge_into! parent
+        parent.merge! child
         expect(parent.model_files.exists?(filename: "child/child_part.stl")).to be true
       end
 
       it "keeps all real files intact" do
-        child.merge_into! parent
+        parent.merge! child
         parent.model_files.each do |file|
           expect(file.exists_on_storage?).to be true
         end

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -250,6 +250,10 @@ RSpec.describe Model do
       expect(described_class.common_root(parent, child)).to eq "parent"
     end
 
+    it "can merge all contained models at once" do
+      expect { parent.merge!(parent.contained_models) }.to change(described_class, :count).by(-1)
+    end
+
     context "when merging a child model into a parent" do
       it "moves files" do # rubocop:todo RSpec/MultipleExpectations
         file = create(:model_file, model: child, filename: "child_part.stl")

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -5,12 +5,12 @@ require "rails_helper"
 #               PATCH  /models/:id(.:format)                             models#update
 #               PUT    /models/:id(.:format)                             models#update
 #               DELETE /models/:id(.:format)                             models#destroy
-#   edit_models GET    /models/edit(.:format)                                                  models#bulk_edit
-# update_models PATCH  /models/update(.:format)                                                models#bulk_update
-#        models GET    /models(.:format)                                                       models#index
-#     new_model GET    /models/new(.:format)                                                      uploads#index
-#               POST   /models(.:format)                                                      uploads#create
-#   merge_model POST   /models/:id/merge(.:format)                       models#merge
+#   edit_models GET    /models/edit(.:format)                            models#bulk_edit
+# update_models PATCH  /models/update(.:format)                          models#bulk_update
+#        models GET    /models(.:format)                                 models#index
+#     new_model GET    /models/new(.:format)                             models#new
+#               POST   /models(.:format)                                 models#create
+#  merge_models POST   /models/merge(.:format)                           models#merge
 #   scan_model  POST   /models/:id/scan(.:format)                        models#scan
 
 RSpec.describe "Models" do
@@ -331,15 +331,35 @@ RSpec.describe "Models" do
         end
       end
 
-      describe "POST /models/:id/merge" do
-        before { post "/models/#{library.models.first.to_param}/merge" }
+      describe "POST /models/merge" do
+        context "with a target and models to merge into it" do
+          let(:model_one) { create(:model) }
+          let(:model_two) { create(:model) }
+          let(:merge_post) {
+            post "/models/merge", params: {
+              target: model_one.to_param,
+              models: [model_two.to_param]
+            }
+          }
 
-        it "gives a bad request response if no merge parameter is provided", :as_moderator do
-          expect(response).to have_http_status(:bad_request)
+          it "is denied if the user doesn't have update permission on the models", :as_contributor do
+            merge_post
+            expect(response).to have_http_status(:forbidden)
+          end
         end
 
-        it "is denied to non-moderators", :as_contributor do
-          expect(response).to have_http_status(:forbidden)
+        context "without any models" do
+          let(:model) { create(:model) }
+          let(:merge_post) {
+            post "/models/merge", params: {
+              target: model.to_param
+            }
+          }
+
+          it "gives a bad request response if no models are provided", :as_moderator do
+            merge_post
+            expect(response).to have_http_status(:bad_request)
+          end
         end
       end
 

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -332,7 +332,7 @@ RSpec.describe "Models" do
       end
 
       describe "POST /models/merge" do
-        context "with a target and models to merge into it" do
+        context "with a target and models to merge into it", :as_moderator do # rubocop:todo RSpec/MultipleMemoizedHelpers
           let(:model_one) { create(:model) }
           let(:model_two) { create(:model) }
           let(:merge_post) {
@@ -346,9 +346,11 @@ RSpec.describe "Models" do
             merge_post
             expect(response).to have_http_status(:forbidden)
           end
+
+          it "is denied if the user doesn't have update permission on the target"
         end
 
-        context "without any models" do
+        context "without any models", :as_moderator do
           let(:model) { create(:model) }
           let(:merge_post) {
             post "/models/merge", params: {
@@ -356,11 +358,12 @@ RSpec.describe "Models" do
             }
           }
 
-          it "gives a bad request response if no models are provided", :as_moderator do
+          it "gives a bad request response if no models are provided" do
             merge_post
             expect(response).to have_http_status(:bad_request)
           end
         end
+
       end
 
       describe "POST /models/:id/scan" do

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -383,6 +383,29 @@ RSpec.describe "Models" do
             expect(response.body).to include(%(<form action="/models/merge" accept-charset="UTF-8" method="post">))
           end
         end
+
+        context "with form-encoded data", :as_moderator do # rubocop:todo RSpec/MultipleMemoizedHelpers
+          let(:model_one) { create(:model) }
+          let(:model_two) { create(:model) }
+          let(:merge_post) {
+            post "/models/merge", params: {
+              models: {
+                model_one.to_param => "0",
+                model_two.to_param => "1"
+              }
+            }
+          }
+
+          before { merge_post }
+
+          it "extracts selected models from form" do
+            expect(assigns(:models)).to include model_two
+          end
+
+          it "ignores unselected models" do
+            expect(assigns(:models)).not_to include model_one
+          end
+        end
       end
 
       describe "POST /models/:id/scan" do

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -375,12 +375,8 @@ RSpec.describe "Models" do
 
           before { merge_post }
 
-          it "shows the merge options page" do
-            expect(response).to have_http_status(:success)
-          end
-
-          it "merge options page includes a form for choosing the target" do
-            expect(response.body).to include(%(<form action="/models/merge" accept-charset="UTF-8" method="post">))
+          it "redirects to the merge options page" do
+            expect(response).to redirect_to("/models/merge?models%5B%5D=#{model_one.to_param}&models%5B%5D=#{model_two.to_param}")
           end
         end
 
@@ -405,6 +401,22 @@ RSpec.describe "Models" do
           it "ignores unselected models" do
             expect(assigns(:models)).not_to include model_one
           end
+        end
+      end
+
+      describe "GET /models/merge", :as_moderator do # rubocop:todo RSpec/MultipleMemoizedHelpers
+        let(:model_one) { create(:model) }
+        let(:model_two) { create(:model) }
+        let(:configure_merge) {
+          get "/models/merge", params: {
+            models: [model_one.to_param, model_two.to_param]
+          }
+        }
+
+        before { configure_merge }
+
+        it "merge options page includes a form for choosing the target" do
+          expect(response.body).to include(%(<form action="/models/merge" accept-charset="UTF-8" method="post">))
         end
       end
 

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -364,6 +364,25 @@ RSpec.describe "Models" do
           end
         end
 
+        context "without a target", :as_moderator do # rubocop:todo RSpec/MultipleMemoizedHelpers
+          let(:model_one) { create(:model) }
+          let(:model_two) { create(:model) }
+          let(:merge_post) {
+            post "/models/merge", params: {
+              models: [model_one.to_param, model_two.to_param]
+            }
+          }
+
+          before { merge_post }
+
+          it "shows the merge options page" do
+            expect(response).to have_http_status(:success)
+          end
+
+          it "merge options page includes a form for choosing the target" do
+            expect(response.body).to include(%(<form action="/models/merge" accept-charset="UTF-8" method="post">))
+          end
+        end
       end
 
       describe "POST /models/:id/scan" do


### PR DESCRIPTION
This extends our current merging system (which only handles children and parents) to any combination of models, even across libraries. 

Resolves #2737 