### PR TITLE
Temporarily disable uppy dashboard updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,10 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+  allow:
+    - dependency-type: "all"
+  ignore:
+    - dependency-name: "@uppy/dashboard"
   groups:
     uppy:
       patterns:


### PR DESCRIPTION
5.1.1 breaks things, and dependabot keeps updating to it, so stop that for now.