### PR TITLE
Allow registration of FASP providers

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -156,7 +156,7 @@ gem "devise_zxcvbn", "~> 6.0"
 gem "federails", git: "https://gitlab.com/experimentslabs/federails.git", branch: "nodeinfo-metadata"
 gem "federails-moderation", "~> 0.3"
 gem "caber", github: "manyfold3d/caber"
-gem "fasp_client", github: "manyfold3d/fasp_client", ref: "v0.1.0"
+gem "fasp_client", github: "manyfold3d/fasp_client", ref: "v0.1.1"
 
 gem "nanoid", "~> 2.0"
 

--- a/Gemfile
+++ b/Gemfile
@@ -153,9 +153,10 @@ gem "better_content_security_policy", "~> 0.1"
 
 gem "devise_zxcvbn", "~> 6.0"
 
-gem "federails", git: "https://gitlab.com/experimentslabs/federails.git", branch: "merge-contexts"
+gem "federails", git: "https://gitlab.com/experimentslabs/federails.git", branch: "nodeinfo-metadata"
 gem "federails-moderation", "~> 0.3"
 gem "caber", github: "manyfold3d/caber"
+gem "fasp_client", github: "manyfold3d/fasp_client", ref: "v0.1.0"
 
 gem "nanoid", "~> 2.0"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,16 @@ GIT
       rails (>= 7.1.4)
 
 GIT
+  remote: https://github.com/manyfold3d/fasp_client.git
+  revision: faecf7b29d85ddecc6400c6ee840939d1542fcb4
+  ref: v0.1.0
+  specs:
+    fasp_client (0.1.0)
+      ed25519 (~> 1.4)
+      linzer (~> 0.7)
+      rails (~> 8.0)
+
+GIT
   remote: https://github.com/manyfold3d/rubocop-pundit.git
   revision: 1f511e087a58867279ca8d77e0bb97dc2ce2da75
   specs:
@@ -23,8 +33,8 @@ GIT
 
 GIT
   remote: https://gitlab.com/experimentslabs/federails.git
-  revision: 26813a09b022bd01423fdc23e5e0f350ebd42d71
-  branch: merge-contexts
+  revision: 338c1691256fa6000c643581f38221865043b3f3
+  branch: nodeinfo-metadata
   specs:
     federails (0.7.0)
       faraday
@@ -186,6 +196,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
+    cgi (0.4.2)
     chunky_png (1.4.0)
     climate_control (1.2.0)
     cocooned (2.4.1)
@@ -235,6 +246,7 @@ GEM
     down (5.4.2)
       addressable (~> 2.8)
     drb (2.2.3)
+    ed25519 (1.4.0)
     email_validator (2.2.4)
       activemodel
     erb (5.0.2)
@@ -423,6 +435,16 @@ GEM
       launchy (>= 2.2, < 4)
     link_header (0.0.8)
     lint_roller (1.1.0)
+    linzer (0.7.7)
+      cgi (~> 0.4.2)
+      forwardable (~> 1.3, >= 1.3.3)
+      logger (~> 1.7, >= 1.7.0)
+      net-http (~> 0.6.0)
+      openssl (~> 3.0, >= 3.0.0)
+      rack (>= 2.2, < 4.0)
+      starry (~> 0.2)
+      stringio (~> 3.1, >= 3.1.2)
+      uri (~> 1.0, >= 1.0.2)
     listen (3.9.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -516,6 +538,7 @@ GEM
       tzinfo
       validate_url
       webfinger (~> 2.0)
+    openssl (3.3.0)
     orm_adapter (0.5.0)
     ostruct (0.6.1)
     parallel (1.27.0)
@@ -810,6 +833,8 @@ GEM
     standard-performance (1.8.0)
       lint_roller (~> 1.1)
       rubocop-performance (~> 1.25.0)
+    starry (0.2.0)
+      base64
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stopwords-filter2 (0.1.0)
@@ -921,6 +946,7 @@ DEPENDENCIES
   erb_lint (~> 0.9)
   factory_bot
   faker (~> 3.5)
+  fasp_client!
   federails!
   federails-moderation (~> 0.3)
   ffi-libarchive (~> 1.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,8 +16,8 @@ GIT
 
 GIT
   remote: https://github.com/manyfold3d/fasp_client.git
-  revision: faecf7b29d85ddecc6400c6ee840939d1542fcb4
-  ref: v0.1.0
+  revision: 78ffd0f694639dd7f5d4a2fe7588b32bd7788bf8
+  ref: v0.1.1
   specs:
     fasp_client (0.1.0)
       ed25519 (~> 1.4)

--- a/config/initializers/federails.rb
+++ b/config/initializers/federails.rb
@@ -17,6 +17,10 @@ Federails.configure do |conf|
   conf.client_routes_path = "client"
 
   conf.remote_follow_url_method = :new_follow_url
+
+  conf.nodeinfo_metadata = -> do
+    {"faspBaseUrl" => Rails.application.routes.url_helpers.fasp_client_url}
+  end
 end
 
 Federails::Moderation.configure do |conf|

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,4 +163,6 @@ Rails.application.routes.draw do
   # Web crawler stuff
   get "/robots", to: "robots#index"
   get "/sitemap", to: "robots#sitemap"
+
+  mount FaspClient::Engine => "/fasp"
 end

--- a/db/migrate/20250806142734_create_fasp_client_providers.fasp_client.rb
+++ b/db/migrate/20250806142734_create_fasp_client_providers.fasp_client.rb
@@ -1,0 +1,20 @@
+# This migration comes from fasp_client (originally 20250801150509)
+class CreateFaspClientProviders < ActiveRecord::Migration[8.0]
+  def change
+    create_table :fasp_client_providers do |t|
+      t.string :uuid
+      t.string :name
+      t.string :base_url
+      t.string :server_id
+      t.string :public_key
+      t.string :ed25519_signing_key
+      t.integer :status
+      t.json :capabilities
+      t.json :privacy_policy
+      t.string :sign_in_url
+      t.string :contact_email
+      t.string :fediverse_account
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_07_24_094951) do
+ActiveRecord::Schema[8.0].define(version: 2025_08_06_142734) do
   create_table "altcha_solutions", force: :cascade do |t|
     t.string "algorithm"
     t.string "challenge"
@@ -97,6 +97,23 @@ ActiveRecord::Schema[8.0].define(version: 2025_07_24_094951) do
   end
 
   create_table "data_migrations", primary_key: "version", id: :string, force: :cascade do |t|
+  end
+
+  create_table "fasp_client_providers", force: :cascade do |t|
+    t.string "uuid"
+    t.string "name"
+    t.string "base_url"
+    t.string "server_id"
+    t.string "public_key"
+    t.string "ed25519_signing_key"
+    t.integer "status"
+    t.json "capabilities"
+    t.json "privacy_policy"
+    t.string "sign_in_url"
+    t.string "contact_email"
+    t.string "fediverse_account"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
   end
 
   create_table "favorites", force: :cascade do |t|


### PR DESCRIPTION
Using https://github.com/manyfold3d/fasp_client, this PR adds support for the FASP standard for connecting to auxiliary service providers; currently the UI lacks design and authentication, but the fundamentals are working.

Resolves #4582 
Resolves #4583 
Resolves #4584 
Resolves #4585 
Resolves #4586 
Resolves #4588 
