### PR TITLE
Add automated workflow to deduplicate dependencies

### DIFF
--- a/.github/workflows/yarn-dedupe.yml
+++ b/.github/workflows/yarn-dedupe.yml
@@ -1,0 +1,26 @@
+name: Deduplicate NPM packages
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '0 12 * * *'
+
+jobs:
+  dedupe:
+    if: github.triggering_actor != 'allcontributors[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: ./.github/actions/setup
+      - name: Sync to translation.io
+        run: yarn dedupe
+      - name: Open pull request with changes
+        uses: peter-evans/create-pull-request@v8
+        with:
+          token: "${{ secrets.TRANSLATION_SYNC_PAT }}"
+          commit-message: "Deduplicated NPM packages"
+          branch: "dependencies/dedupe"
+          labels: dependencies
+          title: "Deduplicate NPM packages"
+          delete-branch: true
+          add-paths: yarn.lock


### PR DESCRIPTION
Apparently expecting a package manager to do this all by itself is a bit much.