### PR TITLE
Remove ghcr.io references

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -92,7 +92,7 @@ jobs:
         run: curl http://localhost:3214/health --fail-with-body
     services:
       manyfold:
-        image: ghcr.io/${{ github.repository_owner }}/manyfold-solo:sha-${{ github.sha }}
+        image: manyfold3d/manyfold-solo:sha-${{ github.sha }}
         env:
           SECRET_KEY_BASE: abc123
         options: >-

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   app:
-    image: ghcr.io/manyfold3d/manyfold:latest
+    image: manyfold3d/manyfold:latest
     ports:
       - 3214:3214
     volumes:

--- a/spec/lib/usage_report_spec.rb
+++ b/spec/lib/usage_report_spec.rb
@@ -31,8 +31,8 @@ RSpec.describe UsageReport do
     end
 
     it "includes image type" do
-      ClimateControl.modify DOCKER_TAG: "ghcr.io/manyfold3d/manyfold:latest" do
-        expect(JSON.parse(described_class.generate)["version"]["image"]).to eq "ghcr.io/manyfold3d/manyfold"
+      ClimateControl.modify DOCKER_TAG: "manyfold3d/manyfold:latest" do
+        expect(JSON.parse(described_class.generate)["version"]["image"]).to eq "manyfold3d/manyfold"
       end
     end
 


### PR DESCRIPTION
It's still available and maintained, but we want people to primarily use dockerhub now.