### PR TITLE
Include incoming federated likes in displayed like count

### DIFF
--- a/app/components/like_button.rb
+++ b/app/components/like_button.rb
@@ -15,7 +15,7 @@ class Components::LikeButton < Components::BaseButton
     @form_attributes = @liked ?
       {id: current_user.liked_list.list_items.find_by(listable: @thing), _destroy: "1"} :
       {listable_type: @thing.model_name, listable_id: @thing.id}
-    @count = @thing.list_items.includes(:list).where("list.special": :liked).count
+    @count = @thing.like_count
     @count = nil if @count == 0
   end
 

--- a/app/models/comment.rb
+++ b/app/models/comment.rb
@@ -10,7 +10,7 @@ class Comment < ApplicationRecord
   belongs_to :commenter, polymorphic: true, optional: true
   belongs_to :commentable, polymorphic: true
 
-  acts_as_federails_data handles: "Note", actor_entity_method: :commenter, url_param: :public_id, should_federate_method: :federate?
+  acts_as_federails_data handles: "Note", actor_entity_method: :commenter, url_param: :public_id, should_federate_method: :federate?, route_path_segment: :comments
   on_federails_delete_requested :federated_delete
 
   def to_activitypub_object

--- a/app/models/concerns/likeable.rb
+++ b/app/models/concerns/likeable.rb
@@ -1,0 +1,7 @@
+module Likeable
+  extend ActiveSupport::Concern
+
+  def like_count
+    list_items.includes(:list).where("list.special": :liked).count
+  end
+end

--- a/app/models/concerns/likeable.rb
+++ b/app/models/concerns/likeable.rb
@@ -1,15 +1,9 @@
 module Likeable
   extend ActiveSupport::Concern
 
-  def like_count
-    calculate_like_count
+  def update_like_count!
+    count = list_items.includes(:list).where("list.special": :liked).count +
+      Federails::Activity.includes(:actor).where(action: "Like", entity: [self] + comments.where(system: true), "actor.local": false).count # rubocop:disable Pundit/UsePolicyScope
+    update_attribute(:like_count, count) # rubocop:disable Rails/SkipsModelValidations
   end
-
-  private
-
-  def calculate_like_count
-    list_items.includes(:list).where("list.special": :liked).count +
-      Federails::Activity.includes(:actor).where(action: "Like", entity: [self] + comments.where(system: true), 'actor.local': false).count
-  end
-
 end

--- a/app/models/concerns/likeable.rb
+++ b/app/models/concerns/likeable.rb
@@ -2,6 +2,14 @@ module Likeable
   extend ActiveSupport::Concern
 
   def like_count
-    list_items.includes(:list).where("list.special": :liked).count
+    calculate_like_count
   end
+
+  private
+
+  def calculate_like_count
+    list_items.includes(:list).where("list.special": :liked).count +
+      Federails::Activity.includes(:actor).where(action: "Like", entity: [self] + comments.where(system: true), 'actor.local': false).count
+  end
+
 end

--- a/app/models/list_item.rb
+++ b/app/models/list_item.rb
@@ -3,4 +3,8 @@ class ListItem < ApplicationRecord
 
   belongs_to :list
   belongs_to :listable, polymorphic: true
+
+  after_create -> do
+    listable.update_like_count! if list.special == "liked"
+  end
 end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -13,6 +13,7 @@ class Model < ApplicationRecord
   include Problematic
   include Indexable
   include FaspClient::DataSharing::Lifecycle
+  include Likeable
 
   broadcasts_refreshes
 

--- a/app/services/activity_pub/like_activity_handler.rb
+++ b/app/services/activity_pub/like_activity_handler.rb
@@ -1,0 +1,15 @@
+class ActivityPub::LikeActivityHandler
+  def self.handle_like_activity(activity_hash_or_id)
+    activity = Fediverse::Request.dereference(activity_hash_or_id)
+    actor = Federails::Actor.find_or_create_by_object activity["actor"]
+    object = Fediverse::Request.dereference(activity["object"])
+    entity = begin
+      Federails::Actor.find_by_federation_url(object["id"])&.entity # rubocop:disable Rails/DynamicFindBy
+    rescue ActiveRecord::RecordNotFound
+      Federails::Utils::Object.find_or_create!(object)
+    end
+    raise ActiveRecord::RecordNotFound unless entity
+    Federails::Activity.create! actor: actor, action: "Like", entity: entity
+    entity.is_a?(Comment) ? entity.commentable.update_like_count! : entity.update_like_count!
+  end
+end

--- a/config/initializers/federails.rb
+++ b/config/initializers/federails.rb
@@ -32,6 +32,7 @@ end
 Rails.application.config.after_initialize do
   Fediverse::Inbox.register_handler("Create", "*", ActivityPub::ActorActivityHandler, :handle_create_activity)
   Fediverse::Inbox.register_handler("Update", "*", ActivityPub::ActorActivityHandler, :handle_update_activity)
+  Fediverse::Inbox.register_handler("Like", "*", ActivityPub::LikeActivityHandler, :handle_like_activity)
 end
 
 # i18n-tasks-use t("activerecord.models.federails/moderation/domain_block")

--- a/db/migrate/20260410150554_add_like_count_to_models.rb
+++ b/db/migrate/20260410150554_add_like_count_to_models.rb
@@ -1,0 +1,5 @@
+class AddLikeCountToModels < ActiveRecord::Migration[8.0]
+  def change
+    add_column :models, :like_count, :integer, default: 0, null: false
+  end
+end

--- a/spec/models/concerns/likeable_shared.rb
+++ b/spec/models/concerns/likeable_shared.rb
@@ -1,0 +1,8 @@
+shared_examples "Likeable" do
+  let(:user) { create :user }
+  let(:thing) { create(described_class.to_s.underscore.to_sym) }
+
+  it "changes like count when added to a list" do
+    expect{user.liked_list.models << thing}.to change(thing, :like_count).by(1)
+  end
+end

