### PR TITLE
Add CLI commands for initial setup

### DIFF
--- a/app/lib/cli/libraries_command.rb
+++ b/app/lib/cli/libraries_command.rb
@@ -13,5 +13,18 @@ module Cli
       puts "\nQueueing #{scope.count} #{"library".pluralize(scope.count)} for filesystem scan"
       scope.find_each(&:detect_filesystem_changes_later)
     end
+
+    desc "create", "create a new library (local filesystem only)"
+    option :name, required: true, type: :string, description: "library name"
+    option :path, required: true, type: :string, description: "local filesystem path"
+    def create
+      l = Library.create(name: options[:name], path: options[:path], storage_service: "filesystem")
+      if l.valid?
+        puts "\nNew library created OK"
+      else
+        puts "\nError when creating library:\n"
+        puts l.errors.full_messages.inspect
+      end
+    end
   end
 end

--- a/app/lib/cli/users_command.rb
+++ b/app/lib/cli/users_command.rb
@@ -30,5 +30,26 @@ module Cli
     rescue RuntimeError => e
       puts "\n#{e}"
     end
+
+    desc "create", "create a new user"
+    option :email, required: true, type: :string, aliases: :mail
+    option :username, required: true, type: :string, aliases: :login
+    option :password, required: true, type: :string
+    option :role, required: false, type: :string, enum: %w[administrator moderator contributor member]
+    def create
+      u = User.create(
+        username: options[:username],
+        email: options[:email],
+        password: options[:password],
+        password_confirmation: options[:password_confirmation]
+      )
+      if u.valid?
+        u.add_role(options[:role].to_sym) if options[:role]
+        puts "\nNew user created OK"
+      else
+        puts "\nError when creating user:\n"
+        puts u.errors.full_messages.inspect
+      end
+    end
   end
 end


### PR DESCRIPTION
You can now add the first administrator user with:

```
bin/manyfold user create --username=bob --email=bob@example.com --password=<whatever> --role=administrator
```

And you can add a library with

```
bin/manyfold libraries create --name="My Library" --path=/path/to/my/library
```

This means you can script the initial site setup (see #1975 for the rationale). 

Resolves #6043 
Resolves #6042