### PR TITLE
Present password feedback directly to user

### DIFF
--- a/app/javascript/controllers/zxcvbn_controller.ts
+++ b/app/javascript/controllers/zxcvbn_controller.ts
@@ -30,7 +30,10 @@ export default class extends Controller {
     const widths = ['w-0', 'w-25', 'w-50', 'w-75', 'w-100']
     const severities = ['bg-danger', 'bg-danger', 'bg-danger', 'bg-warning', 'bg-success', 'bg-success', 'bg-success', 'bg-success', 'bg-success'].slice(4 - this.minScore, 4 - this.minScore + 5)
     const result = zxcvbn(this.value())
-    if (this.meter != null) { this.meter.className = `progress-bar zxcvbn-meter ${widths[result.score]} ${severities[result.score]}` }
+    if (this.meter != null) {
+      this.meter.className = `progress-bar zxcvbn-meter ${widths[result.score]} ${severities[result.score]}`
+      this.meter.textContent = String(result.feedback.warning ?? '')
+    }
   }
 }
 


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [x] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

This presents zxcvbn's feedback directly to the user in the password input screen. The side-effect being that it will render a progress bar between 0-25%. Right now the progress bar does not render unless it's an increment of (100/4). The progress bar looks like a plain grey box until 25% and users are, understandably, not aware that the password they're inputting needs to be more complex.

I'm not sure if this is the best approach. Ideally, we should have a width of 1 as the minimum value and then increase from there but zxcvbn's scores are only 0-4, so we can't get a middle progress value.

Also, the strings aren't translated. It's presenting the string from zxcvbn directly, so I'm not sure how to override that with translatable strings. 

## Linked issues

Partially addresses https://github.com/manyfold3d/manyfold/issues/4483

## Description of changes

* Adds feedback text inside the progress bar
