### PR TITLE
Push docker images to DockerHub as well as GHCR

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,9 @@ jobs:
         id: docker_meta
         uses: docker/metadata-action@v6
         with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.variant }}
+          images: |
+            ${{ github.repository_owner }}/${{ matrix.variant }}
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.variant }}
           tags: |
             type=raw,value=${{ inputs.tag }},event=workflow_dispatch
             type=schedule,pattern=nightly
@@ -58,6 +60,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
         id: depot


### PR DESCRIPTION
As part of moving us away from being so reliant on GitHub