### PR TITLE
Don't use outline variants of secondary buttons

### DIFF
--- a/app/components/burger_menu.rb
+++ b/app/components/burger_menu.rb
@@ -6,7 +6,7 @@ class Components::BurgerMenu < Components::Base
   end
 
   def view_template
-    classes = %w[btn btn-outline-secondary]
+    classes = %w[btn btn-secondary]
     classes << "btn-sm" if @small
     div do
       a href: "#", role: "button", data: {bs_toggle: "dropdown"}, aria: {expanded: false}, class: classes.join(" ") do

--- a/app/components/select_input_row.rb
+++ b/app/components/select_input_row.rb
@@ -17,7 +17,7 @@ class Components::SelectInputRow < Components::InputRow
       }
     )
     if @options[:button]
-      a href: @options[:button][:path], class: "btn btn-outline-secondary" do
+      a href: @options[:button][:path], class: "btn btn-secondary" do
         @options[:button][:label]
       end
     end

--- a/app/views/application/_order_buttons.html.erb
+++ b/app/views/application/_order_buttons.html.erb
@@ -1,4 +1,4 @@
 <div class="float-end mb-3">
-  <%= link_to Icon(icon: "book", label: t(".sort.name")), {order: "name"}.merge(@filter&.to_params), class: "btn #{(session["order"] == "name") ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
-  <%= link_to Icon(icon: "clock", label: t(".sort.time")), {order: "recent"}.merge(@filter&.to_params), class: "btn #{(session["order"] == "recent") ? "btn-secondary" : "btn-outline-secondary"} btn-sm" %>
+  <%= link_to Icon(icon: "book", label: t(".sort.name")), {order: "name"}.merge(@filter&.to_params), class: "btn #{(session["order"] == "name") ? "btn-primary" : "btn-secondary"} btn-sm" %>
+  <%= link_to Icon(icon: "clock", label: t(".sort.time")), {order: "recent"}.merge(@filter&.to_params), class: "btn #{(session["order"] == "recent") ? "btn-primary" : "btn-secondary"} btn-sm" %>
 </div>

--- a/app/views/libraries/index.html.erb
+++ b/app/views/libraries/index.html.erb
@@ -60,10 +60,10 @@
               <td><%= t("activerecord.attributes.library.tag_regex") %></td>
               <td>
                 <% library.tag_regex.each do |reg| %>
-                  <%= link_to t(".tag_regex.check"), models_path(library: library, missingtag: reg), {class: "btn btn-outline-secondary"} %>
+                  <%= link_to t(".tag_regex.check"), models_path(library: library, missingtag: reg), {class: "btn btn-secondary"} %>
                   <code><%= reg %></code><br>
                 <% end %>
-                <%= if !library.tag_regex.empty? then link_to t(".tag_regex.search_missing"), models_path(library: library, missingtag: ""), {class: "btn btn-outline-secondary"} end %>
+                <%= if !library.tag_regex.empty? then link_to t(".tag_regex.search_missing"), models_path(library: library, missingtag: ""), {class: "btn btn-secondary"} end %>
               </td>
             </tr>
           </table>

--- a/app/views/models/_file.html.erb
+++ b/app/views/models/_file.html.erb
@@ -44,7 +44,7 @@
       <div class="row">
         <div class="col">
           <%= link_to t(".open_button.text"), model_model_file_path(@model, file), {class: "btn btn-primary", "aria-label": translate(".open_button.label", name: file.name)} %>
-          <%= link_to Icon(icon: "cloud-download", label: t("general.download")), model_model_file_path(@model, file, file.extension&.to_sym, download: "true"), {class: "btn btn-outline-secondary", download: "download"} %>
+          <%= link_to Icon(icon: "cloud-download", label: t("general.download")), model_model_file_path(@model, file, file.extension&.to_sym, download: "true"), {class: "btn btn-secondary", download: "download"} %>
           <% if file.presupported || file.presupported_version %>
             <%= Icon icon: "bar-chart-line-fill", label: ModelFile.human_attribute_name(:presupported) %>
           <% end %>
@@ -53,7 +53,7 @@
         <div class="col col-auto">
           <div class="float-end">
             <div class="dropup">
-              <a href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false" class="btn btn-outline-secondary">
+              <a href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false" class="btn btn-secondary">
                 <%= Icon icon: "list", label: t("general.menu") %>
               </a>
               <ul class="dropdown-menu dropdown-menu-end">

--- a/app/views/problems/index.html.erb
+++ b/app/views/problems/index.html.erb
@@ -46,9 +46,9 @@
         <td><%= ResolveButton(problem: problem, user: current_user) %></td>
         <td>
           <% if problem.ignored %>
-            <%= link_to Icon(icon: "eye-fill", label: t(".unignore")), problem_path(problem, problem: {ignored: false}), method: :patch, class: "btn btn-outline-secondary" %>
+            <%= link_to Icon(icon: "eye-fill", label: t(".unignore")), problem_path(problem, problem: {ignored: false}), method: :patch, class: "btn btn-secondary" %>
           <% else %>
-            <%= link_to Icon(icon: "eye-slash", label: t(".ignore")), problem_path(problem, problem: {ignored: true}), method: :patch, class: "btn btn-outline-secondary", data: {bs_toggle: "collapse", bs_target: "#problem-#{problem.id}"} %>
+            <%= link_to Icon(icon: "eye-slash", label: t(".ignore")), problem_path(problem, problem: {ignored: true}), method: :patch, class: "btn btn-secondary", data: {bs_toggle: "collapse", bs_target: "#problem-#{problem.id}"} %>
           <% end %>
         </td>
       </tr>


### PR DESCRIPTION
`btn-outline-secondary` is just too unclear in dark mode on many themes, so I've just stopped using it.

Resolves #4834
Resolves #4859