### PR TITLE
Overwrite existing file with same filename on upload

### DIFF
--- a/app/jobs/process_uploaded_file_job.rb
+++ b/app/jobs/process_uploaded_file_job.rb
@@ -70,11 +70,15 @@ class ProcessUploadedFileJob < ApplicationJob
     # Handle different file types
     case File.extname(file.original_filename).delete(".").downcase
     when *SupportedMimeTypes.indexable_extensions
-      new_file = model.model_files.create(filename: file.original_filename, attachment: file)
+      if (existing_file = model.model_files.where(filename: file.original_filename).first)
+        existing_file.update(attachment: file)
+        existing_file
+      else
+        model.model_files.create(filename: file.original_filename, attachment: file)
+      end
     else
       Rails.logger.warn("Ignoring #{file.inspect}")
     end
-    new_file
   end
 
   private

--- a/spec/jobs/process_uploaded_file_job_spec.rb
+++ b/spec/jobs/process_uploaded_file_job_spec.rb
@@ -120,6 +120,16 @@ RSpec.describe ProcessUploadedFileJob do
       expect { job.perform(library.id, file, model: model) }.to change(model.model_files, :count).by(1)
     end
 
+    it "doesn't increase model count if uploading the same filename" do
+      create(:model_file, model: model, filename: "test.stl")
+      expect { job.perform(library.id, file, model: model) }.not_to change(model.model_files, :count)
+    end
+
+    it "overwrites existing file with the same filename" do
+      create(:model_file, model: model, filename: "test.stl")
+      expect { job.perform(library.id, file, model: model) }.to change { model.model_files.first.attachment.read }.to("solid\n")
+    end
+
     it "promotes the file to proper storage" do
       job.perform(library.id, file, model: model)
       expect(model.model_files.last.attachment.storage_key).to eq :library_1


### PR DESCRIPTION
If an uploaded file has the same filename as an existing one, it will now overwrite what's there. Resolves #4966.