### PR TITLE
Remove adding users to groups by ID, to avoid enumeration

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -163,8 +163,6 @@ class ApplicationController < ActionController::Base
   def match_user(value)
     raise ActiveRecord::RecordNotFound if value.blank?
     query = case value
-    when /[[:digit:]]+/
-      {id: value.to_i}
     when URI::MailTo::EMAIL_REGEXP
       {email: value}
     else

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -83,10 +83,10 @@ RSpec.describe "Groups", :after_first_run do
         expect(group.reload.members).to include(user)
       end
 
-      it "adds members by ID" do
+      it "cannot add members by ID (to avoid enumeration)" do
         id_params = {group: {memberships_attributes: {"0" => {user_id: user.id}}}}
         patch "/creators/#{creator.to_param}/groups/#{group.to_param}", params: id_params
-        expect(group.reload.members).to include(user)
+        expect(group.reload.members).not_to include(user)
       end
 
       it "adds members by email" do


### PR DESCRIPTION
This was only ever a temporary capability until we had email.
