### PR TITLE
Refactor 3rd-party file format support info into a common form

### DIFF
--- a/app/components/preview_frame.rb
+++ b/app/components/preview_frame.rb
@@ -46,9 +46,9 @@ class Components::PreviewFrame < Components::Base
       image cover_collection_path(@object), @object.name
     elsif @file.is_image?
       image model_model_file_path(@file.model, @file, format: @file.extension, derivative: "preview"), @file.name
-    elsif Renderer.supports?(@file)
+    elsif Renderers::Three.supports?(@file)
       div class: "card-img-top #{"sensitive" if needs_hiding?}" do
-        Renderer file: @file
+        Renderers::Three file: @file
       end
     elsif @file.has_render?
       image model_model_file_path(@file.model, @file, format: @file.extension, derivative: "render"), @file.name

--- a/app/components/preview_frame.rb
+++ b/app/components/preview_frame.rb
@@ -46,7 +46,7 @@ class Components::PreviewFrame < Components::Base
       image cover_collection_path(@object), @object.name
     elsif @file.is_image?
       image model_model_file_path(@file.model, @file, format: @file.extension, derivative: "preview"), @file.name
-    elsif @file.is_renderable?
+    elsif Renderer.supports?(@file)
       div class: "card-img-top #{"sensitive" if needs_hiding?}" do
         Renderer file: @file
       end

--- a/app/components/renderer.rb
+++ b/app/components/renderer.rb
@@ -4,12 +4,12 @@ class Components::Renderer < Components::Base
   include Phlex::Rails::Helpers::JavascriptPath
   include Phlex::Rails::Helpers::NumberToHumanSize
 
-  def initialize(file:)
-    @file = file
+  def self.supports?(file)
+    FileHandlers::Three.can_load? file&.mime_type
   end
 
-  def render?
-    @file&.is_renderable?
+  def initialize(file:)
+    @file = file
   end
 
   def before_template

--- a/app/components/renderers/three.rb
+++ b/app/components/renderers/three.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Components::Renderer < Components::Base
+class Components::Renderers::Three < Components::Base
   include Phlex::Rails::Helpers::JavascriptPath
   include Phlex::Rails::Helpers::NumberToHumanSize
 

--- a/app/helpers/components_helper.rb
+++ b/app/helpers/components_helper.rb
@@ -8,6 +8,13 @@ module ComponentsHelper
     end
   end
 
+  # and the same for Renderers
+  Components::Renderers.constants.each do |constant|
+    define_method "Renderers#{constant}" do |**args, &block|
+      render Components::Renderers.const_get(constant).new(**args, &block)
+    end
+  end
+
   def render_component_collection(component, param, collection, kwargs = {})
     safe_join(collection.map { |it| render component.new(**{param => it}.merge(kwargs)) }, " ")
   end

--- a/app/jobs/analysis/file_conversion_job.rb
+++ b/app/jobs/analysis/file_conversion_job.rb
@@ -16,7 +16,7 @@ class Analysis::FileConversionJob < ApplicationJob
     file = ModelFile.find(file_id)
 
     # Can we convert this format?
-    raise UnsupportedFormatError if !SupportedMimeTypes.can_export?(output_format) || !file.loadable?
+    raise UnsupportedFormatError unless file.convertable?(to: output_format)
     extension = Mime::EXTENSION_LOOKUP.select { |k, v| v.symbol == output_format }.keys.last
 
     status[:step] = "jobs.analysis.file_conversion.loading_mesh" # i18n-tasks-use t('jobs.analysis.file_conversion.loading_mesh')

--- a/app/jobs/scan/model/parse_metadata_job.rb
+++ b/app/jobs/scan/model/parse_metadata_job.rb
@@ -45,7 +45,7 @@ class Scan::Model::ParseMetadataJob < ApplicationJob
 
   def preview_priority(file)
     return 0 if file.is_image?
-    return 1 if file.is_renderable?
+    return 1 if Components::Renderer.supports?(file)
     100
   end
 

