### PR TITLE
Allow quoting for federated create/update notes

### DIFF
--- a/app/serializers/activity_pub/comment_serializer.rb
+++ b/app/serializers/activity_pub/comment_serializer.rb
@@ -9,6 +9,7 @@ module ActivityPub
             "https://purl.archive.org/miscellany",
             {
               f3di: "http://purl.org/f3di/ns#",
+              gts: "https://gotosocial.org/ns#",
               Hashtag: "as:Hashtag",
               sensitive: "as:sensitive"
             }
@@ -20,7 +21,12 @@ module ActivityPub
           "f3di:compatibilityNote" => @object.system,
           "inReplyTo" => in_reply_to,
           "url" => url,
-          "likes" => likes
+          "likes" => likes,
+          "gts:interactionPolicy" => @object.system ? {
+            "gts:canQuote" => {
+              "gts:automaticApproval" => Fediverse::Collection::PUBLIC
+            }
+          } : nil
         }.compact.merge(address_fields)
       )
     end

--- a/spec/serializers/activity_pub/comment_serializer_spec.rb
+++ b/spec/serializers/activity_pub/comment_serializer_spec.rb
@@ -40,6 +40,10 @@ RSpec.describe ActivityPub::CommentSerializer do
     it "includes canonical comment link in url field" do
       expect(ap["url"]).to eq "http://localhost:3214/models/#{model.public_id}#comment-#{comment.public_id}"
     end
+
+    it "does not automatically allows quoting" do
+      expect(ap.dig("gts:interactionPolicy", "gts:canQuote", "gts:automaticApproval")).to be_nil
+    end
   end
 
   context "when the system comments on something with tags" do
@@ -59,6 +63,16 @@ RSpec.describe ActivityPub::CommentSerializer do
         id: model.federails_actor.federated_url + "#likes",
         type: "Collection",
         totalItems: 0
+      })
+    end
+
+    it "include gotosocial namespace in JSON-LD context, for quoting" do
+      expect(ap["@context"].last).to include({gts: "https://gotosocial.org/ns#"})
+    end
+
+    it "automatically allows quoting" do
+      expect(ap.dig("gts:interactionPolicy", "gts:canQuote")).to eq({
+        "gts:automaticApproval" => "https://www.w3.org/ns/activitystreams#Public"
       })
     end
   end


### PR DESCRIPTION
Only system comments (the ones created automatically as Notes for creation/update messages) are quotable, people's individual comments won't be. We can add config options for that later.

Resolves #5348