### PR TITLE
Add three CERN licenses

### DIFF
--- a/app/helpers/models_helper.rb
+++ b/app/helpers/models_helper.rb
@@ -43,6 +43,9 @@ module ModelsHelper
         CC-BY-SA-4.0
         CC-PDDC
         CC0-1.0
+        CERN-OHL-P-2.0
+        CERN-OHL-S-2.0
+        CERN-OHL-W-2.0
         MIT
         GPL-2.0-only
         GPL-3.0-only

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -760,6 +760,9 @@ en:
     CC-BY-SA-40: Creative Commons Attribution ShareAlike
     CC-PDDC: Creative Commons Public Domain Declaration
     CC0-10: Creative Commons Zero
+    CERN-OHL-P-20: CERN Open Hardware Licence Version 2 - Permissive
+    CERN-OHL-S-20: CERN Open Hardware Licence Version 2 - Strongly Reciprocal
+    CERN-OHL-W-20: CERN Open Hardware Licence Version 2 - Weakly Reciprocal
     GPL-20-only: GNU General Public License v2.0
     GPL-30-only: GNU General Public License v3.0
     LGPL-20-only: GNU Lesser General Public License v2

--- a/spec/helpers/models_helper_spec.rb
+++ b/spec/helpers/models_helper_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe ModelsHelper do
       expect(helper.license_select_options).to include('<option value="CC0-1.0">Creative Commons Zero</option>')
     end
 
+    it "includes CERN licenses" do
+      expect(helper.license_select_options).to include('<option value="CERN-OHL-S-2.0">CERN Open Hardware Licence Version 2 - Strongly Reciprocal</option>')
+    end
+
     it "sets selected option" do
       expect(helper.license_select_options(selected: "CC0-1.0")).to include('<option selected="selected" value="CC0-1.0">Creative Commons Zero</option>')
     end


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [x] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Summary

This adds three new licenses. It includes the CERN Open Hardware Licence Version 2 - Permissive, Strongly Reciprocal and Weakly Reciprocal variants, known by the CERN-OHL-P-2.0, CERN-OHL-S-2.0 and CERN-OHL-W-2.0 SPDX identifiers respectively.

## Linked issues

I copied the approach taken in #4389. Let me know if you've another preferred way you'd like to handle this instead.

## Description of changes

* Adds three licenses to the `ModelsHelper` > `license_select_options` method.
* Adds three "translations" to the English locale.
* Adds a test to ensure one of our new options is visible in the licence drop down.

<img width="1725" height="847" alt="image" src="https://github.com/user-attachments/assets/d69d6a6f-e11c-4139-b7a2-197aea1ec794" />
