### PR TITLE
fix: scrolling inner containers

### DIFF
--- a/app/assets/stylesheets/src/layout.scss
+++ b/app/assets/stylesheets/src/layout.scss
@@ -11,6 +11,6 @@
 }
 
 .skip-link-container {
-	overflow-y: hidden;
+	overflow: hidden;
 	position: relative;
 }


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [ ] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

Fixes a scrolling div that should have no overflow.

## Linked issues

resolves #5484

## Description of changes

The container should have no overflow in either axis.
