### PR TITLE
Widen Access-Control-Allow-Origin headers for file content

### DIFF
--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -7,7 +7,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
       methods: [:get, :options, :head]
     resource "*",
       headers: [:any],
-      methods: [:get, :options, :head],
+      methods: [:any],
       if: ->(env) { env["HTTP_ACCEPT"]&.split(", ")&.include? Mime[:manyfold_api_v0].to_s }
   end
 end


### PR DESCRIPTION
Allows other sites and in-browser tools like Flock to fetch raw file contents. Also allows any HTTP verb for API requests.