### PR TITLE
Include toot:discoverable in ActivityPub responses

### DIFF
--- a/app/serializers/activity_pub/collection_serializer.rb
+++ b/app/serializers/activity_pub/collection_serializer.rb
@@ -7,13 +7,15 @@ module ActivityPub
           {
             f3di: "http://purl.org/f3di/ns#",
             toot: "http://joinmastodon.org/ns#",
-            indexable: "toot:indexable"
+            indexable: "toot:indexable",
+            discoverable: "toot:discoverable"
           }
         ],
         summary: @object.caption,
         content: @object.notes,
         "f3di:concreteType": "Collection",
         indexable: @object.indexable?,
+        discoverable: @object.indexable?,
         attachment: @object.links.map { |it| {type: "Link", href: it.url} },
         attributedTo: short_creator(@object.creator),
         context: short_collection(@object.collection),

--- a/app/serializers/activity_pub/creator_serializer.rb
+++ b/app/serializers/activity_pub/creator_serializer.rb
@@ -7,6 +7,7 @@ module ActivityPub
           f3di: "http://purl.org/f3di/ns#",
           toot: "http://joinmastodon.org/ns#",
           indexable: "toot:indexable",
+          discoverable: "toot:discoverable",
           attributionDomains: {
             "@id": "toot:attributionDomains",
             "@type": "@id"
@@ -19,6 +20,7 @@ module ActivityPub
         ],
         "f3di:concreteType": "Creator",
         indexable: @object.indexable?,
+        discoverable: @object.indexable?,
         attachment: @object.links.map { |it| {type: "Link", href: it.url} }
       }.merge(address_fields)
     end

--- a/app/serializers/activity_pub/model_serializer.rb
+++ b/app/serializers/activity_pub/model_serializer.rb
@@ -11,7 +11,8 @@ module ActivityPub
             toot: "http://joinmastodon.org/ns#",
             Hashtag: "as:Hashtag",
             sensitive: "as:sensitive",
-            indexable: "toot:indexable"
+            indexable: "toot:indexable",
+            discoverable: "toot:discoverable"
           }
         ],
         summary: @object.caption,
@@ -20,6 +21,7 @@ module ActivityPub
         attachment: @object.links.map { |it| {type: "Link", href: it.url} },
         sensitive: @object.sensitive,
         indexable: @object.indexable?,
+        discoverable: @object.indexable?,
         tag: hashtags,
         attributedTo: short_creator(@object.creator),
         context: short_collection(@object.collection),

--- a/spec/serializers/activity_pub/generic_activity_pub_serializer_shared.rb
+++ b/spec/serializers/activity_pub/generic_activity_pub_serializer_shared.rb
@@ -26,4 +26,12 @@ shared_examples "GenericActivityPubSerializer" do
       indexable: true
     })
   end
+
+  it "includes discoverable flag set to same as indexable" do
+    allow(SiteSettings).to receive(:default_indexable).and_return(false)
+    object.update!(indexable: "yes")
+    expect(ap).to include({
+      discoverable: true
+    })
+  end
 end


### PR DESCRIPTION
Currently controller by same option as `indexable`, so there's no specific separate choice for the user. Resolves #4688

In the longer term we should break out this single choice into a sensible set of user preferences around discovery, visibility, indexing etc, but I don't think I know enough about that yet to do it sensibly.