### PR TITLE
Remove site-wide default owner

### DIFF
--- a/app/models/concerns/caber_object.rb
+++ b/app/models/concerns/caber_object.rb
@@ -53,15 +53,14 @@ module CaberObject
 
   def set_owner
     # Set owner if not already set
-    if permitted_users.with_permission("own").empty?
+    if owners.empty?
       o = @owner || SiteSettings.default_user
       grant_permission_to("own", o) if o
     end
   end
 
-  def owner
-    # Get the first owner
-    permitted_users.with_permission("own").first
+  def owners
+    permitted_users.with_permission("own")
   end
 
   def will_be_public?

--- a/app/models/concerns/caber_object.rb
+++ b/app/models/concerns/caber_object.rb
@@ -53,9 +53,8 @@ module CaberObject
 
   def set_owner
     # Set owner if not already set
-    if owners.empty?
-      o = @owner || SiteSettings.default_user
-      grant_permission_to("own", o) if o
+    if @owner && owners.empty?
+      grant_permission_to("own", @owner)
     end
   end
 

--- a/app/models/concerns/caber_object.rb
+++ b/app/models/concerns/caber_object.rb
@@ -68,12 +68,12 @@ module CaberObject
   end
 
   def matching_permission_preset
-    total = caber_relations.count
-    if total == 1 && caber_relations.where(permission: "own").one?
+    non_owner_total = caber_relations.where.not(permission: "own").count
+    if non_owner_total == 0
       "private"
-    elsif total == 2 && caber_relations.where(permission: "view", subject: Role.find_by!(name: "member")).one?
+    elsif non_owner_total == 1 && caber_relations.where(permission: "view", subject: Role.find_by!(name: "member")).one?
       "member"
-    elsif total == 2 && caber_relations.where(permission: "view", subject: nil).one?
+    elsif non_owner_total == 1 && caber_relations.where(permission: "view", subject: nil).one?
       "public"
     else
       ""

--- a/app/models/concerns/caber_object.rb
+++ b/app/models/concerns/caber_object.rb
@@ -71,7 +71,7 @@ module CaberObject
     non_owner_total = caber_relations.where.not(permission: "own").count
     if non_owner_total == 0
       "private"
-    elsif non_owner_total == 1 && caber_relations.where(permission: "view", subject: Role.find_by!(name: "member")).one?
+    elsif non_owner_total == 1 && caber_relations.where(permission: "view", subject: Role.find_or_create_by(name: "member")).one?
       "member"
     elsif non_owner_total == 1 && caber_relations.where(permission: "view", subject: nil).one?
       "public"

--- a/app/models/concerns/talkative.rb
+++ b/app/models/concerns/talkative.rb
@@ -10,7 +10,7 @@ module Talkative
 
   def owning_actor
     return nil unless caber_ready?
-    owners.first&.federails_actor
+    owners.first&.federails_actor || federails_actor
   end
 
   private

--- a/app/models/concerns/talkative.rb
+++ b/app/models/concerns/talkative.rb
@@ -10,8 +10,7 @@ module Talkative
 
   def owning_actor
     return nil unless caber_ready?
-    user = permitted_users.with_permission("own").first || SiteSettings.default_user
-    user&.federails_actor
+    owners.first&.federails_actor
   end
 
   private

--- a/app/models/list_item.rb
+++ b/app/models/list_item.rb
@@ -10,8 +10,10 @@ class ListItem < ApplicationRecord
 
   def update_likes
     if SiteSettings.federation_enabled? && listable.public?
-      listable.federails_actor.like! actor: list.owner.federails_actor
-      listable.creation_comment.try(:like!, actor: list.owner.federails_actor)
+      if (actor = list.owners&.first&.federails_actor)
+        listable.federails_actor.like! actor: actor
+        listable.creation_comment.try(:like!, actor: actor)
+      end
     end
     listable.update_like_count!
   end

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -78,10 +78,6 @@ class SiteSettings < RailsSettings::Base
     Rails.application.config.manyfold_features[:oidc]
   end
 
-  def self.default_user
-    User.with_role(:administrator).first
-  end
-
   def self.social_enabled?
     multiuser_enabled? || federation_enabled?
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -214,8 +214,12 @@ class User < ApplicationRecord
     !(attributes["quota"] == 0) && SiteSettings.enable_user_quota
   end
 
