### PR TITLE
Force multiuser mode if federation is enabled

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -75,7 +75,7 @@ module Manyfold
     # Load some feature settings from ENV
     # Some are automatically enabled in test mode because they impact initialization
     config.manyfold_features = {
-      multiuser: (ENV.fetch("MULTIUSER", nil) == "enabled"),
+      multiuser: ENV.fetch("MULTIUSER", nil) == "enabled" || ENV.fetch("FEDERATION", nil) == "enabled",
       federation: (ENV.fetch("FEDERATION", nil) == "enabled"),
       demo_mode: (ENV.fetch("DEMO_MODE", nil) == "enabled"),
       oidc: ENV.key?("OIDC_CLIENT_ID") && ENV.key?("OIDC_CLIENT_SECRET") && ENV.key?("OIDC_ISSUER")


### PR DESCRIPTION
This is a bit safer, though when singleuser goes away completely (#5938), it won't be necessary any more.