### PR TITLE
XRFragments entrypoint support

### DIFF
--- a/app/deserializers/form/model_deserializer.rb
+++ b/app/deserializers/form/model_deserializer.rb
@@ -4,6 +4,7 @@ module Form
       return nil unless @params
       allowed = @params.require(:model).permit(
         :preview_file_id, # i18n-tasks-use t("activerecord.attributes.model.preview_file")
+        :entrypoint_id, # i18n-tasks-use t("activerecord.attributes.model.entrypoint")
         :creator_id, # i18n-tasks-use t("activerecord.attributes.model.creator_id")
         :library_id, # i18n-tasks-use t("activerecord.attributes.model.library_id")
         :name, # i18n-tasks-use t("activerecord.attributes.model.name")

--- a/app/deserializers/form/model_deserializer.rb
+++ b/app/deserializers/form/model_deserializer.rb
@@ -4,7 +4,6 @@ module Form
       return nil unless @params
       allowed = @params.require(:model).permit(
         :preview_file_id, # i18n-tasks-use t("activerecord.attributes.model.preview_file")
-        :entrypoint_id, # i18n-tasks-use t("activerecord.attributes.model.entrypoint")
         :creator_id, # i18n-tasks-use t("activerecord.attributes.model.creator_id")
         :library_id, # i18n-tasks-use t("activerecord.attributes.model.library_id")
         :name, # i18n-tasks-use t("activerecord.attributes.model.name")
@@ -14,6 +13,8 @@ module Form
         :sensitive, # i18n-tasks-use t("activerecord.attributes.model.sensitive")
         :indexable, # i18n-tasks-use t("activerecord.attributes.model.indexable")
         :ai_indexable, # i18n-tasks-use t("activerecord.attributes.model.ai_indexable")
+        :entrypoint_id, # i18n-tasks-use t("activerecord.attributes.model.entrypoint")
+        :entrypoint_fragment, # i18n-tasks-use t("activerecord.attributes.model.entrypoint_fragment")
         :q,
         :library,
         :creator,

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -231,7 +231,7 @@ class Model < ApplicationRecord
     save!
   end
 
-  def self.create_from(other, link_preview_file: false, name: nil, path: nil)
+  def self.create_from(other, link_preview_file: false, link_entrypoint: false, name: nil, path: nil)
     new_model = other.dup
     new_model.update(
       path: path,
@@ -239,6 +239,7 @@ class Model < ApplicationRecord
       public_id: nil,
       tags: other.tags,
       preview_file: link_preview_file ? other.preview_file : nil,
+      entrypoint: link_entrypoint ? other.entrypoint : nil,
       collections: other.collections
     )
     path ? new_model.save! : new_model.organize!
@@ -252,9 +253,12 @@ class Model < ApplicationRecord
 
   def split!(files: [])
     preview_file_will_move = files.include?(preview_file)
-    new_model = Model.create_from(self, link_preview_file: preview_file_will_move)
+    entrypoint_will_move = files.include?(entrypoint)
+    new_model = Model.create_from(self, link_preview_file: preview_file_will_move, link_entrypoint: entrypoint_will_move)
     # Clear preview file if it was moved
     update!(preview_file: nil) if preview_file_will_move
+    # Clear entrypoint file if it was moved
+    update!(entrypoint: nil) if entrypoint_will_move
     # Move files
     files.each { |it| new_model.adopt_file(it) }
     # Done!

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -43,6 +43,7 @@ class Model < ApplicationRecord
   has_many :collections, through: :collections_models, after_add: :after_collection_added, after_remove: :after_collection_removed
 
   belongs_to :preview_file, class_name: "ModelFile", optional: true
+  belongs_to :entrypoint, class_name: "ModelFile", optional: true
 
   # old collection_id database field is deprecated but kept around for compatibility
   belongs_to :deprecated_collection, class_name: "Collection", foreign_key: "collection_id", optional: true # rubocop:disable Rails/InverseOf

--- a/app/views/models/_form.html.erb
+++ b/app/views/models/_form.html.erb
@@ -46,7 +46,7 @@
   <%= select_input_row form, :indexable, indexable_select_options(form.object) %>
   <%= select_input_row form, :ai_indexable, ai_indexable_select_options(form.object) if SiteSettings.allow_ai_bots %>
 
-  <%= collection_select_input_row form, :entrypoint, Naturally.sort_by(@model.three_d_files, :name_and_filename), :id, :name_and_filename, help: t(".entrypoint.help_html") %>
+  <%= collection_select_input_row form, :entrypoint, Naturally.sort_by(@model.three_d_files, :name_and_filename), :id, :name_and_filename, help: t(".entrypoint.help_html"), include_blank: true %>
   <%= text_input_row form, :entrypoint_fragment, help: t(".entrypoint_fragment.help") %>
 
   <%= render "caber_relations_form", form: form %>

--- a/app/views/models/_form.html.erb
+++ b/app/views/models/_form.html.erb
@@ -45,6 +45,10 @@
   <%= checkbox_input_row form, :sensitive %>
   <%= select_input_row form, :indexable, indexable_select_options(form.object) %>
   <%= select_input_row form, :ai_indexable, ai_indexable_select_options(form.object) if SiteSettings.allow_ai_bots %>
+
+  <%= collection_select_input_row form, :entrypoint, Naturally.sort_by(@model.three_d_files, :name_and_filename), :id, :name_and_filename, help: t(".entrypoint.help_html") %>
+  <%= text_input_row form, :entrypoint_fragment, help: t(".entrypoint_fragment.help") %>
+
   <%= render "caber_relations_form", form: form %>
 
   <div>

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -5,7 +5,7 @@
   <%= tag.meta name: "fediverse:creator", content: @model.creator.federails_actor.at_address if @model.creator %>
   <%= tag.link rel: "alternate", type: Mime[:oembed], href: model_url(@model, format: :oembed), title: @model.name %>
   <%- if @model.entrypoint %>
-    <%= tag.link rel: "alternate", as: "spatial-entrypoint", type: @model.entrypoint.mime_type, href: model_model_file_raw_url(@model, @model.entrypoint.filename) %>
+    <%= tag.link rel: "alternate", as: "spatial-entrypoint", type: @model.entrypoint.mime_type, href: model_model_file_raw_url(@model, @model.entrypoint.filename, anchor: @model.entrypoint_fragment) %>
   <%- end %>
 <% end %>
 

--- a/app/views/models/show.html.erb
+++ b/app/views/models/show.html.erb
@@ -4,6 +4,9 @@
   <%= tag.meta name: "description", content: truncate(sanitize(@model.notes), length: 80) if @model.notes.present? %>
   <%= tag.meta name: "fediverse:creator", content: @model.creator.federails_actor.at_address if @model.creator %>
   <%= tag.link rel: "alternate", type: Mime[:oembed], href: model_url(@model, format: :oembed), title: @model.name %>
+  <%- if @model.entrypoint %>
+    <%= tag.link rel: "alternate", as: "spatial-entrypoint", type: @model.entrypoint.mime_type, href: model_model_file_raw_url(@model, @model.entrypoint.filename) %>
+  <%- end %>
 <% end %>
 
 <div itemscope itemtype="https://schema.org/3DModel">

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -104,6 +104,8 @@ cs:
         ai_indexable:
         caption: Titulek
         creator_id: Autor
+        entrypoint:
+        entrypoint_fragment:
         indexable:
         library_id: Knihovna
         license: Licence

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -104,6 +104,8 @@ de:
         ai_indexable: Verwendung für KI-Training zulassen
         caption: Bildunterschrift
         creator_id: Autor
+        entrypoint:
+        entrypoint_fragment:
         indexable: Suchindizierung zulassen
         library_id: Sammlung
         license: Lizenz

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -104,6 +104,8 @@ en:
         ai_indexable: Allow use for AI training
         caption: Caption
         creator_id: Creator
+        entrypoint: Entrypoint
+        entrypoint_fragment: Entrypoint Fragment
         indexable: Allow search indexing
         library_id: Library
         license: License

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -104,6 +104,8 @@ es:
         ai_indexable: Permitir el uso para el entrenamiento de IA
         caption: Subtítulo
         creator_id: Creador
+        entrypoint:
+        entrypoint_fragment:
         indexable: Permitir la indexación de búsquedas
         library_id: Biblioteca
         license: Licencia

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -106,6 +106,8 @@ fr:
         ai_indexable: Permettre l'utilisation pour l'entrainement d'IA
         caption: Légende
         creator_id: Créateur
+        entrypoint:
+        entrypoint_fragment:
         indexable:
         library_id: Bibliothèque
         license: Licence

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -104,6 +104,8 @@ ja:
         ai_indexable:
         caption: キャプション
         creator_id: クリエイター
+        entrypoint:
+        entrypoint_fragment:
         indexable:
         library_id: ライブラリー
         license: ライセンス

--- a/config/locales/models/cs.yml
+++ b/config/locales/models/cs.yml
@@ -39,6 +39,10 @@ cs:
       presupported: Předběžně podporovaná verze
       set_as_preview: Nastavit jako náhled
     form:
+      entrypoint:
+        help_html:
+      entrypoint_fragment:
+        help:
       notes:
         help_html: Můžete použít <a href="https://www.markdownguide.org/cheat-sheet/" target="markdown">Markdown</a>.
       preview_file:

--- a/config/locales/models/de.yml
+++ b/config/locales/models/de.yml
@@ -39,6 +39,10 @@ de:
       presupported: Version mit Supportstruktur
       set_as_preview: Als Vorschau setzen
     form:
+      entrypoint:
+        help_html:
+      entrypoint_fragment:
+        help:
       notes:
         help_html: 'Du kannst <a href="https://www.markdownguide.org/cheat-sheet/" target="markdown">Markdown</a> verwenden. '
       preview_file:

--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -39,6 +39,10 @@ en:
       presupported: Presupported Version
       set_as_preview: Set as preview
     form:
+      entrypoint:
+        help_html: Optionally choose a 3D file to be used as an entrypoint (or index, or main) file for this model. Used for <a href="https://xrfragment.org/#XRF%20microformat">XRFragments</a>.
+      entrypoint_fragment:
+        help: 'Optionally set a particular fragment (e.g. #main) within the selected file to be used as the entrypoint.'
       notes:
         help_html: You can use <a href="https://www.markdownguide.org/cheat-sheet/" target="markdown">Markdown</a>.
       preview_file:

--- a/config/locales/models/es.yml
+++ b/config/locales/models/es.yml
@@ -39,6 +39,10 @@ es:
       presupported: Versión con soporte predefinido
       set_as_preview: Establecer como vista previa
     form:
+      entrypoint:
+        help_html:
+      entrypoint_fragment:
+        help:
       notes:
         help_html: Puedes utilizar <a href="https://www.markdownguide.org/cheat-sheet/" target="markdown">Markdown</a>.
       preview_file:

--- a/config/locales/models/fr.yml
+++ b/config/locales/models/fr.yml
@@ -39,6 +39,10 @@ fr:
       presupported:
       set_as_preview: Définir comme aperçu
     form:
+      entrypoint:
+        help_html:
+      entrypoint_fragment:
+        help:
       notes:
         help_html: Vous pouvez utiliser du <a href="https://www.markdownguide.org/cheat-sheet/" target="markdown">Markdown</a>.
       preview_file:

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -39,6 +39,10 @@ ja:
       presupported:
       set_as_preview:
     form:
+      entrypoint:
+        help_html:
+      entrypoint_fragment:
+        help:
       notes:
         help_html:
       preview_file:

--- a/config/locales/models/nl.yml
+++ b/config/locales/models/nl.yml
@@ -39,6 +39,10 @@ nl:
       presupported:
       set_as_preview: Als voorbeeld instellen
     form:
+      entrypoint:
+        help_html:
+      entrypoint_fragment:
+        help:
       notes:
         help_html: Je kunt <a href="https://www.markdownguide.org/cheat-sheet/" target="markdown">Markdown</a> gebruiken.
       preview_file:

--- a/config/locales/models/pl.yml
+++ b/config/locales/models/pl.yml
@@ -39,6 +39,10 @@ pl:
       presupported:
       set_as_preview: Ustaw jako podgląd
     form:
+      entrypoint:
+        help_html:
+      entrypoint_fragment:
+        help:
       notes:
         help_html: Możesz używać <a href="https://www.markdownguide.org/cheat-sheet/" target="markdown">Markdown</a>.
       preview_file:

--- a/config/locales/models/pt.yml
+++ b/config/locales/models/pt.yml
@@ -39,6 +39,10 @@ pt:
       presupported:
       set_as_preview:
     form:
+      entrypoint:
+        help_html:
+      entrypoint_fragment:
+        help:
       notes:
         help_html:
       preview_file:

--- a/config/locales/models/ru.yml
+++ b/config/locales/models/ru.yml
@@ -39,6 +39,10 @@ ru:
       presupported:
       set_as_preview:
     form:
+      entrypoint:
+        help_html:
+      entrypoint_fragment:
+        help:
       notes:
         help_html:
       preview_file:

--- a/config/locales/models/zh-CN.yml
+++ b/config/locales/models/zh-CN.yml
@@ -39,6 +39,10 @@ zh-CN:
       presupported: 有支撑的版本
       set_as_preview: 设置为预览
     form:
+      entrypoint:
+        help_html:
+      entrypoint_fragment:
+        help:
       notes:
         help_html: 您可以使用<a href="https://www.markdownguide.org/cheat-sheet/" target="markdown">Markdown</a>。
       preview_file:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -104,6 +104,8 @@ nl:
         ai_indexable: Gebruik voor AI-training toestaan
         caption: Onderschrift
         creator_id: Maker
+        entrypoint:
+        entrypoint_fragment:
         indexable: Indexering voor zoekopdrachten toestaan
         library_id: Bibliotheek
         license: Licentie

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -104,6 +104,8 @@ pl:
         ai_indexable:
         caption: Napis
         creator_id: Twórca
+        entrypoint:
+        entrypoint_fragment:
         indexable:
         library_id: Biblioteka
         license: Licencja

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -104,6 +104,8 @@ pt:
         ai_indexable:
         caption:
         creator_id:
+        entrypoint:
+        entrypoint_fragment:
         indexable:
         library_id:
         license:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -104,6 +104,8 @@ ru:
         ai_indexable: Разрешить использование данных для обучения ИИ
         caption: Описание
         creator_id: Автор
+        entrypoint:
+        entrypoint_fragment:
         indexable: Разрешить индексацию поисковыми системами
         library_id: Библиотека
         license: Лицензия

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -104,6 +104,8 @@ zh-CN:
         ai_indexable: 允许用于 AI 训练
         caption: 标题
         creator_id: 创作者
+        entrypoint:
+        entrypoint_fragment:
         indexable: 允许搜索索引
         library_id: 资料库
         license: 许可证

--- a/db/migrate/20260512112504_add_entrypoint_to_models.rb
+++ b/db/migrate/20260512112504_add_entrypoint_to_models.rb
@@ -1,5 +1,6 @@
 class AddEntrypointToModels < ActiveRecord::Migration[8.0]
   def change
     add_reference :models, :entrypoint, null: true, foreign_key: {to_table: :model_files}
+    add_column :models, :entrypoint_fragment, :string, null: true
   end
 end

--- a/db/migrate/20260512112504_add_entrypoint_to_models.rb
+++ b/db/migrate/20260512112504_add_entrypoint_to_models.rb
@@ -1,0 +1,5 @@
+class AddEntrypointToModels < ActiveRecord::Migration[8.0]
+  def change
+    add_reference :models, :entrypoint, null: true, foreign_key: {to_table: :model_files}
+  end
+end

--- a/spec/deserializers/form/model_deserializer_spec.rb
+++ b/spec/deserializers/form/model_deserializer_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe Form::ModelDeserializer do
       "model" => ActionController::Parameters.new({
         "name" => "Batarang",
         "preview_file_id" => "12345",
+        "entrypoint_id" => "54321",
         "creator_id" => "93",
         "library_id" => "20",
         "tag_list" => ["wonderful", "toys"],

--- a/spec/deserializers/form/model_deserializer_spec.rb
+++ b/spec/deserializers/form/model_deserializer_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe Form::ModelDeserializer do
         "name" => "Batarang",
         "preview_file_id" => "12345",
         "entrypoint_id" => "54321",
+        "entrypoint_fragment" => "fragment",
         "creator_id" => "93",
         "library_id" => "20",
         "tag_list" => ["wonderful", "toys"],

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -574,6 +574,22 @@ RSpec.describe Model do
       expect(model.preview_file).to eq preview_file
     end
 
+    it "sets entrypoint in new model if file is part of split" do # rubocop:todo RSpec/MultipleExpectations
+      entrypoint = model.model_files.first
+      model.update!(entrypoint: entrypoint)
+      new_model = model.split! files: [entrypoint]
+      expect(model.reload.entrypoint).to be_nil
+      expect(new_model.reload.entrypoint).to eq entrypoint
+    end
+
+    it "leaves entrypoint in old model if file is not part of split" do # rubocop:todo RSpec/MultipleExpectations
+      entrypoint = model.model_files.first
+      model.update!(entrypoint: entrypoint)
+      new_model = model.split! files: [model.model_files.last]
+      expect(model.reload.entrypoint).to eq entrypoint
+      expect(new_model.reload.entrypoint).to be_nil
+    end
+
     it "copies permissions" do # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
       member_role = Role.find_by(name: :member)
       model.revoke_permission("view", member_role)

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Models" do
   end
 
   [:multiuser, :singleuser].each do |mode|
-    context "when signed in in #{mode} mode", mode do
+    context "when signed in in #{mode} mode", mode, :after_first_run do
       let!(:creator) { create(:creator) }
       let!(:collection) { create(:collection) }
       let!(:library) do
@@ -167,6 +167,22 @@ RSpec.describe "Models" do
           expect(response).to have_http_status(:redirect)
           expect(private_model.reload).to be_public
           expect(private_creator.reload).to be_public
+        end
+
+        it "sets preview file", :as_moderator do
+          model = library.models.first
+          file = create(:model_file, model: model, filename: "test.jpg")
+          expect {
+            put "/models/#{model.to_param}", params: {model: {preview_file_id: file.id}}
+          }.to change { model.reload.preview_file }.from(nil).to(file)
+        end
+
+        it "sets entrypoint", :as_moderator do
+          model = library.models.first
+          file = create(:model_file, model: model, filename: "test.stl")
+          expect {
+            put "/models/#{model.to_param}", params: {model: {entrypoint_id: file.id}}
+          }.to change { model.reload.entrypoint }.from(nil).to(file)
         end
 
         it "adds links", :as_moderator do # rubocop:todo RSpec/ExampleLength

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -185,6 +185,13 @@ RSpec.describe "Models" do
           }.to change { model.reload.entrypoint }.from(nil).to(file)
         end
 
+        it "sets entrypoint fragment", :as_moderator do
+          model = library.models.first
+          expect {
+            put "/models/#{model.to_param}", params: {model: {entrypoint_fragment: "main"}}
+          }.to change { model.reload.entrypoint_fragment }.from(nil).to("main")
+        end
+
         it "adds links", :as_moderator do # rubocop:todo RSpec/ExampleLength
           model = library.models.first
           put "/models/#{model.to_param}", params: {


### PR DESCRIPTION
You can now choose an "entrypoint" file and fragment for a model. The entrypoint URL is included in a header link tag for the model page as well.

This is to support XRFragments: https://xrfragment.org/#XR%20Fragments and might have more utility in future!

Resolves #4967 
Resolves #4963 