### PR TITLE
Handle file access and other errors during backfill jobs

### DIFF
--- a/app/jobs/upgrade/backfill_image_derivatives.rb
+++ b/app/jobs/upgrade/backfill_image_derivatives.rb
@@ -16,8 +16,12 @@ class Upgrade::BackfillImageDerivatives < ApplicationJob
     Rails.logger.info("Creating image derivatives for: #{modelfile.path_within_library}")
     modelfile.attachment_derivatives!
     modelfile.save(touch: false, validate: false)
+  rescue Errno::EACCES => ex
+    Rails.logger.error ex.message
   rescue Shrine::FileNotFound
     Rails.logger.error("File not found: #{modelfile.path_within_library}")
+  rescue Shrine::Error => ex
+    Rails.logger.error("File error: #{ex.message} #{modelfile.path_within_library}")
   rescue MiniMagick::Error => ex
     Rails.logger.error ex.message
   end

--- a/app/jobs/upgrade/fix_nil_file_size_values.rb
+++ b/app/jobs/upgrade/fix_nil_file_size_values.rb
@@ -11,7 +11,11 @@ class Upgrade::FixNilFileSizeValues < ApplicationJob
   def each_iteration(modelfile)
     modelfile.attachment_attacher.refresh_metadata!
     modelfile.save(touch: false)
+  rescue Errno::EACCES => ex
+    Rails.logger.error ex.message
   rescue Shrine::FileNotFound
-    Rails.logger.info("File not found during FixNilFileSizeValues upgrade job: #{modelfile.path_within_library}")
+    Rails.logger.error("File not found: #{modelfile.path_within_library}")
+  rescue Shrine::Error => ex
+    Rails.logger.error("File error: #{ex.message} #{modelfile.path_within_library}")
   end
 end


### PR DESCRIPTION
Makes sure we don't crap out halfway through a backfill due to errors on a single file