--- a/app/jobs/scan/model/parse_metadata_job.rb
+++ b/app/jobs/scan/model/parse_metadata_job.rb
@@ -45,7 +45,7 @@ class Scan::Model::ParseMetadataJob < ApplicationJob
 
   def preview_priority(file)
     return 0 if file.is_image?
-    return 1 if Components::Renderer.supports?(file)
+    return 1 if Components::Renderers::Three.supports?(file)
     100
   end
 

--- a/app/jobs/upgrade/backfill_model_renders.rb
+++ b/app/jobs/upgrade/backfill_model_renders.rb
@@ -2,7 +2,7 @@ class Upgrade::BackfillModelRenders < Upgrade::BackfillDerivativesBase
   queue_as :performance
 
   def mime_types
-    SupportedMimeTypes.renderable_types
+    FileHandlers::F3d.input_types
   end
 
   def derivative

--- a/app/lib/file_handlers/assimp.rb
+++ b/app/lib/file_handlers/assimp.rb
@@ -1,0 +1,15 @@
+class FileHandlers::Assimp < FileHandlers::Base
+  class << self
+    def input_types
+      Mime::EXTENSION_LOOKUP.slice(
+        *::Assimp.extension_list.to_s.delete("*.").split(";")
+      ).values
+    end
+
+    def output_types
+      Mime::EXTENSION_LOOKUP.slice(
+        *(0...::Assimp.aiGetExportFormatCount).map { |it| ::Assimp.aiGetExportFormatDescription it }.map(&:file_extension)
+      ).values
+    end
+  end
+end

--- a/app/lib/file_handlers/assimp.rb
+++ b/app/lib/file_handlers/assimp.rb
@@ -1,5 +1,9 @@
 class FileHandlers::Assimp < FileHandlers::Base
   class << self
