### PR TITLE
Terminate offscreen renderer workers when disconnected from page

### DIFF
--- a/app/javascript/controllers/renderer_controller.ts
+++ b/app/javascript/controllers/renderer_controller.ts
@@ -3,8 +3,14 @@ import { ObjectPreview } from '../src/object_preview'
 
 // Connects to data-controller="renderer"
 export default class extends Controller {
+  preview: ObjectPreview
+
   connect (): void {
-    const preview = new ObjectPreview(this.element)
-    preview.connect()
+    this.preview = new ObjectPreview(this.element)
+    this.preview.connect()
+  }
+
+  disconnect (): void {
+    this.preview.disconnect()
   }
 }


### PR DESCRIPTION
Reduces memory leakage. Resolves #5134 