### PR TITLE
Remove data-schema file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,7 @@ dump.rdb
 
 # Ignore schema file, it's database-dependent and Manyfold shouldn't be
 db/schema.rb
+db/data_schema.rb
 
 .yardoc
 doc

--- a/db/data_schema.rb
+++ b/db/data_schema.rb
@@ -1,1 +1,0 @@
-DataMigrate::Data.define(version: 20250121164452)


### PR DESCRIPTION
We don't need it, and we don't have db/schema.rb, so get rid of this to be consistent.