### PR TITLE
Add button to scan a single library

### DIFF
--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -43,6 +43,7 @@
               <div class="btn-group">
                 <button type="button" data-bs-toggle="dropdown" aria-expanded="false"
                   class="btn btn-warning btn-sm mt-1 dropdown-toggle">
+                  <%= render Components::Icon.new(icon: "radar") %>
                   <%= t ".scan" %>
                 </button>
                 <ul class="dropdown-menu">

--- a/app/views/libraries/index.html.erb
+++ b/app/views/libraries/index.html.erb
@@ -13,7 +13,11 @@
           <%= content_tag(:small, class: "text-info float-end") { t("activerecord.attributes.library.default") } if library.default? %>
         </div>
         <div class="card-body">
-          <%= link_to t("general.edit"), edit_library_path(library), {class: "btn btn-secondary float-end #{policy(:library).edit? ? "" : "disabled"}"} %>
+          <div class="float-end">
+            <%= render Components::GoButton.new(icon: "box", icon_only: true, label: Model.model_name.human.pluralize, href: models_path(library: library.to_param), variant: "outline-secondary") %>
+            <%= render Components::DoButton.new(icon: "radar", icon_only: true, label: t("application.navbar.scan_changes"), href: scans_path(library: library.to_param), method: :post, variant: "outline-warning") if policy(:scan).create? %>
+            <%= render Components::GoButton.new(icon: "pencil", label: t("general.edit"), href: edit_library_path(library), variant: :secondary) %>
+          </div>
           <p>
             <%= markdownify(library.notes) if library.notes %>
           </p>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -312,7 +312,7 @@ en:
         toggler:
           label: Toggle navigation
       scan: Scan
-      scan_changes: Scan for changes
+      scan_changes: Scan for new files
       scanning: Scanning
       search: Search
       settings: Site Settings


### PR DESCRIPTION
Resolves #4401. You can do a "scan for new files", or you can filter the model list then run a metadata rescan from there.