### PR TITLE
Unlock iteration jobs when they're interrupted, so they can be requeued

### DIFF
--- a/app/jobs/scan/check_all_job.rb
+++ b/app/jobs/scan/check_all_job.rb
@@ -1,8 +1,5 @@
-class Scan::CheckAllJob < ApplicationJob
-  include JobIteration::Iteration
-
+class Scan::CheckAllJob < Upgrade::IterationJob
   queue_as :scan
-  unique :until_executed
 
   def build_enumerator(filter_params, instigator, cursor:)
     scope = instigator ?

--- a/app/jobs/upgrade/file_type_iteration_job.rb
+++ b/app/jobs/upgrade/file_type_iteration_job.rb
@@ -1,8 +1,4 @@
-class Upgrade::FileTypeIterationJob < ApplicationJob
-  include JobIteration::Iteration
-
-  unique :until_executed
-
+class Upgrade::FileTypeIterationJob < Upgrade::IterationJob
   def mime_type
     raise NotImplementedError
   end

--- a/app/jobs/upgrade/fix_nil_file_size_values.rb
+++ b/app/jobs/upgrade/fix_nil_file_size_values.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-class Upgrade::FixNilFileSizeValues < ApplicationJob
-  include JobIteration::Iteration
-
-  unique :until_executed
-
+class Upgrade::FixNilFileSizeValues < Upgrade::IterationJob
   def build_enumerator(cursor:)
     enumerator_builder.active_record_on_records(ModelFile.unscoped.where(size: nil), cursor: cursor)
   end

--- a/app/jobs/upgrade/fix_stale_attachment_data_job.rb
+++ b/app/jobs/upgrade/fix_stale_attachment_data_job.rb
@@ -1,8 +1,5 @@
-class Upgrade::FixStaleAttachmentDataJob < ApplicationJob
-  include JobIteration::Iteration
-
+class Upgrade::FixStaleAttachmentDataJob < Upgrade::IterationJob
   queue_as :low
-  unique :until_executed
 
   def scope
     where_clause = case DatabaseDetector.server

--- a/app/jobs/upgrade/generate_slugs_job.rb
+++ b/app/jobs/upgrade/generate_slugs_job.rb
@@ -1,11 +1,7 @@
 # frozen_string_literal: true
 
 # Originally done in db/data/20230617222353_generate_slugs.rb
-class Upgrade::GenerateSlugsJob < ApplicationJob
-  include JobIteration::Iteration
-
-  unique :until_executed
-
+class Upgrade::GenerateSlugsJob < Upgrade::IterationJob
   def build_enumerator(model, cursor:)
     enumerator_builder.active_record_on_records(model.unscoped.where(slug: nil), cursor: cursor)
   end

--- a/app/jobs/upgrade/iteration_job.rb
+++ b/app/jobs/upgrade/iteration_job.rb
@@ -1,0 +1,12 @@
+class Upgrade::IterationJob < ApplicationJob
+  include JobIteration::Iteration
+
+  unique :until_executed
+
+  # Because we're making these unique until executed, they can't requeue themselves upon interruption
+  # while they're locked. So, we explicitly unlock the job on shutdown.
+  on_shutdown -> do
+    Rails.logger.debug "Unlocking job before requeuing"
+    self.class.unlock!
+  end
+end

--- a/app/jobs/upgrade/prune_orphaned_problems.rb
+++ b/app/jobs/upgrade/prune_orphaned_problems.rb
@@ -1,10 +1,6 @@
 # frozen_string_literal: true
 
-class Upgrade::PruneOrphanedProblems < ApplicationJob
-  include JobIteration::Iteration
-
-  unique :until_executed
-
+class Upgrade::PruneOrphanedProblems < Upgrade::IterationJob
   def build_enumerator(cursor:)
     enumerator_builder.active_record_on_records(Problem.all, cursor: cursor)
   end


### PR DESCRIPTION
Any iteration job that had a lot of records and got interrupted wouldn't get requeued because of the existing execution lock. So, we explicitly unlock the job before shutdown.