### PR TITLE
Add ability to install only certain database adapters via bundler groups

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,10 +31,19 @@ gem "ffi-libarchive", "~> 1.1"
 gem "bootsnap", "~> 1.24", require: false
 
 # Database adapters
-gem "activerecord-enhancedsqlite3-adapter", "~> 0.8"
-group :production do
+# All are installed by default, but you can exclude ones you don't want with bundler.
+# e.g. `bundle install --without="postgres mysql"` or `bundle config set without "postgres mysql"`
+group :sqlite3 do
+  gem "activerecord-enhancedsqlite3-adapter", "~> 0.8"
+  gem "sqlite3_ar_regexp", "~> 3.0"
+end
+group :mysql do
   gem "mysql2", "~> 0.5"
+end
+group :postgres do
   gem "pg", "~> 1.6"
+  gem "pghero", "~> 3.8"
+  gem "pg_query", "~> 6.2"
 end
 
 group :development, :test do
@@ -100,8 +109,6 @@ gem "kaminari", "~> 1.2"
 gem "lograge", "~> 0.14"
 
 gem "acts_as_favoritor", "~> 6.0"
-
-gem "sqlite3_ar_regexp", "~> 3.0"
 
 gem "mittsu", "~> 0.5"
 gem "mittsu-mesh_analysis"
@@ -173,9 +180,6 @@ group :development, :production do
   gem "rails_performance", "~> 1.6"
   gem "redis-namespace"
 end
-
-gem "pghero", "~> 3.8"
-gem "pg_query", "~> 6.2"
 
 gem "to_regexp", "~> 0.2"
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -18,7 +18,7 @@ require "rack/contrib"
 
 # Require the gems listed in Gemfile, including any gems
 # you've limited to :test, :development, or :production.
-Bundler.require(*Rails.groups)
+Bundler.require(:sqlite3, :postgres, :mysql, *Rails.groups)
 
 module Manyfold
   class Application < Rails::Application

--- a/config/initializers/warnings.rb
+++ b/config/initializers/warnings.rb
@@ -1,1 +1,1 @@
-SQLite3::ForkSafety.suppress_warnings!
+SQLite3::ForkSafety.suppress_warnings! if defined?(SQLite3)

--- a/config/routes/admin.rb
+++ b/config/routes/admin.rb
@@ -13,6 +13,6 @@ authenticate :user, lambda { |u| u.is_administrator? } do
   end
   mount Sidekiq::Web => "/admin/sidekiq"
   mount RailsPerformance::Engine => "/admin/performance" unless Rails.env.test? || ENV["RAILS_ASSETS_PRECOMPILE"].present?
-  mount PgHero::Engine => "/admin/pghero"
+  mount PgHero::Engine => "/admin/pghero" if defined?(PgHero)
   get "/activity" => "activity#index", :as => :activity
 end


### PR DESCRIPTION
All are installed by default, but you can exclude ones you don't want with bundler.

e.g. `bundle install --without="postgres mysql"` or `bundle config set without "postgres mysql"`
