### PR TITLE
Automatically run yarn in setup script

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -14,6 +14,7 @@ FileUtils.chdir APP_ROOT do
 
   puts "== Installing dependencies =="
   system("bundle check") || system!("bundle install")
+  system("yarn install")
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")


### PR DESCRIPTION
Should avoid hard-to-spot problems with missing executable dependencies like "esbuild" after upgrades.