### PR TITLE
Don't generate derivatives for SVG files

### DIFF
--- a/app/jobs/upgrade/backfill_image_derivatives.rb
+++ b/app/jobs/upgrade/backfill_image_derivatives.rb
@@ -18,6 +18,7 @@ class Upgrade::BackfillImageDerivatives < ApplicationJob
 
   def each_iteration(modelfile)
     return unless modelfile.is_image?
+    return if modelfile.extension.downcase == "svg"
     Rails.logger.info("Creating image derivatives for: #{modelfile.path_within_library}")
     modelfile.attachment_derivatives!
     modelfile.save(touch: false, validate: false)


### PR DESCRIPTION
No need really, plus imagemagick can't handle them without another bit of software, so it throws an error.