### PR TITLE
Download model files from Thingiverse during sync

### DIFF
--- a/app/deserializers/integrations/thingiverse/model_deserializer.rb
+++ b/app/deserializers/integrations/thingiverse/model_deserializer.rb
@@ -9,7 +9,9 @@ class Integrations::Thingiverse::ModelDeserializer < Integrations::Thingiverse::
       notes: r.body["description"],
       tag_list: r.body["tags"]&.pluck("tag"),
       sensitive: r.body["is_nsfw"],
-      file_urls: r.body.dig("zip_data", "images").map { |it| {url: it.dig("url"), filename: "images/" + filename_from_url(it.dig("url"))} },
+      file_urls:
+        r.body.dig("zip_data", "images").map { |it| {url: it.dig("url"), filename: "images/" + filename_from_url(it.dig("url"))} } +
+          r.body.dig("zip_data", "files").map { |it| {url: it.dig("url"), filename: "files/" + filename_from_url(it.dig("url"))} },
       preview_filename: "images/" + r.body.dig("default_image", "name")
     }
   end

--- a/spec/deserializers/integrations/thingiverse/model_deserializer_spec.rb
+++ b/spec/deserializers/integrations/thingiverse/model_deserializer_spec.rb
@@ -46,6 +46,13 @@ RSpec.describe Integrations::Thingiverse::ModelDeserializer, :thingiverse_api_ke
       })
     end
 
+    it "extracts 3d file info to check and download" do
+      expect(deserializer.deserialize[:file_urls]).to include({
+        url: "https://cdn.thingiverse.com/assets/62/09/06/48/fa/Slatwall_support.stl",
+        filename: "files/Slatwall_support.stl"
+      })
+    end
+
     it "extracts preview filename" do
       expect(deserializer.deserialize[:preview_filename]).to eq "images/Slatwall_support.png"
     end


### PR DESCRIPTION
This is the behind-the-scenes work that helps resolve #1990 and #2762. Neater UI to come, but at this point, if a model has a valid Thingiverse link, it can pull in the rest of the files.