+  def owned_models
+    permitted_models.with_permission("own")
+  end
+
   def current_space_used
-    permitted_models.with_permission("own").sum(&:size_on_disk)
+    owned_models.sum(&:size_on_disk)
   end
 
   def first_use?

--- a/spec/jobs/create_object_from_url_job_spec.rb
+++ b/spec/jobs/create_object_from_url_job_spec.rb
@@ -25,11 +25,10 @@ RSpec.describe CreateObjectFromUrlJob, :after_first_run do
     contributor = create(:contributor)
     job.perform(url: "https://www.thingiverse.com/thing:4049220", owner: contributor)
     expect(Model.last.grants_permission_to?("own", contributor)).to be true
-    expect(Model.last.grants_permission_to?("own", SiteSettings.default_user)).to be false
   end
 
-  it "sets default owner if not specified", :thingiverse_api_key do
+  it "has no owner if not specified", :thingiverse_api_key do
     job.perform(url: "https://www.thingiverse.com/thing:4049220")
-    expect(Model.last.grants_permission_to?("own", SiteSettings.default_user)).to be true
+    expect(Model.last.owners).to be_empty
   end
 end

--- a/spec/jobs/process_uploaded_file_job_spec.rb
+++ b/spec/jobs/process_uploaded_file_job_spec.rb
@@ -55,14 +55,14 @@ RSpec.describe ProcessUploadedFileJob do
       expect { job.perform(library.id, file) }.to change(Model, :count).by(1)
     end
 
-    it "Sets default owner permission if no owner set" do
+    it "has no owner if no owner is explicitly set" do
       job.perform(library.id, file)
-      expect(Model.last.permitted_users.with_permission(:own)).to include SiteSettings.default_user
+      expect(Model.last.owners).to be_empty
     end
 
     it "Sets owner permission to provided user" do
       job.perform(library.id, file, owner: uploader)
-      expect(Model.last.permitted_users.with_permission(:own)).to include uploader
+      expect(Model.last.owners).to include uploader
     end
 
     it "Sets default visibility even if a owner is provided" do

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -8,7 +8,10 @@ RSpec.describe Comment do
 
     it "posts a Federails Activity on creation" do # rubocop:disable RSpec/MultipleExpectations
       expect { create(:comment, commenter: commenter, commentable: commentable) }.to change(Federails::Activity, :count).by(1)
-      expect(Federails::Activity.last.action).to eq "Create"
+      activity = Federails::Activity.last
+      expect(activity.action).to eq "Create"
+      expect(activity.actor).to eq commenter.federails_actor
+      expect(activity.entity.commentable).to eq commentable
     end
 
     it "posts a Federails Activity on update" do # rubocop:disable RSpec/MultipleExpectations
@@ -85,8 +88,10 @@ RSpec.describe Comment do
     let(:commenter) { create(:creator) }
     let(:commentable) { create(:model, :public) }
 
-    it "Does not post a Federails Activity on creation" do
-      expect { create(:comment, commenter: commenter, commentable: commentable) }.not_to change(Federails::Activity, :count)
+    it "does not post a Federails Activity on creation" do
+      expect {
+        create(:comment, commenter: commenter, commentable: commentable)
+      }.not_to change(Federails::Activity.where(actor: commenter.federails_actor), :count)
     end
 
     it "does not have a federated_url" do
@@ -99,8 +104,10 @@ RSpec.describe Comment do
     let(:commenter) { create(:creator, :public) }
     let(:commentable) { create(:model, creator: commenter) }
 
-    it "Does not post a Federails Activity on creation" do
-      expect { create(:comment, commenter: commenter, commentable: commentable) }.not_to change(Federails::Activity, :count)
+    it "does not post a Federails Activity on creation" do
+      expect {
+        create(:comment, commenter: commenter, commentable: commentable)
+      }.not_to change(Federails::Activity.where(actor: commenter.federails_actor), :count)
     end
 
     it "does not have a federated_url" do

