### PR TITLE
Fix API key owner authorization for edit/delete

### DIFF
--- a/app/policies/doorkeeper/application_policy.rb
+++ b/app/policies/doorkeeper/application_policy.rb
@@ -22,7 +22,7 @@ class Doorkeeper::ApplicationPolicy < ApplicationPolicy
   def update?
     all_of(
       one_of(
-        user == record,
+        record.owner == user,
         user&.is_administrator?
       ),
       SiteSettings.multiuser_enabled?,

--- a/spec/policies/doorkeeper/application_policy_spec.rb
+++ b/spec/policies/doorkeeper/application_policy_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe Doorkeeper::ApplicationPolicy do
+  subject(:policy) { described_class }
+
+  let(:owner) { create(:contributor) }
+  let(:other_user) { create(:contributor) }
+  let(:admin) { create(:admin) }
+  let(:application) { create(:oauth_application, owner: owner) }
+
+  permissions :update?, :destroy? do
+    it "allows the owner" do
+      expect(policy).to permit(owner, application)
+    end
+
+    it "allows administrators" do
+      expect(policy).to permit(admin, application)
+    end
+
+    it "denies non-owners" do
+      expect(policy).not_to permit(other_user, application)
+    end
+  end
+end


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [ ] Check that the tests and code linter both pass.
- [ ] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

Fixes authorization for OAuth application owners so they can edit/delete their own API keys.

## Linked issues

Resolves #5514

## Description of changes

- Update `Doorkeeper::ApplicationPolicy#update?` to check `record.owner == user` instead of `user == record`.
- Add policy coverage in `spec/policies/doorkeeper/application_policy_spec.rb` to assert:
  - owners are permitted to update/destroy,
  - admins are permitted,
  - non-owners are denied.

Validation signal in this environment:
- Verified the policy now contains `record.owner == user` and no longer contains `user == record`.
- Verified the new policy spec file contains the expected owner/admin/non-owner permission cases.

Note: full Rails test/lint execution wasn't possible here because Ruby/Bundler are unavailable in this runtime.
