### PR TITLE
URL parameter for per_page on problems list

### DIFF
--- a/app/controllers/problems_controller.rb
+++ b/app/controllers/problems_controller.rb
@@ -26,7 +26,7 @@ class ProblemsController < ApplicationController
     # Don't show types ignored in user settings
     query = query.visible(helpers.problem_settings)
     query = query.includes([:problematic])
-    @problems = query.page(page).per(50).order([:category, :problematic_type]).includes(problematic: [:library, :model])
+    @problems = query.page(page).per(params[:per_page]&.to_i || 50).order([:category, :problematic_type]).includes(problematic: [:library, :model])
     # Do we have any filters at all?
     @filters_applied = [:show_ignored, :severity, :category, :type].any? { |k| params.has_key?(k) }
   end


### PR DESCRIPTION
No UI for it yet though, this is just a quick hacky workaround for #4552 until a proper fix can be done. Add `per_page=xx` as a query parameter to the problem list URL.