### PR TITLE
Check for updated files and grab new version if available

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -208,3 +208,5 @@ gem "altcha-rails", "~> 0.0.6"
 gem "reverse_markdown", "~> 3.0"
 
 gem "graphlient", "~> 0.8.0"
+
+gem "webmock", "~> 3.25", group: :test

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -206,6 +206,9 @@ GEM
     concurrent-ruby (1.3.5)
     connection_pool (2.5.3)
     content_disposition (1.0.0)
+    crack (1.0.0)
+      bigdecimal
+      rexml
     crass (1.0.6)
     cronex (0.15.0)
       tzinfo
@@ -344,6 +347,7 @@ GEM
     has_scope (0.8.2)
       actionpack (>= 5.2)
       activesupport (>= 5.2)
+    hashdiff (1.2.0)
     hashie (5.0.0)
     highline (3.1.2)
       reline
@@ -896,6 +900,10 @@ GEM
       activesupport
       faraday (~> 2.0)
       faraday-follow_redirects
+    webmock (3.25.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
@@ -1031,6 +1039,7 @@ DEPENDENCIES
   vcr (~> 6.3)
   warning (~> 1.5)
   web-console (~> 4.1)
+  webmock (~> 3.25)
   with_model (~> 2.2)
 
 RUBY VERSION

--- a/app/jobs/update_metadata_from_link_job.rb
+++ b/app/jobs/update_metadata_from_link_job.rb
@@ -30,7 +30,7 @@ class UpdateMetadataFromLinkJob < ApplicationJob
 
   def import_files(data, model)
     data.dig(:file_urls)&.each do |it|
-      model.add_file_from_url(url: it[:url], filename: it[:filename])
+      model.create_or_update_file_from_url(url: it[:url], filename: it[:filename])
     rescue ActiveRecord::RecordInvalid
       Rails.logger.info("Couldn't add file #{it[:url]} to model #{model.to_param}")
     end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -148,11 +148,8 @@ class Model < ApplicationRecord
 
   def create_or_update_file_from_url(url:, filename:)
     uri = URI.parse(url)
-    if (file = model_files.find_by(filename: filename))
-      file.update_from_url!(url: url)
-    else
-      model_files.create!(filename: filename, attachment_remote_url: uri.to_s)
-    end
+    file = model_files.find_or_create_by(filename: filename)
+    file.update_from_url!(url: uri.to_s)
   rescue URI::InvalidURIError
   end
 

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -146,10 +146,10 @@ class Model < ApplicationRecord
     end
   end
 
-  def add_file_from_url(url:, filename:)
+  def create_or_update_file_from_url(url:, filename:)
     uri = URI.parse(url)
-    if model_files.exists?(filename: filename)
-      Rails.logger.info("Not downloading file #{filename} in model #{to_param}, already exists")
+    if (file = model_files.find_by(filename: filename))
+      file.update_from_url!(url: url)
     else
       model_files.create!(filename: filename, attachment_remote_url: uri.to_s)
     end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -150,6 +150,7 @@ class Model < ApplicationRecord
     uri = URI.parse(url)
     file = model_files.find_or_create_by(filename: filename)
     file.update_from_url!(url: uri.to_s)
+    file
   rescue URI::InvalidURIError
   end
 

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -234,8 +234,8 @@ class ModelFile < ApplicationRecord
       url,
       downloader: {
         headers: {
-          "If-None-Match" => attachment.metadata["remote_etag"],
-          "If-Modified-Since" => attachment.metadata["remote_last_modified"]
+          "If-None-Match" => attachment&.metadata&.dig("remote_etag"),
+          "If-Modified-Since" => attachment&.metadata&.dig("remote_last_modified")
         }.compact
       }
     )

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -229,6 +229,18 @@ class ModelFile < ApplicationRecord
     created_at
   end
 
+  def update_from_url!(url:)
+    attachment_attacher.assign_remote_url(
+      url,
+      downloader: {
+        headers: {
+          "If-None-Match" => attachment.metadata["remote_etag"],
+          "If-Modified-Since" => attachment.metadata["remote_last_modified"]
+        }.compact
+      }
+    )
+  end
+
   private
 
   def rescan_duplicates

--- a/app/uploaders/library_uploader.rb
+++ b/app/uploaders/library_uploader.rb
@@ -47,4 +47,14 @@ class LibraryUploader < Shrine
     Shrine.with_file(io) { |it| it.mtime }
   rescue NoMethodError
   end
