### PR TITLE
Rename object_id to model_id in deserializers

### DIFF
--- a/app/deserializers/integrations/my_mini_factory/model_deserializer.rb
+++ b/app/deserializers/integrations/my_mini_factory/model_deserializer.rb
@@ -1,10 +1,10 @@
 class Integrations::MyMiniFactory::ModelDeserializer < Integrations::MyMiniFactory::BaseDeserializer
-  attr_reader :object_id
+  attr_reader :model_id
 
   def deserialize
     return {} unless valid?
     # Fetch from MMF API
-    r = fetch "objects/#{CGI.escapeURIComponent(@object_id)}"
+    r = fetch "objects/#{CGI.escapeURIComponent(@model_id)}"
     {
       name: r.body["name"],
       notes: ReverseMarkdown.convert(r.body["description_html"]),
@@ -32,7 +32,7 @@ class Integrations::MyMiniFactory::ModelDeserializer < Integrations::MyMiniFacto
 
   def valid_path?(path)
     match = /\A\/object\/3d-print-[[:alnum:]-]+-([[:digit:]]+)\Z/.match(path)
-    @object_id = match[1] if match.present?
+    @model_id = match[1] if match.present?
     match.present?
   end
 end

--- a/app/deserializers/integrations/thangs/model_deserializer.rb
+++ b/app/deserializers/integrations/thangs/model_deserializer.rb
@@ -1,9 +1,9 @@
 class Integrations::Thangs::ModelDeserializer < Integrations::Thangs::BaseDeserializer
-  attr_reader :object_id
+  attr_reader :model_id
 
   def deserialize
     return {} unless valid?
-    r = fetch "models/#{CGI.escapeURIComponent(@object_id)}"
+    r = fetch "models/#{CGI.escapeURIComponent(@model_id)}"
     files = r.body.dig("attachments").filter_map { |it| {url: it.dig("imageUrl"), filename: filename_from_url(it.dig("imageUrl"))} if it.dig("attachmentType") == "image" }
     {
       name: r.body["name"],
@@ -31,7 +31,7 @@ class Integrations::Thangs::ModelDeserializer < Integrations::Thangs::BaseDeseri
 
   def valid_path?(path)
     match = /\A\/designer\/#{PATH_COMPONENTS[:username]}\/3d-model\/#{PATH_COMPONENTS[:model_slug]}-#{PATH_COMPONENTS[:model_id]}\Z/.match(CGI.unescape(path))
-    @object_id = match[:model_id] if match.present?
+    @model_id = match[:model_id] if match.present?
     match.present?
   end
 

--- a/app/deserializers/integrations/thingiverse/model_deserializer.rb
+++ b/app/deserializers/integrations/thingiverse/model_deserializer.rb
@@ -1,9 +1,9 @@
 class Integrations::Thingiverse::ModelDeserializer < Integrations::Thingiverse::BaseDeserializer
-  attr_reader :object_id
+  attr_reader :model_id
 
   def deserialize
     return {} unless valid?
-    r = fetch "things/#{CGI.escapeURIComponent(@object_id)}"
+    r = fetch "things/#{CGI.escapeURIComponent(@model_id)}"
     {
       name: r.body["name"],
       notes: r.body["description"],
@@ -34,7 +34,7 @@ class Integrations::Thingiverse::ModelDeserializer < Integrations::Thingiverse::
 
   def valid_path?(path)
     match = /\A\/thing:([[:digit:]]+)\Z/.match(path)
-    @object_id = match[1] if match.present?
+    @model_id = match[1] if match.present?
     match.present?
   end
 end

--- a/spec/deserializers/integrations/my_mini_factory/model_deserializer_spec.rb
+++ b/spec/deserializers/integrations/my_mini_factory/model_deserializer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Integrations::MyMiniFactory::ModelDeserializer, :mmf_api_key do
 
     it "extracts object ID" do
       deserializer = described_class.new(uri: "https://www.myminifactory.com/object/3d-print-example-1234")
-      expect(deserializer.object_id).to eq "1234"
+      expect(deserializer.model_id).to eq "1234"
     end
   end
 

--- a/spec/deserializers/integrations/thangs/model_deserializer_spec.rb
+++ b/spec/deserializers/integrations/thangs/model_deserializer_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Integrations::Thangs::ModelDeserializer, :thingiverse_api_key do
 
     it "extracts object ID" do
       deserializer = described_class.new(uri: "https://thangs.com/designer/CHEP/3d-model/CHEP%20Cube%20-%20Calibration%20Cube-29638")
-      expect(deserializer.object_id).to eq "29638"
+      expect(deserializer.model_id).to eq "29638"
     end
   end
 

--- a/spec/deserializers/integrations/thingiverse/model_deserializer_spec.rb
+++ b/spec/deserializers/integrations/thingiverse/model_deserializer_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Integrations::Thingiverse::ModelDeserializer, :thingiverse_api_ke
 
     it "extracts object ID" do
       deserializer = described_class.new(uri: "https://www.thingiverse.com/thing:4049220")
-      expect(deserializer.object_id).to eq "4049220"
+      expect(deserializer.model_id).to eq "4049220"
     end
   end
 


### PR DESCRIPTION
Resolves warnings about redefining `object_id`, which is a low-level Ruby thing.