--- a/spec/models/concerns/likeable_shared.rb
+++ b/spec/models/concerns/likeable_shared.rb
@@ -1,9 +1,9 @@
 shared_examples "Likeable" do
-  let(:user) { create :user }
-  let(:thing) { create(described_class.to_s.underscore.to_sym) }
+  let(:user) { create(:user) }
+  let(:thing) { create(described_class.to_s.underscore.to_sym, :public) }
 
   it "changes like count when added to a list" do
-    expect{user.liked_list.models << thing}.to change(thing, :like_count).by(1)
+    expect { user.liked_list.models << thing }.to change(thing, :like_count).by(1)
   end
 
   context "with federation", :federated do

--- a/spec/models/concerns/likeable_shared.rb
+++ b/spec/models/concerns/likeable_shared.rb
@@ -5,4 +5,34 @@ shared_examples "Likeable" do
   it "changes like count when added to a list" do
     expect{user.liked_list.models << thing}.to change(thing, :like_count).by(1)
   end
+
+  context "with federation", :federated do
+    let(:actor) { create :actor, :distant }
+
+    it "includes remote Like activities in count" do
+      expect{
+        Federails::Activity.create action: "Like", entity: thing, actor: actor
+      }.to change(thing, :like_count).by(1)
+    end
+
+    it "includes Likes on system comments in count" do
+      comment = create :comment, commentable: thing, system: true, commenter: thing
+      expect{
+        Federails::Activity.create action: "Like", entity: comment, actor: actor
+      }.to change(thing, :like_count).by(1)
+    end
+
+    it "ignores Likes on non-system comments in count" do
+      comment = create :comment, commentable: thing, system: false, commenter: thing
+      expect{
+        Federails::Activity.create action: "Like", entity: comment, actor: actor
+      }.not_to change(thing, :like_count)
+    end
+
+    it "ignores local Like activities in count" do
+      expect{
+        Federails::Activity.create action: "Like", entity: thing, actor: user.federails_actor
+      }.not_to change(thing, :like_count)
+    end
+  end
 end

--- a/spec/models/concerns/likeable_shared.rb
+++ b/spec/models/concerns/likeable_shared.rb
@@ -7,32 +7,52 @@ shared_examples "Likeable" do
   end
 
   context "with federation", :federated do
-    let(:actor) { create :actor, :distant }
+    let(:actor) { create(:actor, :distant) }
 
-    it "includes remote Like activities in count" do
-      expect{
-        Federails::Activity.create action: "Like", entity: thing, actor: actor
-      }.to change(thing, :like_count).by(1)
+    it "includes remote Like activities in count" do # rubocop:todo RSpec/ExampleLength
+      activity = {
+        "action" => "Like",
+        "actor" => actor.federated_url,
+        "object" => thing.to_activitypub_object.merge("id" => thing.federails_actor.federated_url)
+      }
+      expect {
+        ActivityPub::LikeActivityHandler.handle_like_activity(activity)
+      }.to change { thing.reload.like_count }.from(0).to(1)
     end
 
-    it "includes Likes on system comments in count" do
-      comment = create :comment, commentable: thing, system: true, commenter: thing
-      expect{
-        Federails::Activity.create action: "Like", entity: comment, actor: actor
-      }.to change(thing, :like_count).by(1)
+    it "includes Likes on system comments in count" do # rubocop:todo RSpec/ExampleLength
+      comment = create(:comment, commentable: thing, system: true, commenter: thing)
+      activity = {
+        "action" => "Like",
+        "actor" => actor.federated_url,
+        "object" => comment.to_activitypub_object
+      }
+      expect {
+        ActivityPub::LikeActivityHandler.handle_like_activity(activity)
+      }.to change { thing.reload.like_count }.from(0).to(1)
     end
 
-    it "ignores Likes on non-system comments in count" do
-      comment = create :comment, commentable: thing, system: false, commenter: thing
-      expect{
-        Federails::Activity.create action: "Like", entity: comment, actor: actor
-      }.not_to change(thing, :like_count)
+    it "ignores Likes on non-system comments in count" do # rubocop:todo RSpec/ExampleLength
+      comment = create(:comment, commentable: thing, system: false, commenter: thing)
+      activity = {
+        "action" => "Like",
+        "actor" => actor.federated_url,
+        "object" => comment.to_activitypub_object
+      }
+      expect {
+        ActivityPub::LikeActivityHandler.handle_like_activity(activity)
+      }.not_to change { thing.reload.like_count }
     end
 
-    it "ignores local Like activities in count" do
-      expect{
-        Federails::Activity.create action: "Like", entity: thing, actor: user.federails_actor
-      }.not_to change(thing, :like_count)
+    it "ignores local Like activities in count" do # rubocop:todo RSpec/ExampleLength
+      activity = {
+        "action" => "Like",
+        "actor" => user.federails_actor.federated_url,
+        "object" => thing.to_activitypub_object.merge("id" => thing.federails_actor.federated_url)
+      }
+      expect {
+        ActivityPub::LikeActivityHandler.handle_like_activity(activity)
+      }.not_to change { thing.reload.like_count }
     end
   end
 end

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Model do
   it_behaves_like "Indexable"
   it_behaves_like "IndexableWithCreatorDelegation"
   it_behaves_like "Linkable"
+  it_behaves_like "Likeable"
 
   it "is not valid without a path" do
     expect(build(:model, path: nil)).not_to be_valid


### PR DESCRIPTION
This involves both having a local like count cache, handling incoming likes, and updating the counter cache automatically. Resolves #5689.