--- a/spec/models/concerns/caber_object_shared.rb
+++ b/spec/models/concerns/caber_object_shared.rb
@@ -8,15 +8,14 @@ shared_examples "Caber::Object" do
     expect(caber_object.class).to respond_to :can_grant_permissions_to
   end
 
-  it "is created with a default owner" do
+  it "is created with no default owner" do
     create(described_class.to_s.underscore.to_sym)
-    expect(caber_object.grants_permission_to?("own", admin)).to be true
+    expect(caber_object.caber_relations).to be_empty
   end
 
-  it "can be given an explicit owner at creation" do # rubocop:disable RSpec/MultipleExpectations, RSpec/ExampleLength
+  it "can be given an explicit owner at creation" do
     object = create(described_class.to_s.underscore.to_sym, owner: contributor)
     expect(object.grants_permission_to?("own", contributor)).to be true
-    expect(object.grants_permission_to?("own", admin)).to be false
   end
 
   context "when assigning permissions at creation" do

--- a/spec/models/concerns/caber_object_shared.rb
+++ b/spec/models/concerns/caber_object_shared.rb
@@ -194,7 +194,13 @@ shared_examples "Caber::Object" do
       expect(object.reload.matching_permission_preset).to eq "public"
     end
 
-    it "is member if there is a member view permission, an owner, and nothing else" do
+    it "is member if there is a member view permission, owner, and nothing else" do
+      object.grant_permission_to "view", Role.find_by(name: "member")
+      object.grant_permission_to "own", contributor
+      expect(object.reload.matching_permission_preset).to eq "member"
+    end
+
+    it "is member if there is a member view permission, no owner, and nothing else" do
       object.grant_permission_to "view", Role.find_by(name: "member")
       expect(object.reload.matching_permission_preset).to eq "member"
     end

--- a/spec/models/concerns/caber_object_shared.rb
+++ b/spec/models/concerns/caber_object_shared.rb
@@ -10,7 +10,7 @@ shared_examples "Caber::Object" do
 
   it "is created with no default owner" do
     create(described_class.to_s.underscore.to_sym)
-    expect(caber_object.caber_relations).to be_empty
+    expect(caber_object.owners).to be_empty
   end
 
   it "can be given an explicit owner at creation" do

--- a/spec/models/concerns/caber_object_shared.rb
+++ b/spec/models/concerns/caber_object_shared.rb
@@ -1,6 +1,5 @@
 shared_examples "Caber::Object" do
   let(:caber_object) { create(described_class.to_s.underscore.to_sym) }
-  let!(:admin) { create(:admin) }
   let(:contributor) { create(:contributor) }
   let(:member) { create(:user) }
 

--- a/spec/models/concerns/caber_object_shared.rb
+++ b/spec/models/concerns/caber_object_shared.rb
@@ -50,7 +50,7 @@ shared_examples "Caber::Object" do
       let(:object) { create(described_class.to_s.underscore.to_sym, permission_preset: "private") }
 
       it "does not grant view permission to member role" do
-        expect(object.grants_permission_to?("view", Role.find_by!(name: "member"))).to be false
+        expect(object.grants_permission_to?("view", Role.find_or_create_by(name: "member"))).to be false
       end
 
       it "does not grant public view permission" do
@@ -98,7 +98,7 @@ shared_examples "Caber::Object" do
       let(:object) { create(described_class.to_s.underscore.to_sym) }
 
       it "does not grant view permission to member role" do
-        expect(object.grants_permission_to?("view", Role.find_by!(name: "member"))).to be false
+        expect(object.grants_permission_to?("view", Role.find_or_create_by(name: "member"))).to be false
       end
 
       it "does not grant public view permission" do
@@ -194,13 +194,13 @@ shared_examples "Caber::Object" do
     end
 
     it "is member if there is a member view permission, owner, and nothing else" do
-      object.grant_permission_to "view", Role.find_by(name: "member")
+      object.grant_permission_to "view", Role.find_or_create_by(name: "member")
       object.grant_permission_to "own", contributor
       expect(object.reload.matching_permission_preset).to eq "member"
     end
 
     it "is member if there is a member view permission, no owner, and nothing else" do
-      object.grant_permission_to "view", Role.find_by(name: "member")
+      object.grant_permission_to "view", Role.find_or_create_by(name: "member")
       expect(object.reload.matching_permission_preset).to eq "member"
     end
 

