### PR TITLE
Add bulk action buttons above problems table

### DIFF
--- a/app/views/problems/index.html.erb
+++ b/app/views/problems/index.html.erb
@@ -11,6 +11,9 @@
 <% end %>
 
 <%= form_with url: resolve_problems_path, method: :post, class: "mb-3" do |form| %>
+  <%= form.submit translate(".bulk_resolve"), name: "resolve", class: "btn btn-danger", data: {confirm: translate(".bulk_confirm")} %>
+  <%= form.submit translate(".bulk_ignore"), name: "ignore", class: "btn btn-secondary mb-3" %>
+
   <table class="table table-striped" data-controller="bulk-edit" data-action="change->bulk-edit#handleCheckboxChange">
     <tr>
       <th><input type="checkbox" aria-label="<%= translate ".select_all" %>" value="0" name="bulk-select-all"></th>


### PR DESCRIPTION
The bulk resolve/ignore buttons only appeared at the bottom of the problems table. With many items, users had to scroll down after selecting problems at the top.

This adds the same buttons above the table so they're accessible without scrolling, same pattern as the pagination which already appears at both top and bottom.

Fixes #4560