### PR TITLE
Add specific i18n section in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -22,10 +22,13 @@ changelog:
     - title: ⛑️ Trust & Safety ⛑️
       labels:
         - trust+safety
-    - title: 🌍 Sustainability & Performance 🌍
+    - title: 🔋 Sustainability & Performance 🔋
       labels:
         - sustainability
         - performance
+    - title: 🌍 Internationalization 🌏
+      labels:
+        - localisation
     - title: 🛠️ Other Improvements 🛠️
       labels:
         - "*"


### PR DESCRIPTION
Now that we can highlight specific languages in separate PRs, it'll be nice to pull them out in the release notes