### PR TITLE
Prevent 3d rendering of image files

### DIFF
--- a/app/uploaders/application_uploader.rb
+++ b/app/uploaders/application_uploader.rb
@@ -126,7 +126,7 @@ class ApplicationUploader < Shrine
           carousel: magick.resize_to_limit!(1024, 768)
         }
       end
-    elsif SiteSettings.generate_model_renders && FileHandlers::F3d.can_load?(context[:record].mime_type)
+    elsif SiteSettings.generate_model_renders && FileHandlers::F3d.can_load?(context[:record].mime_type) && context[:record]&.is_3d_model?
       Shrine.with_file(original) do |it|
         up = context[:record]&.up_direction
         options = F3D_OPTS.merge(


### PR DESCRIPTION
Only happens if 3d renders are on, but image derivatives are off. Resolves #6087
