### PR TITLE
Faster manifold check

### DIFF
--- a/app/jobs/analysis/geometric_analysis_job.rb
+++ b/app/jobs/analysis/geometric_analysis_job.rb
@@ -17,7 +17,7 @@ class Analysis::GeometricAnalysisJob < ApplicationJob
       if mesh
         status[:step] = "jobs.analysis.geometric_analysis.manifold_check" # i18n-tasks-use t('jobs.analysis.geometric_analysis.manifold_check')
         # Check for manifold mesh
-        manifold = mesh.manifold?
+        manifold = manifold?(mesh)
         Problem.create_or_clear(
           file,
           :non_manifold,
@@ -52,5 +52,34 @@ class Analysis::GeometricAnalysisJob < ApplicationJob
   def self.load_mesh(file)
     # TODO: This can be better, but needs changes upstream in Mittsu to allow loaders to parse from an IO object
     loader(file)&.new&.parse(file.attachment.read)
+  end
+
+  private
+
+  def manifold?(mesh)
+    # Shortcut if there is nothing here
+    return true if mesh.geometry.nil? && mesh.children.empty?
+    # Recurse children to see if they are manifold
+    children_are_manifold = mesh.children.map { |x| manifold?(x) }.all?
+    # Detect manifold geometry in this object
+    edges = {}
+    # For each face, record its edges in the edge hash
+    mesh.geometry&.faces&.each do |face|
+      update_edge_hash face.a, face.b, edges
+      update_edge_hash face.b, face.c, edges
+      update_edge_hash face.c, face.a, edges
+    end
+    # If there's anything left in the edge hash, then either
+    # we have holes, or we have badly oriented faces
+    edges.empty? && children_are_manifold
+  end
+
+  # Updates edge hash with the passed vertex indexes
+  # First, the reverse edge is searched for in the hash
+  # If found, it's removed as we've got a match
+  # If not, we record this edge in the hash
+  def update_edge_hash(v1, v2, edges)
+    return if edges.delete "#{v2}->#{v1}"
+    edges["#{v1}->#{v2}"] = true
   end
 end

--- a/app/jobs/analysis/geometric_analysis_job.rb
+++ b/app/jobs/analysis/geometric_analysis_job.rb
@@ -9,7 +9,7 @@ class Analysis::GeometricAnalysisJob < ApplicationJob
   def perform(file_id)
     # Get model
     file = ModelFile.find(file_id)
-    return unless file.loadable?
+    return unless FileHandlers::Assimp.can_load?(file.mime_type)
     if SiteSettings.analyse_manifold
       status[:step] = "jobs.analysis.geometric_analysis.loading_mesh" # i18n-tasks-use t('jobs.analysis.geometric_analysis.loading_mesh')
       # Get mesh


### PR DESCRIPTION
By using assimp loader and models, we can make the manifold check faster. This PR at present gives at least a 5x speed improvement; loading is super fast, though the manifold check is still slowish as it's done in Ruby. Still a big increase.

Unfortunately due to a bug in assimp's vertex join postprocessing (see https://github.com/assimp/assimp/pull/6278), it currently fails, as all meshes are coming up as non-manifold because of repeated vertices. We'll need to wait for the assimp 6.0.3 release before we can merge this.