+    def scopes
+      [:server]
+    end
+
     def input_types
       Mime::EXTENSION_LOOKUP.slice(
         *::Assimp.extension_list.to_s.delete("*.").split(";")

--- a/app/lib/file_handlers/base.rb
+++ b/app/lib/file_handlers/base.rb
@@ -1,0 +1,25 @@
+class FileHandlers::Base
+  class << self
+    extend Memoist
+
+    def can_load?(type)
+      type.in? input_types
+    end
+    memoize :can_load?
+
+    def input_types
+      []
+    end
+    memoize :input_types
+
+    def can_save?(type)
+      type.in? output_types
+    end
+    memoize :can_save?
+
+    def output_types
+      []
+    end
+    memoize :output_types
+  end
+end

--- a/app/lib/file_handlers/base.rb
+++ b/app/lib/file_handlers/base.rb
@@ -2,6 +2,15 @@ class FileHandlers::Base
   class << self
     extend Memoist
 
+    def scopes
+      # Derived classes should return an array of places that this handler applies to.
+      # Any of:
+      #  :server (the thing running Manyfold)
+      #  :browser (the visitor's web browser - Safari, Chrome, etc)
+      #  :client (the visitor's machine, that the browser is running on)
+      raise NotImplementedError
+    end
+
     def can_load?(type)
       type.in? input_types
     end

--- a/app/lib/file_handlers/f3d.rb
+++ b/app/lib/file_handlers/f3d.rb
@@ -1,0 +1,7 @@
+class FileHandlers::F3d < FileHandlers::Base
+  class << self
+    def input_types
+      F3d.reader_mime_types.filter_map { |it| Mime::Type.lookup(it) }.uniq
+    end
+  end
+end

--- a/app/lib/file_handlers/f3d.rb
+++ b/app/lib/file_handlers/f3d.rb
@@ -1,5 +1,9 @@
 class FileHandlers::F3d < FileHandlers::Base
   class << self
+    def scopes
+      [:server]
+    end
+
     def input_types
       F3d.reader_mime_types.filter_map { |it| Mime::Type.lookup(it) }.uniq
     end

--- a/app/lib/file_handlers/three.rb
+++ b/app/lib/file_handlers/three.rb
@@ -1,0 +1,9 @@
+class FileHandlers::Three < FileHandlers::Base
+  class << self
+    def input_types
+      Mime::EXTENSION_LOOKUP.slice(
+        "stl", "obj", "3mf", "ply", "gltf", "glb", "drc", "fbx", "3ds", "gcode", "mpd", "ldr", "3dm"
+      ).values
+    end
+  end
+end

--- a/app/lib/file_handlers/three.rb
+++ b/app/lib/file_handlers/three.rb
@@ -1,5 +1,9 @@
 class FileHandlers::Three < FileHandlers::Base
   class << self
+    def scopes
+      [:browser]
+    end
+
     def input_types
       Mime::EXTENSION_LOOKUP.slice(
         "stl", "obj", "3mf", "ply", "gltf", "glb", "drc", "fbx", "3ds", "gcode", "mpd", "ldr", "3dm"

--- a/app/lib/supported_mime_types.rb
+++ b/app/lib/supported_mime_types.rb
@@ -52,11 +52,6 @@ module SupportedMimeTypes
     end
     memoize :model_extensions
 
-    def can_export?(type)
-      FileHandlers::Assimp.can_save? type
-    end
-    memoize :can_export?
-
     def indexable_types
       image_types + model_types + video_types + document_types + archive_types
     end

--- a/app/lib/supported_mime_types.rb
+++ b/app/lib/supported_mime_types.rb
@@ -57,11 +57,6 @@ module SupportedMimeTypes
     end
     memoize :can_export?
 
-    def can_render?(type)
-      FileHandlers::F3d.can_load? type
-    end
-    memoize :can_render?
-
     def indexable_types
       image_types + model_types + video_types + document_types + archive_types
     end

--- a/app/lib/supported_mime_types.rb
+++ b/app/lib/supported_mime_types.rb
@@ -52,27 +52,11 @@ module SupportedMimeTypes
     end
     memoize :model_extensions
 
-    def loadable
-      Mime::EXTENSION_LOOKUP.slice(
-        *Assimp.extension_list.to_s.delete("*.").split(";")
-      ).values.map(&:to_sym)
-    end
-    memoize :loadable
-
-    def can_load?(type)
-      loadable.include? type
-    end
+    delegate :can_load?, to: :"FileHandlers::Assimp"
     memoize :can_load?
 
-    def exportable
-      Mime::EXTENSION_LOOKUP.slice(
-        *(0...Assimp.aiGetExportFormatCount).map { |it| Assimp.aiGetExportFormatDescription it }.map(&:file_extension)
-      ).values.map(&:to_sym)
-    end
-    memoize :exportable
-
     def can_export?(type)
-      exportable.include? type
+      FileHandlers::Assimp.can_save? type
     end
     memoize :can_export?
 

--- a/app/lib/supported_mime_types.rb
+++ b/app/lib/supported_mime_types.rb
@@ -52,9 +52,6 @@ module SupportedMimeTypes
     end
     memoize :model_extensions
 
-    delegate :can_load?, to: :"FileHandlers::Assimp"
-    memoize :can_load?
-
     def can_export?(type)
       FileHandlers::Assimp.can_save? type
     end

--- a/app/lib/supported_mime_types.rb
+++ b/app/lib/supported_mime_types.rb
@@ -60,13 +60,8 @@ module SupportedMimeTypes
     end
     memoize :can_export?
 
-    def renderable_types
-      F3d.reader_mime_types.filter_map { |it| Mime::Type.lookup(it) }.uniq
-    end
-    memoize :renderable_types
-
     def can_render?(type)
-      renderable_types.include? type
+      FileHandlers::F3d.can_load? type
     end
     memoize :can_render?
 

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -210,7 +210,7 @@ class Model < ApplicationRecord
   end
 
   def valid_preview_files
-    model_files.select { |it| it.is_image? || it.is_renderable? }
+    model_files.select { |it| it.is_image? || Components::Renderer.supports?(it) }
   end
 
   def image_files

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -210,7 +210,7 @@ class Model < ApplicationRecord
   end
 
   def valid_preview_files
-    model_files.select { |it| it.is_image? || Components::Renderer.supports?(it) }
+    model_files.select { |it| it.is_image? || Components::Renderers::Three.supports?(it) }
   end
 
   def image_files

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -83,7 +83,7 @@ class ModelFile < ApplicationRecord
   end
 
   def is_renderable?
-    ["stl", "obj", "3mf", "ply", "gltf", "glb", "drc", "fbx", "3ds", "gcode", "mpd", "ldr", "3dm"].include? extension
+    FileHandlers::Three.can_load? mime_type
   end
 
   def has_render?

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -209,8 +209,9 @@ class ModelFile < ApplicationRecord
     Analysis::FileConversionJob.set(wait: delay).perform_later(id, format.to_sym)
   end
 
-  def loadable?
-    FileHandlers::Assimp.can_load? mime_type
+  def convertable?(to: nil)
+    return false unless FileHandlers::Assimp.can_load? mime_type
+    to.nil? || FileHandlers::Assimp.can_save?(to)
   end
 
   def delete_from_disk_and_destroy

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -82,10 +82,6 @@ class ModelFile < ApplicationRecord
     SupportedMimeTypes.model_extensions.include? extension
   end
 
-  def is_renderable?
-    FileHandlers::Three.can_load? mime_type
-  end
-
   def has_render?
     is_3d_model? && attachment_attacher.derivatives.key?(:render)
   end

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -210,7 +210,7 @@ class ModelFile < ApplicationRecord
   end
 
   def loadable?
-    SupportedMimeTypes.can_load? mime_type.symbol
+    FileHandlers::Assimp.can_load? mime_type
   end
 
   def delete_from_disk_and_destroy

--- a/app/policies/model_file_policy.rb
+++ b/app/policies/model_file_policy.rb
@@ -9,7 +9,7 @@ class ModelFilePolicy < ApplicationPolicy
   end
 
   def convert?
-    can_update_model? && @record.loadable? && !@record.problems.exists?(category: :non_manifold)
+    can_update_model? && @record.convertable? && !@record.problems.exists?(category: :non_manifold)
   end
 
   def update?

--- a/app/serializers/o_embed/application_serializer.rb
+++ b/app/serializers/o_embed/application_serializer.rb
@@ -26,7 +26,7 @@ module OEmbed
     def model_file_properties(model_file)
       props = if model_file&.is_image?
         photo_properties(model_file)
-      elsif Components::Renderer.supports?(model_file)
+      elsif Components::Renderers::Three.supports?(model_file)
         renderable_properties(model_file)
       elsif model_file&.is_video?
         video_properties(model_file)

--- a/app/serializers/o_embed/application_serializer.rb
+++ b/app/serializers/o_embed/application_serializer.rb
@@ -26,7 +26,7 @@ module OEmbed
     def model_file_properties(model_file)
       props = if model_file&.is_image?
         photo_properties(model_file)
-      elsif model_file&.is_renderable?
+      elsif Components::Renderer.supports?(model_file)
         renderable_properties(model_file)
       elsif model_file&.is_video?
         video_properties(model_file)

--- a/app/uploaders/application_uploader.rb
+++ b/app/uploaders/application_uploader.rb
@@ -126,7 +126,7 @@ class ApplicationUploader < Shrine
           carousel: magick.resize_to_limit!(1024, 768)
         }
       end
-    elsif SiteSettings.generate_model_renders && SupportedMimeTypes.can_render?(context[:record].mime_type)
+    elsif SiteSettings.generate_model_renders && FileHandlers::F3d.can_load?(context[:record].mime_type)
       Shrine.with_file(original) do |it|
         up = context[:record]&.up_direction
         options = F3D_OPTS.merge(

--- a/app/views/model_files/embedded.html.erb
+++ b/app/views/model_files/embedded.html.erb
@@ -4,6 +4,6 @@
   <%= video_tag model_model_file_path(@model, @file, format: @file.extension), alt: @file.name, style: "width: 100%", controls: true %>
 <% elsif @file.is_document? %>
   <%= tag.iframe src: model_model_file_path(@model, @file, format: @file.extension), alt: @file.name, style: "width: 100%; aspect-ratio: 0.707" %>
-<% elsif @file.is_renderable? %>
+<% elsif Components::Renderer.supports?(@file) %>
   <%= Renderer(file: @file) %>
 <% end %>

--- a/app/views/model_files/embedded.html.erb
+++ b/app/views/model_files/embedded.html.erb
@@ -4,6 +4,6 @@
   <%= video_tag model_model_file_path(@model, @file, format: @file.extension), alt: @file.name, style: "width: 100%", controls: true %>
 <% elsif @file.is_document? %>
   <%= tag.iframe src: model_model_file_path(@model, @file, format: @file.extension), alt: @file.name, style: "width: 100%; aspect-ratio: 0.707" %>
-<% elsif Components::Renderer.supports?(@file) %>
-  <%= Renderer(file: @file) %>
+<% elsif Components::Renderers::Three.supports?(@file) %>
+  <%= RenderersThree(file: @file) %>
 <% end %>

--- a/app/views/model_files/show.html.erb
+++ b/app/views/model_files/show.html.erb
@@ -19,7 +19,7 @@
       <%= video_tag model_model_file_path(@model, @file, format: @file.extension), alt: @file.name, style: "width: 100%", controls: true %>
     <% elsif @file.is_document? %>
       <%= tag.iframe src: model_model_file_path(@model, @file, format: @file.extension), alt: @file.name, style: "width: 100%; aspect-ratio: 0.707" %>
-    <% elsif @file.is_renderable? %>
+    <% elsif Components::Renderer.supports?(@file) %>
       <% if @file.presupported_version || @file.unsupported_version %>
         <ul class="nav nav-tabs">
           <li class="nav-item">

--- a/app/views/model_files/show.html.erb
+++ b/app/views/model_files/show.html.erb
@@ -19,7 +19,7 @@
       <%= video_tag model_model_file_path(@model, @file, format: @file.extension), alt: @file.name, style: "width: 100%", controls: true %>
     <% elsif @file.is_document? %>
       <%= tag.iframe src: model_model_file_path(@model, @file, format: @file.extension), alt: @file.name, style: "width: 100%; aspect-ratio: 0.707" %>
-    <% elsif Components::Renderer.supports?(@file) %>
+    <% elsif Components::Renderers::Three.supports?(@file) %>
       <% if @file.presupported_version || @file.unsupported_version %>
         <ul class="nav nav-tabs">
           <li class="nav-item">
@@ -38,7 +38,7 @@
           </li>
         </ul>
       <% end %>
-      <%= Renderer(file: @file) %>
+      <%= RenderersThree(file: @file) %>
     <% elsif @file.has_render? %>
       <%= image_tag model_model_file_path(@model, @file, format: @file.extension, derivative: "render"), style: "width: 100%", alt: @file.name %>
     <% end %>

--- a/app/views/models/_file.html.erb
+++ b/app/views/models/_file.html.erb
@@ -3,7 +3,7 @@
     <% if file.is_image? %>
       <%= content_tag :div, nil, class: "card-img-top card-img-top-background", style: "background-image: url(#{model_model_file_path(@model, file, format: file.extension)})" %>
       <%= image_tag model_model_file_path(@model, file, format: file.extension), class: "card-img-top image-preview", alt: file.name %>
-    <% elsif file.is_renderable? %>
+    <% elsif Components::Renderer.supports?(@file) %>
       <div class="card-img-top">
         <%= Renderer(file: file) %>
       </div>
@@ -65,7 +65,7 @@
                 <%= DropdownDivider() %>
               <% end %>
               <%= DropdownItem icon: "pencil-fill", label: t(".edit"), path: edit_model_model_file_path(@model, file) if policy(file).edit? %>
-              <%= DropdownItem icon: "image", label: t(".set_as_preview"), path: model_path(@model, "model[preview_file_id]": file.id), method: :patch if policy(@model).edit? && file.is_renderable? || file.is_image? %>
+              <%= DropdownItem icon: "image", label: t(".set_as_preview"), path: model_path(@model, "model[preview_file_id]": file.id), method: :patch if policy(@model).edit? && Components::Renderer.supports?(file) || file.is_image? %>
               <%= DropdownItem icon: "trash", label: t(".delete"), path: model_model_file_path(@model, file), method: :delete, confirm: translate("model_files.destroy.confirm") if policy(file).destroy? %>
             <% end %>
           </div>

--- a/app/views/models/_file.html.erb
+++ b/app/views/models/_file.html.erb
@@ -3,9 +3,9 @@
     <% if file.is_image? %>
       <%= content_tag :div, nil, class: "card-img-top card-img-top-background", style: "background-image: url(#{model_model_file_path(@model, file, format: file.extension)})" %>
       <%= image_tag model_model_file_path(@model, file, format: file.extension), class: "card-img-top image-preview", alt: file.name %>
-    <% elsif Components::Renderer.supports?(@file) %>
+    <% elsif Components::Renderers::Three.supports?(file) %>
       <div class="card-img-top">
-        <%= Renderer(file: file) %>
+        <%= RenderersThree(file: file) %>
       </div>
     <% elsif file.has_render? %>
       <%= content_tag :div, nil, class: "card-img-top card-img-top-background", style: "background-image: url(#{model_model_file_path(@model, file, format: file.extension)})" %>
@@ -65,7 +65,7 @@
                 <%= DropdownDivider() %>
               <% end %>
               <%= DropdownItem icon: "pencil-fill", label: t(".edit"), path: edit_model_model_file_path(@model, file) if policy(file).edit? %>
-              <%= DropdownItem icon: "image", label: t(".set_as_preview"), path: model_path(@model, "model[preview_file_id]": file.id), method: :patch if policy(@model).edit? && Components::Renderer.supports?(file) || file.is_image? %>
+              <%= DropdownItem icon: "image", label: t(".set_as_preview"), path: model_path(@model, "model[preview_file_id]": file.id), method: :patch if policy(@model).edit? && Components::Renderers::Three.supports?(file) || file.is_image? %>
               <%= DropdownItem icon: "trash", label: t(".delete"), path: model_model_file_path(@model, file), method: :delete, confirm: translate("model_files.destroy.confirm") if policy(file).destroy? %>
             <% end %>
           </div>

--- a/spec/components/renderer_spec.rb
+++ b/spec/components/renderer_spec.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Components::Renderer, type: :component do
+  context "when checking renderer support"
+  {
+    stl: true,
+    png: false,
+    pdf: false,
+    lys: false
+  }.each_pair do |extension, result|
+    it "shows that #{extension} files are#{"n't" if result == false} renderable" do
+      file = create(:model_file, filename: "test.#{extension}")
+      expect(described_class.supports?(file)).to be result
+    end
+  end
+end

--- a/spec/components/renderers/three_spec.rb
+++ b/spec/components/renderers/three_spec.rb
@@ -2,7 +2,7 @@
 
 require "rails_helper"
 
-RSpec.describe Components::Renderer, type: :component do
+RSpec.describe Components::Renderers::Three, type: :component do
   context "when checking renderer support"
   {
     stl: true,

--- a/spec/models/model_file_spec.rb
+++ b/spec/models/model_file_spec.rb
@@ -227,18 +227,6 @@ RSpec.describe ModelFile do
     end
   end
 
-  {
-    stl: true,
-    png: false,
-    pdf: false,
-    lys: false
-  }.each_pair do |extension, result|
-    it "shows that #{extension} files are#{"n't" if result == false} renderable" do
-      file = create(:model_file, filename: "test.#{extension}")
-      expect(file.is_renderable?).to be result
-    end
-  end
-
   [true, false].each do |state|
     before do
       allow(SiteSettings).to receive_messages(default_indexable: state, default_ai_indexable: state)


### PR DESCRIPTION
This unifies the existing can_*? methods (and similar) into a common framework for third party software, such as assimp, f3d, and three.js.

A single class interface now encapsulates the capabilities of each handler, allowing introspection, autodetection, and the simple addition of others in future.