### PR TITLE
Add users to permission lists and groups by fediverse address

### DIFF
--- a/app/deserializers/manyfold_api/v0/group_deserializer.rb
+++ b/app/deserializers/manyfold_api/v0/group_deserializer.rb
@@ -19,8 +19,8 @@ module ManyfoldApi::V0
         properties: {
           name: {type: :string, example: "Patrons"},
           description: {type: :string, example: "My subscribers"},
-          add_members: {type: :array, items: {type: :string, example: "username"}},
-          remove_members: {type: :array, items: {type: :string, example: "username"}}
+          add_members: {type: :array, items: {type: :string, example: "username / email / fediverse address"}},
+          remove_members: {type: :array, items: {type: :string, example: "username / email / fediverse address"}}
         }
       }
     end

--- a/spec/requests/groups_spec.rb
+++ b/spec/requests/groups_spec.rb
@@ -95,6 +95,20 @@ RSpec.describe "Groups", :after_first_run do
         expect(group.reload.members).to include(user)
       end
 
+      it "adds members by fediverse address" do
+        allow(SiteSettings).to receive(:federation_enabled?).and_return(true)
+        id_params = {group: {memberships_attributes: {"0" => {user_id: user.federails_actor.at_address}}}}
+        patch "/creators/#{creator.to_param}/groups/#{group.to_param}", params: id_params
+        expect(group.reload.members).to include(user)
+      end
+
+      it "doesn't add any members by fediverse address if federation is disabled" do
+        allow(SiteSettings).to receive(:federation_enabled?).and_return(false)
+        id_params = {group: {memberships_attributes: {"0" => {user_id: user.federails_actor.at_address}}}}
+        patch "/creators/#{creator.to_param}/groups/#{group.to_param}", params: id_params
+        expect(group.reload.members).to be_empty
+      end
+
       it "removes memberships" do
         group.members << user
         remove_params = {group: {memberships_attributes: {"0" => {id: group.memberships.last.id, _destroy: "1"}}}}

--- a/spec/requests/permittable_shared.rb
+++ b/spec/requests/permittable_shared.rb
@@ -54,6 +54,15 @@ shared_examples "Permittable" do |object_class|
         expect(object.reload).not_to be_public
       end
 
+      it "grants permissions to users by fediverse address" do # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
+        allow(SiteSettings).to receive(:federation_enabled?).and_return(true)
+        u = create(:user)
+        expect {
+          put "/#{path}/#{object.to_param}", params: {symbol => {caber_relations_attributes: {"0" => {subject: u.federails_actor.at_address, permission: "view"}}}}
+        }.to change { object.grants_permission_to?("view", u) }.from(false).to(true)
+        expect(object.reload).not_to be_public
+      end
+
       it "grants permissions to groups" do # rubocop:disable RSpec/MultipleExpectations
         group = create(:group)
         expect {


### PR DESCRIPTION
Any valid address with `@` or `acct:` will be treated as a fediverse address and looked up. At the moment, this will only match existing users and their canonical addresses.