### PR TITLE
Remove hexagon avatars from Vapor theme

### DIFF
--- a/app/assets/stylesheets/src/avatars.scss
+++ b/app/assets/stylesheets/src/avatars.scss
@@ -12,9 +12,3 @@ img.avatar {
 		width: 6rem;
 	}
 }
-
-// Let's have hexagon avatars in the Vapor theme, just for fun!
-body.vapor-theme img.avatar {
-	aspect-ratio: 0.8660254;
-	clip-path: polygon(0% 25%, 0 74%, 50% 100%, 100% 75%, 100% 25%, 50% 0%);
-}


### PR DESCRIPTION
Doesn't actually work in reality. Never mind.