### PR TITLE
Update Federails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -153,7 +153,7 @@ gem "better_content_security_policy", "~> 0.1"
 
 gem "devise_zxcvbn", "~> 6.0"
 
-gem "federails", git: "https://gitlab.com/experimentslabs/federails.git", branch: "mariadb-serialization"
+gem "federails", git: "https://gitlab.com/experimentslabs/federails.git", branch: "main"
 gem "federails-moderation", "~> 0.3"
 gem "caber", github: "manyfold3d/caber"
 gem "fasp_client", "~> 0.6"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -30,8 +30,8 @@ GIT
 
 GIT
   remote: https://gitlab.com/experimentslabs/federails.git
-  revision: c72b26f802f28e58d8619cbda33b03165b699da3
-  branch: mariadb-serialization
+  revision: 41d26258cdbb19650d55390441b97540e84d20fa
+  branch: main
   specs:
     federails (0.7.0)
       faraday

--- a/db/migrate/20251010145758_create_federails_hosts.federails.rb
+++ b/db/migrate/20251010145758_create_federails_hosts.federails.rb
@@ -1,0 +1,23 @@
+# This migration comes from federails (originally 20250426061729)
+class CreateFederailsHosts < ActiveRecord::Migration[7.2]
+  def change
+    create_table :federails_hosts do |t|
+      t.string :domain, null: false, default: nil
+      t.string :nodeinfo_url
+      t.string :software_name
+      t.string :software_version
+
+      # Uncomment the lines below if you use PostgreSQL
+      # t.jsonb :protocols, default: []
+      # t.jsonb :services, default: {}
+      #
+      # Other databases
+      t.text :protocols, default: "[]"
+      t.text :services, default: "{}"
+
+      t.timestamps
+
+      t.index :domain, unique: true
+    end
+  end
+end


### PR DESCRIPTION
Adds host caching, nodeinfo fix, and includes mariadb serialization from the branch we were using before.