### PR TITLE
Safely handle file conflicts during model merging

### DIFF
--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -277,8 +277,8 @@ RSpec.describe Model do
     context "when merging models that have duplicated files" do
       before do
         create(:model_file, model: parent, filename: "parent_part.stl")
-        create(:model_file, model: parent, filename: "child/duplicate.stl")
-        create(:model_file, model: child, filename: "duplicate.stl")
+        create(:model_file, model: parent, filename: "child/duplicate.stl", digest: "abcd")
+        create(:model_file, model: child, filename: "duplicate.stl", digest: "abcd")
         create(:model_file, model: child, filename: "child_part.stl")
       end
 
@@ -363,9 +363,8 @@ RSpec.describe Model do
     it "renames incoming file to avoid conflict if files are different" do # rubocop:disable RSpec/MultipleExpectations
       create(:model_file, model: model, filename: "test.stl", digest: "abcd")
       create(:model_file, model: target, filename: "test.stl", digest: "1234")
-      expect { target.merge!(model) }.not_to change { target.model_files.count }
-      expect(target.model_files.last.filename).to eq "test1.stl"
-      expect(target.model_files.last.digest).to eq "1234"
+      target.merge!(model)
+      expect(target.model_files.map(&:filename)).to eq ["test_abcd.stl", "test.stl"]
     end
 
     it "discards incoming file if they are identical" do


### PR DESCRIPTION
Identical files are discarded, but non-identical files with the same name will be renamed using the file digest. Last part of #2737.