### PR TITLE
[reverted] Disable CSRF protection for OIDC callbacks

### DIFF
--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,6 +1,7 @@
 class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
   rate_limit to: 10, within: 3.minutes
 
+  skip_forgery_protection
   skip_after_action :verify_authorized
 
   def openid_connect


### PR DESCRIPTION
Just isn't needed there, probably should have always been off. I think the error was getting absorbed before, but is now being caught and displayed to the user after #5101.