### PR TITLE
Add option to make models public by default

### DIFF
--- a/app/models/concerns/caber_object.rb
+++ b/app/models/concerns/caber_object.rb
@@ -32,8 +32,12 @@ module CaberObject
 
   def assign_default_permissions
     # Grant local view access by default
-    role = SiteSettings.default_viewer_role
-    grant_permission_to("view", Role.find_or_create_by(name: role)) if role.presence
+    case SiteSettings.default_viewer_role.to_sym
+    when :member
+      grant_permission_to("view", Role.find_or_create_by(name: "member"))
+    when :public
+      grant_permission_to("view", nil)
+    end
     # Set default owner if an owner isn't already set
     if permitted_users.with_permission("own").empty?
       owner = SiteSettings.default_user

--- a/app/views/home/_uploading.html.erb
+++ b/app/views/home/_uploading.html.erb
@@ -16,6 +16,7 @@
     <p>
       <%= t ".permissions.private" if SiteSettings.default_viewer_role == "" %>
       <%= t ".permissions.member" if SiteSettings.default_viewer_role == "member" %>
+      <%= t ".permissions.public" if SiteSettings.default_viewer_role == "public" %>
       <%= t ".permissions.edit" %>
     </p>
     <div class="text-end">

--- a/app/views/settings/multiuser.html.erb
+++ b/app/views/settings/multiuser.html.erb
@@ -67,7 +67,8 @@
     <div class="col-sm-8">
       <%= form.select "multiuser[default_viewer_role]",
             [[translate(".default_viewer_role.options.none"), ""],
-              [translate(".default_viewer_role.options.member"), "member"]],
+              [translate(".default_viewer_role.options.member"), "member"],
+              [translate(".default_viewer_role.options.public"), "public"]],
             {selected: SiteSettings.default_viewer_role.to_s},
             {class: "form-select"} %>
       <small><%= t(".default_viewer_role.help") %></small>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -690,6 +690,7 @@ en:
         edit: You can grant additional permissions on the item's edit page.
         member: By default, uploaded content will be visible to any local logged-in user.
         private: By default, uploaded content will not be visible to any other users.
+        public: By default, uploaded content will be publicly visible to anyone who visits the site.
       quota: You can upload up to %{quota} of content, and you can always view your current quota usage on your settings page.
       title: Uploading
       upload: Upload

--- a/config/locales/settings/en.yml
+++ b/config/locales/settings/en.yml
@@ -139,6 +139,7 @@ en:
         options:
           member: Members (logged-in local accounts)
           none: Private
+          public: Public
       details_html: To change these settings, edit the server's <a href='https://manyfold.app/sysadmin/configuration.html'>environment variables</a> and restart.
       email: Email delivery configured?
       federation: Federation enabled?

--- a/spec/models/concerns/caber_object_shared.rb
+++ b/spec/models/concerns/caber_object_shared.rb
@@ -19,6 +19,22 @@ shared_examples "Caber::Object" do
     expect(object.grants_permission_to?("own", admin)).to be false
   end
 
+  context "with default permissions set to public" do
+    before do
+      allow(SiteSettings).to receive(:default_viewer_role).and_return(:public)
+    end
+
+    let(:object) { create(described_class.to_s.underscore.to_sym) }
+
+    it "grants view permission to member role" do
+      expect(object.grants_permission_to?("view", nil)).to be true
+    end
+
+    it "does not grant public update permission" do
+      expect(object.grants_permission_to?("update", nil)).to be false
+    end
+  end
+
   context "with default permissions set to member-visible" do
     before do
       allow(SiteSettings).to receive(:default_viewer_role).and_return(:member)
@@ -30,7 +46,7 @@ shared_examples "Caber::Object" do
       expect(object.grants_permission_to?("view", Role.find_by!(name: "member"))).to be true
     end
 
-    it "does not grants public view permission" do
+    it "does not grant public view permission" do
       expect(object.grants_permission_to?("view", nil)).to be false
     end
   end
@@ -46,7 +62,7 @@ shared_examples "Caber::Object" do
       expect(object.grants_permission_to?("view", Role.find_by!(name: "member"))).to be false
     end
 
-    it "does not grants public view permission" do
+    it "does not grant public view permission" do
       expect(object.grants_permission_to?("view", nil)).to be false
     end
   end


### PR DESCRIPTION
Works; a followup PR will deal with issues that come out when license/creator aren't set (like when doing thinigverse sync)