### PR TITLE
Make signed download URLs end with the original filename, so slicers use it properly

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -54,7 +54,7 @@ class ApplicationController < ActionController::Base
   end
 
   def has_signed_id?
-    params[:id] && ApplicationRecord.signed_id_verifier.valid_message?(params[:id])
+    params[:sig] && ApplicationRecord.signed_id_verifier.valid_message?(params[:sig])
   end
 
   def img_src

--- a/app/helpers/model_files_helper.rb
+++ b/app/helpers/model_files_helper.rb
@@ -24,7 +24,7 @@ module ModelFilesHelper
 
   def slicer_url(slicer, file)
     signed_id = file.signed_id expires_in: 1.hour, purpose: "download"
-    signed_url = model_url(file.model) + "/model_files/#{signed_id}.#{file.extension}"
+    signed_url = model_model_file_by_signed_filename_url(file.model, file.filename, sig: signed_id)
     case slicer
     when :orca
       slic3r_family_open_url "orcaslicer", signed_url

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,7 +165,8 @@ Rails.application.routes.draw do
   end
   resources :doorkeeper_applications, path: "/oauth/applications"
 
-  # Fallback route for filename matching
+  # Fallback routes for filename matching and signed downloads
+  get "/models/:model_id/model_files/signed/:sig/*id" => "model_files#show", :as => "model_model_file_by_signed_filename"
   get "/models/:model_id/model_files/*id" => "model_files#show", :as => "model_model_file_by_filename"
 
   # Web crawler stuff

--- a/spec/helpers/model_files_helper_spec.rb
+++ b/spec/helpers/model_files_helper_spec.rb
@@ -3,7 +3,7 @@ require "rails_helper"
 RSpec.describe ModelFilesHelper do
   describe "#slicer_url" do
     let(:file) { create(:model_file, filename: "model.stl") }
-    let(:slic3r_family_regex) { "://open\\?file=http%3A%2F%2Ftest.host%2Fmodels%2F#{file.model.to_param}%2Fmodel_files%2Fey[0-9a-zA-Z-]+.stl" }
+    let(:slic3r_family_regex) { "://open\\?file=http%3A%2F%2Ftest.host%2Fmodels%2F#{file.model.to_param}%2Fmodel_files%2Fsigned%2Fey[0-9a-zA-Z-]+%2F#{file.filename}" }
 
     it "generates orcaslicer links" do
       url = helper.slicer_url(:orca, file)
@@ -38,7 +38,7 @@ RSpec.describe ModelFilesHelper do
 
     it "generates lychee links" do
       url = helper.slicer_url(:lychee, file)
-      expect(url).to match(/lycheeslicer:\/\/open\/http%3A%2F%2Ftest.host%2Fmodels%2F#{file.model.to_param}%2Fmodel_files%2Fey[0-9a-zA-Z-]+.stl/)
+      expect(url).to match(/lycheeslicer:\/\/open\/http%3A%2F%2Ftest.host%2Fmodels%2F#{file.model.to_param}%2Fmodel_files%2Fsigned%2Fey[0-9a-zA-Z-]+%2F#{file.filename}/)
     end
   end
 end

--- a/spec/requests/model_files_spec.rb
+++ b/spec/requests/model_files_spec.rb
@@ -37,19 +37,26 @@ RSpec.describe "Model Files" do
 
         it "succeeds with a valid ID" do
           id = file.signed_id(expires_in: 1.minute, purpose: "download")
-          get "/models/#{file.model.to_param}/model_files/#{id}.jpg?download=true"
+          get "/models/#{file.model.to_param}/model_files/signed/#{id}/#{file.filename}"
           expect(response).to have_http_status(:success)
         end
 
         it "fails if expired" do
           id = file.signed_id(expires_at: 1.minute.ago, purpose: "download")
-          get "/models/#{file.model.to_param}/model_files/#{id}.jpg?download=true"
+          get "/models/#{file.model.to_param}/model_files/signed/#{id}/#{file.filename}"
           expect(response).to have_http_status(:not_found)
         end
 
         it "fails if purpose doesn't match" do
           id = file.signed_id(expires_in: 1.minute, purpose: "shenanigans")
-          get "/models/#{file.model.to_param}/model_files/#{id}.jpg?download=true"
+          get "/models/#{file.model.to_param}/model_files/signed/#{id}/#{file.filename}"
+          expect(response).to have_http_status(:not_found)
+        end
+
+        it "fails if signed ID doesn't match URL id" do
+          another_file = create(:model_file, filename: "test2.jpg")
+          id = file.signed_id(expires_in: 1.minute, purpose: "download")
+          get "/models/#{file.model.to_param}/model_files/signed/#{id}/#{another_file.filename}"
           expect(response).to have_http_status(:not_found)
         end
       end


### PR DESCRIPTION
Resolves #5048