### PR TITLE
Stub Likes collection for models (and associated compatibility notes)

### DIFF
--- a/app/serializers/activity_pub/comment_serializer.rb
+++ b/app/serializers/activity_pub/comment_serializer.rb
@@ -19,7 +19,8 @@ module ActivityPub
           "tag" => hashtags,
           "f3di:compatibilityNote" => @object.system,
           "inReplyTo" => in_reply_to,
-          "url" => url
+          "url" => url,
+          "likes" => likes
         }.compact.merge(address_fields)
       )
     end
@@ -66,6 +67,15 @@ module ActivityPub
       return nil if @object.system
       # Otherwise, find the system note or just use the actor URL if unavailable
       @object.commentable.comments.where(system: true).first&.federated_url || @object.commentable.federails_actor&.federated_url
+    end
+
+    def likes
+      return nil unless @object.system
+      {
+        id: @object.commentable.federails_actor.federated_url + "#likes",
+        type: "Collection",
+        totalItems: @object.commentable.like_count
+      }
     end
   end
 end

--- a/app/serializers/activity_pub/model_serializer.rb
+++ b/app/serializers/activity_pub/model_serializer.rb
@@ -26,7 +26,8 @@ module ActivityPub
         attributedTo: short_creator(@object.creator),
         context: short_collection(@object.collection),
         "spdx:license": license,
-        preview: oembed_to_preview(OEmbed::ModelSerializer.new(@object, maxwidth: "100%", maxheight: "100%").serialize)
+        preview: oembed_to_preview(OEmbed::ModelSerializer.new(@object, maxwidth: "100%", maxheight: "100%").serialize),
+        likes: likes
       }.compact.merge(address_fields)
     end
 
@@ -58,6 +59,14 @@ module ActivityPub
           href: Rails.application.routes.url_helpers.models_url(tag: tag)
         }
       end
+    end
+
+    def likes
+      {
+        id: @object.federails_actor.federated_url + "#likes",
+        type: "Collection",
+        totalItems: @object.like_count
+      }
     end
   end
 end

--- a/spec/serializers/activity_pub/comment_serializer_spec.rb
+++ b/spec/serializers/activity_pub/comment_serializer_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe ActivityPub::CommentSerializer do
     it "adds tag link" do
       expect(ap["content"]).to include "<a role=\"listitem\" href=\"http://localhost:3214/models?tag=tag\" class=\"mention hashtag\" rel=\"tag\">#Tag</a>"
     end
+
+    it "includes a likes collection" do
+      expect(ap["likes"]).to include({
+        id: model.federails_actor.federated_url + "#likes",
+        type: "Collection",
+        totalItems: 0
+      })
+    end
   end
 
   context "when commenting on something with no tags" do

--- a/spec/serializers/activity_pub/model_serializer_spec.rb
+++ b/spec/serializers/activity_pub/model_serializer_spec.rb
@@ -63,5 +63,13 @@ RSpec.describe ActivityPub::ModelSerializer do
         summary: "caption here"
       })
     end
+
+    it "includes a likes collection" do
+      expect(ap[:likes]).to include({
+        id: object.federails_actor.federated_url + "#likes",
+        type: "Collection",
+        totalItems: 0
+      })
+    end
   end
 end


### PR DESCRIPTION
I'm hoping this will work for sharing like counts, even though there's not a useful dereferenceable URL in the id. This should be pushed into Federails at some point, then it can be a proper collection with its own URL.