+
+  add_metadata :remote_etag do |io|
+    io.meta["etag"]
+  rescue NoMethodError
+  end
+
+  add_metadata :remote_last_modified do |io|
+    io.meta["last-modified"]
+  rescue NoMethodError
+  end
 end

--- a/spec/cassettes/models/model/changed_file_success.yml
+++ b/spec/cassettes/models/model/changed_file_success.yml
@@ -1,0 +1,76 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Buildbee/example-stl/refs/heads/main/binary_cube.stl
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Down/5.4.2
+      If-None-Match:
+      - W/"outdated_etag"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '684'
+      Cache-Control:
+      - max-age=300
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - application/octet-stream
+      Etag:
+      - W/"357a8d67199ae2dcd1933fbd1fbd0bcee7b6a1aa26f284333e7e09a7f0248ab4"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Github-Request-Id:
+      - 126B:348A08:5E097:D68BC:687E294B
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Mon, 21 Jul 2025 12:33:24 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lcy-egml8630060-LCY
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1753101204.380296,VS0,VE122
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      X-Fastly-Request-Id:
+      - 4dae7dadc634b7b1ece17bd106641f1644d0c50c
+      Expires:
+      - Mon, 21 Jul 2025 12:38:24 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        Q09MT1I9f39/IE1BVEVSSUFMPX9/fyB/f38gf39/ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAMAAAAAACAvwAAAAAAAAAAAAAgwQAAIMEAAAAAAAAgwQAAIEEAAKBBAAAgwQAAIEEAAAAAAAAAAAAAAAAAAAAAgD8AACDBAAAgwQAAoEEAACBBAAAgwQAAoEEAACBBAAAgQQAAoEEAAAAAAAAAAAAAAACAPwAAIMEAACDBAACgQQAAIEEAACBBAACgQQAAIMEAACBBAACgQQAAAACAPwAAAAAAAAAAAAAgQQAAIMEAAAAAAAAgQQAAIEEAAAAAAAAgQQAAIMEAAKBBAAAAAAAAAACAPwAAAAAAACDBAAAgQQAAAAAAACBBAAAgQQAAoEEAACBBAAAgQQAAAAAAAAAAAAAAAAAAAACAvwAAIMEAACDBAAAAAAAAIMEAACBBAAAAAAAAIEEAACBBAAAAAAAAAACAvwAAAAAAAAAAAAAgwQAAIMEAAAAAAAAgwQAAIMEAAKBBAAAgwQAAIEEAAKBBAAAAAAAAAACAvwAAAAAAACDBAAAgwQAAAAAAACBBAAAgwQAAAAAAACDBAAAgwQAAoEEAAAAAAAAAAIC/AAAAAAAAIEEAACDBAAAAAAAAIEEAACDBAACgQQAAIMEAACDBAACgQQAAAAAAAAAAAAAAAIC/AAAgwQAAIMEAAAAAAAAgQQAAIEEAAAAAAAAgQQAAIMEAAAAAAAAAAIA/AAAAAAAAAIAAACBBAAAgQQAAAAAAACBBAAAgQQAAoEEAACBBAAAgwQAAoEEAAAAAAAAAAIA/AAAAAAAAIMEAACBBAAAAAAAAIMEAACBBAACgQQAAIEEAACBBAACgQQAA
+  recorded_at: Mon, 21 Jul 2025 12:33:24 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/models/model/new_file_success.yml
+++ b/spec/cassettes/models/model/new_file_success.yml
@@ -1,0 +1,74 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Buildbee/example-stl/refs/heads/main/binary_cube.stl
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Down/5.4.2
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '684'
+      Cache-Control:
+      - max-age=300
+      Content-Security-Policy:
+      - default-src 'none'; style-src 'unsafe-inline'; sandbox
+      Content-Type:
+      - application/octet-stream
+      Etag:
+      - W/"357a8d67199ae2dcd1933fbd1fbd0bcee7b6a1aa26f284333e7e09a7f0248ab4"
+      Strict-Transport-Security:
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - deny
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Github-Request-Id:
+      - 126B:348A08:5E097:D68BC:687E294B
+      Accept-Ranges:
+      - bytes
+      Date:
+      - Mon, 21 Jul 2025 12:08:29 GMT
+      Via:
+      - 1.1 varnish
+      X-Served-By:
+      - cache-lcy-egml8630028-LCY
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '0'
+      X-Timer:
+      - S1753099710.846136,VS0,VE98
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      X-Fastly-Request-Id:
+      - 44643d0b52a65398b8da4b146603ce48d9026a59
+      Expires:
+      - Mon, 21 Jul 2025 12:13:29 GMT
+      Source-Age:
+      - '0'
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        Q09MT1I9f39/IE1BVEVSSUFMPX9/fyB/f38gf39/ICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAgICAMAAAAAACAvwAAAAAAAAAAAAAgwQAAIMEAAAAAAAAgwQAAIEEAAKBBAAAgwQAAIEEAAAAAAAAAAAAAAAAAAAAAgD8AACDBAAAgwQAAoEEAACBBAAAgwQAAoEEAACBBAAAgQQAAoEEAAAAAAAAAAAAAAACAPwAAIMEAACDBAACgQQAAIEEAACBBAACgQQAAIMEAACBBAACgQQAAAACAPwAAAAAAAAAAAAAgQQAAIMEAAAAAAAAgQQAAIEEAAAAAAAAgQQAAIMEAAKBBAAAAAAAAAACAPwAAAAAAACDBAAAgQQAAAAAAACBBAAAgQQAAoEEAACBBAAAgQQAAAAAAAAAAAAAAAAAAAACAvwAAIMEAACDBAAAAAAAAIMEAACBBAAAAAAAAIEEAACBBAAAAAAAAAACAvwAAAAAAAAAAAAAgwQAAIMEAAAAAAAAgwQAAIMEAAKBBAAAgwQAAIEEAAKBBAAAAAAAAAACAvwAAAAAAACDBAAAgwQAAAAAAACBBAAAgwQAAAAAAACDBAAAgwQAAoEEAAAAAAAAAAIC/AAAAAAAAIEEAACDBAAAAAAAAIEEAACDBAACgQQAAIMEAACDBAACgQQAAAAAAAAAAAAAAAIC/AAAgwQAAIMEAAAAAAAAgQQAAIEEAAAAAAAAgQQAAIMEAAAAAAAAAAIA/AAAAAAAAAIAAACBBAAAgQQAAAAAAACBBAAAgQQAAoEEAACBBAAAgwQAAoEEAAAAAAAAAAIA/AAAAAAAAIMEAACBBAAAAAAAAIMEAACBBAACgQQAAIEEAACBBAACgQQAA
+  recorded_at: Mon, 21 Jul 2025 12:08:29 GMT
+recorded_with: VCR 6.3.1

