### PR TITLE
Don't set session cookies on indexed asset requests

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -156,6 +156,8 @@ class ApplicationController < ActionController::Base
     self.status = status
     self.headers.merge!(headers)
     self.response_body = body
+    # Don't set session cookie for asset delivery
+    request.session_options[:skip] = true
   rescue Errno::ENOENT
     head :internal_server_error
   end

--- a/spec/requests/model_files_spec.rb
+++ b/spec/requests/model_files_spec.rb
@@ -147,6 +147,10 @@ RSpec.describe "Model Files" do
         it "has correct MIME type" do
           expect(response.media_type).to eq("model/stl")
         end
+
+        it "does not set session cookies" do
+          expect(response.headers["set-cookie"]).to be_nil
+        end
       end
 
       describe "GET an image file in its original file format", :as_member do
@@ -160,6 +164,10 @@ RSpec.describe "Model Files" do
 
         it "has correct MIME type" do
           expect(response.media_type).to eq("image/jpeg")
+        end
+
+        it "does not set session cookies" do
+          expect(response.headers["set-cookie"]).to be_nil
         end
       end
     end


### PR DESCRIPTION
In order to avoid session leakage via caches.