### PR TITLE
Add specific Bambu Studio links for macOS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -227,3 +227,5 @@ gem "connection_pool", ">= 2.2.5", "< 3.0"
 gem "noticed", "~> 3.0"
 
 gem "devise_invitable", "~> 2.0"
+
+gem "user_agent_parser", "~> 2.20"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -903,6 +903,7 @@ GEM
     unicode-emoji (4.2.0)
     uniform_notifier (1.18.0)
     uri (1.1.1)
+    user_agent_parser (2.20.0)
     useragent (0.16.11)
     validate_url (1.0.15)
       activemodel (>= 3.0.0)
@@ -1066,6 +1067,7 @@ DEPENDENCIES
   turbo-rails (~> 2.0.21)
   tus-server (~> 2.3)
   tzinfo-data
+  user_agent_parser (~> 2.20)
   vcr (~> 6.4)
   warning (~> 1.5)
   web-console (~> 4.1)
@@ -1404,6 +1406,7 @@ CHECKSUMS
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
   uniform_notifier (1.18.0) sha256=4787785556f66f6418486da0f1d78b3239aaff98e2e7938fb05e2062b0ffce9d
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
+  user_agent_parser (2.20.0) sha256=4bd9b667923ee4c7ca0abbe07135e49d9acd6534200b156b89c5e082acbe6ca6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   validate_url (1.0.15) sha256=72fe164c0713d63a9970bd6700bea948babbfbdcec392f2342b6704042f57451
   vcr (6.4.0) sha256=077ac92cc16efc5904eb90492a18153b5e6ca5398046d8a249a7c96a9ea24ae6

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -15,6 +15,11 @@ module ApplicationHelper
     value ? "✅" : "❌"
   end
 
+  def client_os
+    user_agent = UserAgentParser.parse(request&.user_agent)
+    user_agent&.os
+  end
+
   def icon_for(klass)
     case klass.name
     when "Creator"

--- a/app/helpers/model_files_helper.rb
+++ b/app/helpers/model_files_helper.rb
@@ -32,8 +32,15 @@ module ModelFilesHelper
       # Prusa will only open files from printables.com
       slic3r_family_open_url "prusaslicer", signed_url
     when :bambu
-      # Bambu will only open from Makerworld and a few others
-      slic3r_family_open_url "bambustudio", signed_url
+      if client_os.family == "Mac OS X"
+        URI::Generic.new(
+          "bambustudioopen", nil,
+          CGI.escapeURIComponent(signed_url), nil, nil, nil, nil,
+          nil, nil
+        ).to_s
+      else
+        slic3r_family_open_url "bambustudio", signed_url
+      end
     when :cura
       slic3r_family_open_url "cura", signed_url
     when :elegoo


### PR DESCRIPTION
because they have a different URL scheme for some reason.