--- a/spec/cassettes/models/model/unchanged_file_success.yml
+++ b/spec/cassettes/models/model/unchanged_file_success.yml
@@ -1,0 +1,57 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://raw.githubusercontent.com/Buildbee/example-stl/refs/heads/main/binary_cube.stl
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Down/5.4.2
+      If-None-Match:
+      - W/"357a8d67199ae2dcd1933fbd1fbd0bcee7b6a1aa26f284333e7e09a7f0248ab4"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 304
+      message: Not Modified
+    headers:
+      Connection:
+      - keep-alive
+      Date:
+      - Mon, 21 Jul 2025 12:33:49 GMT
+      Via:
+      - 1.1 varnish
+      Cache-Control:
+      - max-age=300
+      Etag:
+      - W/"357a8d67199ae2dcd1933fbd1fbd0bcee7b6a1aa26f284333e7e09a7f0248ab4"
+      X-Served-By:
+      - cache-lcy-egml8630038-LCY
+      X-Cache:
+      - HIT
+      X-Cache-Hits:
+      - '1'
+      X-Timer:
+      - S1753101229.162513,VS0,VE1
+      Vary:
+      - Authorization,Accept-Encoding
+      Access-Control-Allow-Origin:
+      - "*"
+      Cross-Origin-Resource-Policy:
+      - cross-origin
+      X-Fastly-Request-Id:
+      - 6c987c80d82270d4e46fd82354100633db11e809
+      Expires:
+      - Mon, 21 Jul 2025 12:38:49 GMT
+      Source-Age:
+      - '25'
+    body:
+      encoding: UTF-8
+      string: ''
+  recorded_at: Mon, 21 Jul 2025 12:33:49 GMT
+recorded_with: VCR 6.3.1

--- a/spec/support/vcr.rb
+++ b/spec/support/vcr.rb
@@ -2,7 +2,7 @@ require "vcr"
 
 VCR.configure do |config|
   config.cassette_library_dir = "spec/cassettes"
-  config.hook_into :faraday
+  config.hook_into :webmock
   config.ignore_localhost = true
   config.configure_rspec_metadata!
 end


### PR DESCRIPTION
This uses HTTP ETags and Last-Modified dates, so it does rely on that working properly remotely. Resolves #4514