--- a/spec/models/concerns/caber_object_shared.rb
+++ b/spec/models/concerns/caber_object_shared.rb
@@ -183,7 +183,6 @@ shared_examples "Caber::Object" do
     before do
       allow(SiteSettings).to receive(:default_viewer_role).and_return(:private)
       object.caber_relations.destroy_all
-      object.grant_permission_to("own", SiteSettings.default_user)
     end
 
     it "is private if there is only one owner and no other permissions" do
@@ -216,7 +215,6 @@ shared_examples "Caber::Object" do
       group.members << user
       allow(SiteSettings).to receive(:default_viewer_role).and_return(:private)
       object.caber_relations.destroy_all
-      object.grant_permission_to("own", SiteSettings.default_user)
     end
 
     it "group does not have view permission by default" do

--- a/spec/models/concerns/talkative_shared.rb
+++ b/spec/models/concerns/talkative_shared.rb
@@ -5,27 +5,41 @@ shared_examples "Talkative" do
     end
 
     it "posts an activity" do
+      expect {
+        create(described_class.to_s.underscore.to_sym)
+      }.to change { Federails::Activity.where(action: "Create").count }.from(0).to(1)
+    end
+
+    it "posts activity for the correct actor" do
       entity = create(described_class.to_s.underscore.to_sym)
-      expect(Federails::Activity.where(entity: entity.federails_actor, action: "Create").count).to eq 1
+      expect(Federails::Activity.where(action: "Create").last.entity).to eq entity.federails_actor
     end
   end
 
-  context "when being updated" do
-    let!(:entity) { create(described_class.to_s.underscore.to_sym) }
-
-    before do
-      create(:admin)
-    end
+  context "when updating a model that was created a while ago" do
+    let!(:entity) { create(described_class.to_s.underscore.to_sym, created_at: 1.hour.ago, updated_at: 1.hour.ago) }
 
     it "posts an activity after update" do
-      entity.update caption: "test"
-      expect(Federails::Activity.where(entity: entity.federails_actor, action: "Update").count).to eq 1
+      expect {
+        entity.update caption: "test"
+      }.to change { Federails::Activity.where(entity: entity.federails_actor, action: "Update").count }.from(0).to(1)
     end
 
     it "doesn't post an activity after update if there's already been one recently" do
       entity.update caption: "change"
-      entity.update caption: "change again"
-      expect(Federails::Activity.where(entity: entity.federails_actor, action: "Update").count).to eq 1
+      expect {
+        entity.update caption: "change again"
+      }.not_to change { Federails::Activity.where(entity: entity.federails_actor, action: "Update").count }
+    end
+  end
+
+  context "when updating a model that was just created" do
+    let!(:entity) { create(described_class.to_s.underscore.to_sym) }
+
+    it "doesn't post an activity after update" do
+      expect {
+        entity.update caption: "test"
+      }.not_to change { Federails::Activity.where(entity: entity.federails_actor, action: "Update").count }
     end
   end
 end

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -495,6 +495,8 @@ RSpec.describe Model do
       m
     }
 
+    let(:owner) { create(:user) }
+
     it "creates a new model" do
       expect { model.split! }.to change(described_class, :count).by(1)
     end
@@ -544,6 +546,7 @@ RSpec.describe Model do
     it "copies permissions" do # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
       member_role = Role.find_by(name: :member)
       model.revoke_permission("view", member_role)
+      model.grant_permission_to("own", owner)
       new_model = model.split! files: [model.model_files.first]
       expect(model.caber_relations.count).to eq 1
       expect(new_model.caber_relations.count).to eq 1

--- a/spec/requests/lists_spec.rb
+++ b/spec/requests/lists_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe "/lists", :as_member do
     end
 
     context "with list items from different lists" do
-      let!(:other_list) { create(:list, owner: SiteSettings.default_user) }
+      let!(:other_list) { create(:list, owner: create(:user)) }
 
       before do
         other_list.models << model


### PR DESCRIPTION
We don't actually need to set a default owner. Because admins get edit rights on everything, they can already do everything they need without being the owner. So, things can now be owned by nobody, and that's fine.

And, if they need to post something, they do it as themselves