### PR TITLE
Throws 422 if user update fails on first use

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -57,7 +57,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
         bypass_sign_in current_user
         redirect_to root_path, notice: t("devise.registrations.update.setup_complete")
       else
-        render "first_use"
+        render "first_use", status: :unprocessable_entity
       end
     else
       super


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [x] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

This will return a 422 when the update fails on first use. It also fixes an issue where errors were not present when submitting the form

<img width="834" height="414" alt="image" src="https://github.com/user-attachments/assets/48f52cab-06b1-42ee-8e83-cacd385afd75" />


## Linked issues

This should fix https://github.com/manyfold3d/manyfold/issues/4483

## Description of changes

* Changes a single line to return a 422 if a user update fails
