### PR TITLE
Add `manyfold links sync` command to batch run link synchronisations

### DIFF
--- a/bin/manyfold
+++ b/bin/manyfold
@@ -108,6 +108,15 @@ class LinksCommand < Thor
   def deduplicate
     Link.find_duplicated.each(&:remove_duplicates!)
   end
+
+  desc "sync", "run synchronisation with target"
+  option :match, required: false, type: :string, description: "only sync links with URLs that match"
+  def sync
+    scope = Link.all # rubocop:disable Pundit/UsePolicyScope
+    scope = scope.where("url LIKE '%#{options[:match]}%'") if options[:match]
+    puts "\nQueueing #{scope.count} links for synchronisation"
+    scope.find_each(&:update_metadata_from_link_later)
+  end
 end
 
 class ManyfoldCLI < Thor


### PR DESCRIPTION
You can filter the URLs to sync as well: `bin/manyfold links sync --match=thingiverse.com`