### PR TITLE
Add site-wide and user-specific setting for default landing page

### DIFF
--- a/app/components/page_title.rb
+++ b/app/components/page_title.rb
@@ -11,7 +11,7 @@ class Components::PageTitle < Components::Base
     nav aria: {label: "breadcrumb"}, class: "border-bottom pt-1 pb-1" do
       ol class: "breadcrumb" do
         li class: "breadcrumb-item" do
-          a(href: root_path) { Icon icon: "house", label: t("application.navbar.home") }
+          a(href: dashboard_path) { Icon icon: "house", label: t("application.navbar.home") }
         end
         @breadcrumbs.map do |text, path|
           li class: "breadcrumb-item" do

--- a/app/components/page_title.rb
+++ b/app/components/page_title.rb
@@ -11,7 +11,7 @@ class Components::PageTitle < Components::Base
     nav aria: {label: "breadcrumb"}, class: "border-bottom pt-1 pb-1" do
       ol class: "breadcrumb" do
         li class: "breadcrumb-item" do
-          a(href: root_url) { Icon icon: "house", label: t("application.navbar.home") }
+          a(href: root_path) { Icon icon: "house", label: t("application.navbar.home") }
         end
         @breadcrumbs.map do |text, path|
           li class: "breadcrumb-item" do

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -26,8 +26,11 @@ class ApplicationController < ActionController::Base
   end
 
   def index
-    raise NotImplementedError
+    skip_policy_scope
+    redirect_to helpers.landing_page_path
   end
+
+  private
 
   def authenticate_admin_user!
     authenticate_user!
@@ -42,8 +45,6 @@ class ApplicationController < ActionController::Base
   def check_scan_status
     @scan_in_progress = Sidekiq::Queue.new("scan").size > 0
   end
-
-  private
 
   def restore_failed_search
     @query ||= flash[:query]

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -18,7 +18,7 @@ class ApplicationController < ActionController::Base
   rescue_from ScopedSearch::QueryNotSupported, with: -> {
     flash[:alert] = t("application.search_error")
     flash[:query] = params[:q]
-    redirect_back_or_to root_path
+    redirect_back_or_to helpers.landing_page_path
   }
 
   unless Rails.env.test?

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -67,14 +67,14 @@ class FollowsController < ApplicationController
     authorize Federails::Following, :create?
     @actor = Federails::Actor.find_param(params[:id])
     current_user.follow(@actor)
-    redirect_back_or_to root_url, notice: t(".followed", actor: @actor.at_address)
+    redirect_back_or_to helpers.landing_page_path, notice: t(".followed", actor: @actor.at_address)
   end
 
   def unfollow_remote_actor
     authorize Federails::Following, :destroy?
     @actor = Federails::Actor.find_param(params[:id])
     current_user.unfollow(@actor)
-    redirect_back_or_to root_url, notice: t(".unfollowed", actor: @actor.at_address)
+    redirect_back_or_to helpers.landing_page_path, notice: t(".unfollowed", actor: @actor.at_address)
   end
 
   def create

--- a/app/controllers/imports_controller.rb
+++ b/app/controllers/imports_controller.rb
@@ -7,7 +7,7 @@ class ImportsController < ApplicationController
 
   def create
     CreateObjectFromUrlJob.perform_later(url: @url, owner: current_user)
-    redirect_to root_url, notice: t(".success")
+    redirect_to helpers.landing_page_path, notice: t(".success")
   end
 
   private

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -198,9 +198,9 @@ class ModelsController < ApplicationController
       format.html do
         if request.referer && (URI.parse(request.referer).path == model_path(@model))
           # If we're coming from the model page itself, we can't go back there
-          redirect_to root_path, notice: t(".success")
+          redirect_to helpers.landing_page_path, notice: t(".success")
         else
-          redirect_back_or_to root_path, notice: t(".success")
+          redirect_back_or_to helpers.landing_page_path, notice: t(".success")
         end
       end
       format.manyfold_api_v0 { head :no_content }

--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -1,5 +1,6 @@
 class SettingsController < ApplicationController
   before_action :check_owner_permission
+  before_action { SiteSettings.clear_cache }
 
   def update
     # Save site-wide settings if user is an admin
@@ -29,6 +30,7 @@ class SettingsController < ApplicationController
     SiteSettings.site_name = settings[:site_name]
     SiteSettings.site_tagline = settings[:site_tagline]
     SiteSettings.theme = settings[:theme]
+    SiteSettings.default_landing_page = settings[:default_landing_page]
     SiteSettings.about = settings[:about]
     SiteSettings.rules = settings[:rules]
     SiteSettings.support_link = settings[:support_link]

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -142,7 +142,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
   # The path used after sign up.
   def after_sign_up_path_for(resource)
-    SiteSettings.approve_signups ? root_path : welcome_path
+    SiteSettings.approve_signups ? helpers.landing_page_path : welcome_path
   end
 
   # The path used after sign up for inactive accounts.

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -100,6 +100,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
         :current_password, # i18n-tasks-use t("activerecord.attributes.user.current_password")
         :interface_language, # i18n-tasks-use t("activerecord.attributes.user.interface_language")
         :sensitive_content_handling, # i18n-tasks-use t("activerecord.attributes.user.sensitive_content_handling")
+        :landing_page, # i18n-tasks-use t("activerecord.attributes.user.landing_page")
         :sort_order, # i18n-tasks-use t("activerecord.attributes.user.sort_order")
         pagination_settings: [
           :per_page

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -28,6 +28,11 @@ class Users::SessionsController < Devise::SessionsController
 
   protected
 
+  # The path used after sign in.
+  def after_sign_in_path_for(resource)
+    helpers.landing_page_path
+  end
+
   # If you have extra params to permit, append them to the sanitizer.
   # def configure_sign_in_params
   #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
@@ -42,7 +47,7 @@ class Users::SessionsController < Devise::SessionsController
     if !SiteSettings.multiuser_enabled? || User.with_role(:administrator).first.first_use?
       sign_in(:user, User.with_role(:administrator).first)
       flash.discard
-      redirect_back_or_to root_path, alert: nil
+      redirect_back_or_to helpers.landing_page_path, alert: nil
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,6 @@
 module ApplicationHelper
   def landing_page_path
+    SiteSettings.clear_cache
     preference = SiteSettings.default_landing_page
     case preference
     when "all_models"

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,18 @@
 module ApplicationHelper
   def landing_page_path
-    dashboard_path
+    preference = SiteSettings.default_landing_page
+    case preference
+    when "all_models"
+      models_path
+    when "all_collections"
+      collections_path
+    when "all_creators"
+      creators_path
+    when "my_models"
+      models_path(owner: current_user&.to_param)
+    else # also "dashboard"
+      dashboard_path
+    end
   end
 
   def site_name(default: translate("application.title"))

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,7 +1,7 @@
 module ApplicationHelper
   def landing_page_path
     SiteSettings.clear_cache
-    preference = SiteSettings.default_landing_page
+    preference = current_user&.landing_page || SiteSettings.default_landing_page
     case preference
     when "all_models"
       models_path

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,6 @@
 module ApplicationHelper
   def landing_page_path
-    root_path
+    dashboard_path
   end
 
   def site_name(default: translate("application.title"))

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,8 @@
 module ApplicationHelper
+  def landing_page_path
+    root_path
+  end
+
   def site_name(default: translate("application.title"))
     SiteSettings.site_name.presence || default
   end

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -30,6 +30,15 @@ class SiteSettings < RailsSettings::Base
   field :rules, type: :string, default: nil
   field :support_link, type: :string, default: nil
 
+  LANDING_PAGES = [
+    "dashboard", # i18n-tasks-use t('settings.landing_pages.dashboard')
+    "all_models", # i18n-tasks-use t('settings.landing_pages.all_models')
+    "all_creators", # i18n-tasks-use t('settings.landing_pages.all_creators')
+    "all_collections", # i18n-tasks-use t('settings.landing_pages.all_collections')
+    "my_models" # i18n-tasks-use t('settings.landing_pages.my_models')
+  ]
+  field :default_landing_page, type: :string, default: "dashboard", validates: {inclusion: {in: LANDING_PAGES}}
+
   field :enable_user_quota, type: :boolean, default: false
   field :default_user_quota, type: :integer, default: 0
 

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -32,10 +32,10 @@ class SiteSettings < RailsSettings::Base
 
   LANDING_PAGES = [
     "dashboard", # i18n-tasks-use t('settings.landing_pages.dashboard')
+    "my_models", # i18n-tasks-use t('settings.landing_pages.my_models')
     "all_models", # i18n-tasks-use t('settings.landing_pages.all_models')
     "all_creators", # i18n-tasks-use t('settings.landing_pages.all_creators')
-    "all_collections", # i18n-tasks-use t('settings.landing_pages.all_collections')
-    "my_models" # i18n-tasks-use t('settings.landing_pages.my_models')
+    "all_collections" # i18n-tasks-use t('settings.landing_pages.all_collections')
   ]
   field :default_landing_page, type: :string, default: "dashboard", validates: {inclusion: {in: LANDING_PAGES}}
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,7 +71,7 @@ class User < ApplicationRecord
   attribute :sort_order, :integer # Explicit declaration of attribute so as not to break old data migrations
   enum :sort_order, {name: 0, recent: 1, updated: 2}, prefix: :sort_by, default: :name, validate: true
 
-  validates :landing_page, inclusion: {in: SiteSettings::LANDING_PAGES, allow_nil: true}
+  validates :landing_page, inclusion: {in: SiteSettings::LANDING_PAGES, allow_nil: true}, if: -> { has_attribute? :landing_page }
 
   has_many :access_grants, # rubocop:disable Rails/InverseOf
     class_name: "Doorkeeper::AccessGrant",

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -71,6 +71,8 @@ class User < ApplicationRecord
   attribute :sort_order, :integer # Explicit declaration of attribute so as not to break old data migrations
   enum :sort_order, {name: 0, recent: 1, updated: 2}, prefix: :sort_by, default: :name, validate: true
 
+  validates :landing_page, inclusion: {in: SiteSettings::LANDING_PAGES, allow_nil: true}
+
   has_many :access_grants, # rubocop:disable Rails/InverseOf
     class_name: "Doorkeeper::AccessGrant",
     foreign_key: :resource_owner_id,

--- a/app/validators/regex_array_validator.rb
+++ b/app/validators/regex_array_validator.rb
@@ -2,6 +2,7 @@
 
 class RegexArrayValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
+    return unless value.is_a? Array
     return unless value.any? { |pattern| pattern.to_regexp.nil? }
     record.errors.add(attribute, :invalid)
   end

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -115,7 +115,7 @@
             </li>
           <% end %>
         <% end %>
-        <%- unless current_page?(root_path) %>
+        <%- unless current_page?(controller: "/home", action: "index") %>
           <li id="nav-search" class="nav-item ms-1 me-3" data-turbo-permanent>
             <%= form_with url: models_path, method: :get, role: "search" do |f| %>
               <%= f.search_field :q, class: "form-control", placeholder: translate(".search"), aria_label: translate(".search"), aria_describedby: "button-search", value: @query || params[:q] %>

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -3,7 +3,7 @@
         bs_theme: "dark"
       }.merge(tour_attributes(id: "main-navbar", title: t("tour.navbar.main.title", name: site_name), description: t("tour.navbar.main.description"))) do %>
   <div class='container-fluid'>
-    <a class="navbar-brand ms-2" href="<%= root_path %>" aria-label="<%= translate ".home" %>">
+    <a class="navbar-brand ms-2" href="<%= dashboard_path %>" aria-label="<%= translate ".home" %>">
       <%= image_tag site_icon, alt: site_name, height: "40px", class: "me-2" %>
       <span class="d-md-none"><%= site_name %></span>
     </a>
@@ -115,7 +115,7 @@
             </li>
           <% end %>
         <% end %>
-        <%- unless current_page?(controller: "/home", action: "index") %>
+        <%- unless current_page?(dashboard_path) %>
           <li id="nav-search" class="nav-item ms-1 me-3" data-turbo-permanent>
             <%= form_with url: models_path, method: :get, role: "search" do |f| %>
               <%= f.search_field :q, class: "form-control", placeholder: translate(".search"), aria_label: translate(".search"), aria_describedby: "button-search", value: @query || params[:q] %>

--- a/app/views/devise/registrations/_general_settings.html.erb
+++ b/app/views/devise/registrations/_general_settings.html.erb
@@ -14,6 +14,17 @@
     </div>
 
     <div>
+      <%= form.label :landing_page, class: "col-form-label" %>
+    </div>
+    <div>
+      <%= form.select :landing_page,
+            SiteSettings::LANDING_PAGES.map { |it| [t("settings.landing_pages.%{option}" % {option: it}), it] },
+            {selected: @user.landing_page || SiteSettings.default_landing_page},
+            {class: "form-select"} %>
+      <small class="form-text"><%= t ".landing_page.help" %></small>
+    </div>
+
+    <div>
       <%= form.label :sensitive_content_handling, User.human_attribute_name(:sensitive_content_handling), class: "col-form-label" %>
     </div>
     <div>

--- a/app/views/settings/appearance.html.erb
+++ b/app/views/settings/appearance.html.erb
@@ -10,6 +10,10 @@
         label: t(".theme.label"),
         selected: SiteSettings.validated_theme,
         help: t(".theme.help_html") %>
+  <%= select_input_row form, "appearance[default_landing_page]", SiteSettings::LANDING_PAGES.map { |it| [t("settings.landing_pages.%{option}" % {option: it}), it] },
+        label: t(".default_landing_page.label"),
+        selected: SiteSettings.default_landing_page,
+        help: t(".default_landing_page.help") %>
   <hr>
   <h4><%= t(".information") %></h4>
   <%= rich_text_input_row form, "appearance[about]", label: t(".about.label"), value: SiteSettings.about, help: t(".about.help_html") %>

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -147,6 +147,7 @@ cs:
         encrypted_password: Zašifrované heslo
         failed_attempts: Chybných pokusů
         interface_language: Jazyk rozhraní
+        landing_page:
         last_sign_in_at: Poslední přihlášení
         last_sign_in_ip: Poslední přihlášení z IP
         locked_at: Uzamčeno

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -147,6 +147,7 @@ de:
         encrypted_password: Verschlüsseltes Passwort
         failed_attempts: Fehlversuche
         interface_language: Webseiten Sprache
+        landing_page:
         last_sign_in_at: Letzte Anmeldung am
         last_sign_in_ip: IP der letzten Anmeldung
         locked_at: Gesperrt am

--- a/config/locales/devise/cs.yml
+++ b/config/locales/devise/cs.yml
@@ -120,6 +120,8 @@ cs:
         interface_language:
           autodetect: Použít nastavení prohlížeče
           help: 'Poznámka: některé nepřeložené texty se mohou stále zobrazovat v angličtině.'
+        landing_page:
+          help:
         sensitive_content:
           help: Ovlivňuje způsob zobrazení obsahu označeného jako "citlivý"
           hide: Úplně skrýt

--- a/config/locales/devise/de.yml
+++ b/config/locales/devise/de.yml
@@ -120,6 +120,8 @@ de:
         interface_language:
           autodetect: Browsereinstellungen verwenden
           help: 'Hinweis: Einige nicht übersetzte Texte werden möglicherweise noch auf Englisch angezeigt.'
+        landing_page:
+          help:
         sensitive_content:
           help: Beeinflusst die Anzeige von als "Möglicherweise verstörender Inhalt" gekennzeichneten Inhalten
           hide: Vollständig ausblenden

--- a/config/locales/devise/en.yml
+++ b/config/locales/devise/en.yml
@@ -120,6 +120,8 @@ en:
         interface_language:
           autodetect: Use browser settings
           help: 'Note: some untranslated text may still show in English.'
+        landing_page:
+          help: The page you see by default when you log in (and some other times).
         sensitive_content:
           help: Affects how content marked as "sensitive" will be displayed
           hide: Hide completely

--- a/config/locales/devise/es.yml
+++ b/config/locales/devise/es.yml
@@ -120,6 +120,8 @@ es:
         interface_language:
           autodetect: Utilizar la configuración del navegador
           help: 'Nota: es posible que algunos textos no traducidos sigan apareciendo en inglés.'
+        landing_page:
+          help:
         sensitive_content:
           help: Afecta al modo en que se mostrará el contenido marcado como "sensible"
           hide: Ocultar completamente

--- a/config/locales/devise/fr.yml
+++ b/config/locales/devise/fr.yml
@@ -120,6 +120,8 @@ fr:
         interface_language:
           autodetect: Utiliser les paramètres du navigateur
           help: 'Remarque : certains textes non traduits peuvent encore s''afficher en anglais.'
+        landing_page:
+          help:
         sensitive_content:
           help: Affecte l'affichage du contenu marqué comme "sensible"
           hide: Cacher complètement

--- a/config/locales/devise/ja.yml
+++ b/config/locales/devise/ja.yml
@@ -120,6 +120,8 @@ ja:
         interface_language:
           autodetect: ブラウザの設定を使用する
           help: 注：未翻訳のテキストが英語で表示される場合があります。
+        landing_page:
+          help:
         sensitive_content:
           help: "「センシティブ」とマークされたコンテンツがどのように表示されるかに影響します。"
           hide: 完全に隠す

--- a/config/locales/devise/nl.yml
+++ b/config/locales/devise/nl.yml
@@ -120,6 +120,8 @@ nl:
         interface_language:
           autodetect: Gebruik browserinstellingen
           help: 'Let op: sommige onvertaalde teksten kunnen nog steeds in het Engels verschijnen.'
+        landing_page:
+          help:
         sensitive_content:
           help: Beïnvloedt hoe inhoud gemarkeerd als "gevoelig" wordt weergegeven
           hide: Volledig verbergen

--- a/config/locales/devise/pl.yml
+++ b/config/locales/devise/pl.yml
@@ -120,6 +120,8 @@ pl:
         interface_language:
           autodetect: Użyj ustawień przeglądarki
           help: 'Uwaga: niektóre nieprzetłumaczone teksty mogą nadal wyświetlać się w języku angielskim.'
+        landing_page:
+          help:
         sensitive_content:
           help: Wpływa na sposób wyświetlania treści oznaczonych jako "wrażliwych"
           hide: Ukryj całkowicie

--- a/config/locales/devise/pt.yml
+++ b/config/locales/devise/pt.yml
@@ -120,6 +120,8 @@ pt:
         interface_language:
           autodetect:
           help:
+        landing_page:
+          help:
         sensitive_content:
           help:
           hide:

--- a/config/locales/devise/ru.yml
+++ b/config/locales/devise/ru.yml
@@ -120,6 +120,8 @@ ru:
         interface_language:
           autodetect:
           help:
+        landing_page:
+          help:
         sensitive_content:
           help:
           hide:

--- a/config/locales/devise/zh-CN.yml
+++ b/config/locales/devise/zh-CN.yml
@@ -120,6 +120,8 @@ zh-CN:
         interface_language:
           autodetect: 使用浏览器设置
           help: 注意：某些未翻译的文字可能仍显示为英文。
+        landing_page:
+          help:
         sensitive_content:
           help: 影响标记为 "敏感" 的内容的显示方式
           hide: 完全隐藏

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -147,6 +147,7 @@ en:
         encrypted_password: Encrypted password
         failed_attempts: Failed attempts
         interface_language: Interface language
+        landing_page: Landing page
         last_sign_in_at: Last sign in at
         last_sign_in_ip: Last sign in IP
         locked_at: Locked at

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -147,6 +147,7 @@ es:
         encrypted_password: Contraseña cifrada
         failed_attempts: Intentos fallidos
         interface_language: Idioma de la aplicación
+        landing_page:
         last_sign_in_at: Último inicio de sesión el
         last_sign_in_ip: IP último inicio de sesión
         locked_at: Bloqueado el

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -149,6 +149,7 @@ fr:
         encrypted_password: Mot de passe chiffré
         failed_attempts: Tentatives échouées
         interface_language: Langue de l'interface
+        landing_page:
         last_sign_in_at: Date de la dernière connexion
         last_sign_in_ip: IP de la dernière connexion
         locked_at: Verrouillé à

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -147,6 +147,7 @@ ja:
         encrypted_password: 暗号化パスワード
         failed_attempts: 失敗したログイン試行回数
         interface_language: 言語
+        landing_page:
         last_sign_in_at: 最終ログイン時刻
         last_sign_in_ip: 最終ログインIPアドレス
         locked_at: ロック時刻

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -147,6 +147,7 @@ nl:
         encrypted_password: Versleuteld wachtwoord
         failed_attempts: Mislukte pogingen
         interface_language: Interfacetaal
+        landing_page:
         last_sign_in_at: Laatste inlogtijd
         last_sign_in_ip: Laatste inlog IP
         locked_at: Vergrendeld op

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -147,6 +147,7 @@ pl:
         encrypted_password: Zaszyfrowane hasło
         failed_attempts: Nieudanych prób
         interface_language: Język interfejsu
+        landing_page:
         last_sign_in_at: Data ostatniego logowania
         last_sign_in_ip: Adres IP ostatniego logowania
         locked_at: Data zablokowania

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -147,6 +147,7 @@ pt:
         encrypted_password: Palavra-passe cifrada
         failed_attempts: Tentativas falhadas
         interface_language:
+        landing_page:
         last_sign_in_at: Última entrada em
         last_sign_in_ip: Última entrada com IP
         locked_at: Bloqueado em

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -147,6 +147,7 @@ ru:
         encrypted_password: Зашифрованный пароль
         failed_attempts: Неудачные попытки
         interface_language:
+        landing_page:
         last_sign_in_at: Дата последнего входа
         last_sign_in_ip: IP последнего входа
         locked_at: Дата блокировки

--- a/config/locales/settings/cs.yml
+++ b/config/locales/settings/cs.yml
@@ -11,6 +11,9 @@ cs:
       about:
         help_html: Zobrazeno na stránce o aplikaci; Můžete použít <a href="https://www.markdownguide.org/cheat-sheet/" target="markdown">Markdown</a>.
         label: O této instanci
+      default_landing_page:
+        help:
+        label:
       heading: Vzhled
       information: Informace
       rules:
@@ -105,6 +108,12 @@ cs:
       thingiverse_api_key:
         help_html:
         label:
+    landing_pages:
+      all_collections:
+      all_creators:
+      all_models:
+      dashboard:
+      my_models:
     multiuser:
       approve_signups:
         help: Všechny nové účty musí před přihlášením schválit moderátor.

--- a/config/locales/settings/de.yml
+++ b/config/locales/settings/de.yml
@@ -11,6 +11,9 @@ de:
       about:
         help_html: Gezeigt auf der Info-Seite; kannst du <a href="https://www.markdownguide.org/cheat-sheet/" target="markdown">Markdown</a> verwenden.
         label: Über diese Instanz
+      default_landing_page:
+        help:
+        label:
       heading: Erscheinungsbild
       information: Informationen
       rules:
@@ -109,6 +112,12 @@ de:
       thingiverse_api_key:
         help_html: Erstelle eine "Web App" in der <a href="https://www.thingiverse.com/developers/my-apps">Entwicklerkonsole von Thingiverse</a>und füge den App Token hier ein.
         label: API-Schlüssel
+    landing_pages:
+      all_collections:
+      all_creators:
+      all_models:
+      dashboard:
+      my_models:
     multiuser:
       approve_signups:
         help: Alle neuen Konten müssen von einem Moderator genehmigt werden, bevor man sich anmelden kann.

--- a/config/locales/settings/en.yml
+++ b/config/locales/settings/en.yml
@@ -11,6 +11,9 @@ en:
       about:
         help_html: Shown on the about page; You can use <a href="https://www.markdownguide.org/cheat-sheet/" target="markdown">Markdown</a>.
         label: About this instance
+      default_landing_page:
+        help: The page that visitors and account holders will see by default.
+        label: Landing page
       heading: Appearance
       information: Information
       rules:
@@ -105,6 +108,12 @@ en:
       thingiverse_api_key:
         help_html: Create a "web app" in the <a href="https://www.thingiverse.com/developers/my-apps">Thingiverse developer console</a>, and paste the "app token" here.
         label: API key
+    landing_pages:
+      all_collections: Collections
+      all_creators: Creators
+      all_models: Models
+      dashboard: Dashboard
+      my_models: My Models
     multiuser:
       approve_signups:
         help: All new accounts must be approved by a moderator before they can sign in.

--- a/config/locales/settings/es.yml
+++ b/config/locales/settings/es.yml
@@ -11,6 +11,9 @@ es:
       about:
         help_html: Se muestra en la página de información. Puedes utilizar <a href="https://www.markdownguide.org/cheat-sheet/" target="markdown">Markdown</a>.
         label: Acerca de esta instancia
+      default_landing_page:
+        help:
+        label:
       heading: Apariencia
       information: Información
       rules:
@@ -105,6 +108,12 @@ es:
       thingiverse_api_key:
         help_html: Cree una "aplicación web" en la <a href="https://www.thingiverse.com/developers/my-apps">consola de desarrollador de Thingiverse</a> y pegue aquí el "token de aplicación".
         label: Clave API
+    landing_pages:
+      all_collections:
+      all_creators:
+      all_models:
+      dashboard:
+      my_models:
     multiuser:
       approve_signups:
         help: Todas las cuentas nuevas deben ser aprobadas por un moderador antes de poder iniciar sesión.

--- a/config/locales/settings/fr.yml
+++ b/config/locales/settings/fr.yml
@@ -11,6 +11,9 @@ fr:
       about:
         help_html:
         label:
+      default_landing_page:
+        help:
+        label:
       heading:
       information: Informations
       rules:
@@ -105,6 +108,12 @@ fr:
       thingiverse_api_key:
         help_html:
         label: Clé API
+    landing_pages:
+      all_collections:
+      all_creators:
+      all_models:
+      dashboard:
+      my_models:
     multiuser:
       approve_signups:
         help: Tous les nouveaux comptes doivent être approuvés par un modérateur avant de pouvoir se connecter.

--- a/config/locales/settings/ja.yml
+++ b/config/locales/settings/ja.yml
@@ -11,6 +11,9 @@ ja:
       about:
         help_html: アバウトページに掲載。<a href="https://www.markdownguide.org/cheat-sheet/" target="markdown">Markdownを</a>使用することができます。
         label: このインスタンスについて
+      default_landing_page:
+        help:
+        label:
       heading: 外観
       information: インフォメーション
       rules:
@@ -105,6 +108,12 @@ ja:
       thingiverse_api_key:
         help_html:
         label:
+    landing_pages:
+      all_collections:
+      all_creators:
+      all_models:
+      dashboard:
+      my_models:
     multiuser:
       approve_signups:
         help: すべての新規アカウントは、サインインする前にモデレーターの承認が必要です。

--- a/config/locales/settings/nl.yml
+++ b/config/locales/settings/nl.yml
@@ -11,6 +11,9 @@ nl:
       about:
         help_html:
         label:
+      default_landing_page:
+        help:
+        label:
       heading:
       information:
       rules:
@@ -105,6 +108,12 @@ nl:
       thingiverse_api_key:
         help_html:
         label:
+    landing_pages:
+      all_collections:
+      all_creators:
+      all_models:
+      dashboard:
+      my_models:
     multiuser:
       approve_signups:
         help: Alle nieuwe accounts moeten worden goedgekeurd door een moderator voordat ze kunnen inloggen.

--- a/config/locales/settings/pl.yml
+++ b/config/locales/settings/pl.yml
@@ -11,6 +11,9 @@ pl:
       about:
         help_html: Pokazane na stronie o instancji; Możesz użyć <a href="https://www.markdownguide.org/cheat-sheet/" target="markdown">Markdown</a>.
         label: O tej instancji
+      default_landing_page:
+        help:
+        label:
       heading: Wygląd
       information: Informacje
       rules:
@@ -105,6 +108,12 @@ pl:
       thingiverse_api_key:
         help_html:
         label:
+    landing_pages:
+      all_collections:
+      all_creators:
+      all_models:
+      dashboard:
+      my_models:
     multiuser:
       approve_signups:
         help: Wszystkie nowe konta muszą zostać zatwierdzone przez moderatora, zanim będą oni mogli się zalogować.

--- a/config/locales/settings/pt.yml
+++ b/config/locales/settings/pt.yml
@@ -11,6 +11,9 @@ pt:
       about:
         help_html:
         label:
+      default_landing_page:
+        help:
+        label:
       heading:
       information:
       rules:
@@ -105,6 +108,12 @@ pt:
       thingiverse_api_key:
         help_html:
         label:
+    landing_pages:
+      all_collections:
+      all_creators:
+      all_models:
+      dashboard:
+      my_models:
     multiuser:
       approve_signups:
         help:

--- a/config/locales/settings/ru.yml
+++ b/config/locales/settings/ru.yml
@@ -11,6 +11,9 @@ ru:
       about:
         help_html:
         label: Об этом сайте
+      default_landing_page:
+        help:
+        label:
       heading: Внешний вид
       information: Информация для пользователей
       rules:
@@ -105,6 +108,12 @@ ru:
       thingiverse_api_key:
         help_html:
         label:
+    landing_pages:
+      all_collections:
+      all_creators:
+      all_models:
+      dashboard:
+      my_models:
     multiuser:
       approve_signups:
         help:

--- a/config/locales/settings/zh-CN.yml
+++ b/config/locales/settings/zh-CN.yml
@@ -11,6 +11,9 @@ zh-CN:
       about:
         help_html: 如关于页面所示；您可以使用<a href="https://www.markdownguide.org/cheat-sheet/" target="markdown">Markdown</a>。
         label: 关于本实例
+      default_landing_page:
+        help:
+        label:
       heading: 外观
       information: 信息
       rules:
@@ -105,6 +108,12 @@ zh-CN:
       thingiverse_api_key:
         help_html: 在 <a href="https://www.thingiverse.com/developers/my-apps">Thingiverse 开发者控制台</a> 创建一个 "网络应用程序"，并在此粘贴 "应用程序令牌"。
         label: API 密钥
+    landing_pages:
+      all_collections:
+      all_creators:
+      all_models:
+      dashboard:
+      my_models:
     multiuser:
       approve_signups:
         help: 所有新账户必须经批准后才能登录。

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -147,6 +147,7 @@ zh-CN:
         encrypted_password: 密码被加密
         failed_attempts: 失败尝试
         interface_language: 界面语言
+        landing_page:
         last_sign_in_at: 最后登录于
         last_sign_in_ip: 最后登录的 IP
         locked_at: 锁定于

--- a/config/routes/meta.rb
+++ b/config/routes/meta.rb
@@ -1,4 +1,4 @@
-root to: "home#index"
+get "/dashboard", to: "home#index", as: :dashboard
 get "/about", to: "home#about", as: :about
 
 get "health" => "rails/health#show", :as => :rails_health_check

--- a/config/routes/meta.rb
+++ b/config/routes/meta.rb
@@ -1,3 +1,4 @@
+root to: "application#index"
 get "/dashboard", to: "home#index", as: :dashboard
 get "/about", to: "home#about", as: :about
 

--- a/db/migrate/20260514144832_add_landing_page_to_users.rb
+++ b/db/migrate/20260514144832_add_landing_page_to_users.rb
@@ -1,0 +1,5 @@
+class AddLandingPageToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :landing_page, :string, null: true, default: nil
+  end
+end

--- a/spec/migrations/migration_spec.rb
+++ b/spec/migrations/migration_spec.rb
@@ -1,3 +1,5 @@
+require "rails_helper"
+
 # Test migrations
 #
 # This approach runs migrations up to a specified point, loads an SQL file at that point, then runs

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -14,9 +14,9 @@ RSpec.describe "Home" do
         expect(response).to redirect_to("/libraries/new")
       end
 
-      it "shows the homepage if a library has been created", :as_member do
+      it "shows the dashboard if a library has been created", :as_member do
         create(:library)
-        get "/"
+        get "/dashboard"
         expect(response).to have_http_status(:success)
       end
     end

--- a/spec/requests/home_spec.rb
+++ b/spec/requests/home_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe "Home" do
   end
 
   context "when signed in" do
-    describe "GET /" do
+    describe "GET /dashboard" do
       it "redirects to library creation if there isn't one already", :as_member do
-        get "/"
+        get "/dashboard"
         expect(response).to redirect_to("/libraries/new")
       end
 

--- a/spec/requests/imports_spec.rb
+++ b/spec/requests/imports_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Imports", :after_first_run, :thingiverse_api_key do
 
         it "redirects back afterwards" do
           import
-          expect(response).to redirect_to("/")
+          expect(response).to redirect_to("/dashboard")
         end
 
         it "queues creation job with correct arguments" do

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -247,8 +247,8 @@ RSpec.describe "Models" do
       describe "DELETE /models/:id" do # rubocop:todo RSpec/RepeatedExampleGroupBody
         before { delete "/models/#{library.models.first.to_param}" }
 
-        it "redirects to model list after deletion", :as_moderator do
-          expect(response).to redirect_to("/")
+        it "redirects to landing page after deletion", :as_moderator do
+          expect(response).to redirect_to("/dashboard")
         end
 
         it "is denied to non-moderators", :as_contributor do

--- a/spec/requests/users/sessions_spec.rb
+++ b/spec/requests/users/sessions_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe "Users::Sessions" do
         let(:password) { SecureRandom.hex }
         let(:admin) { create(:admin, password: password, password_confirmation: password) }
 
-        it "succeeds and redirects to homepage with good credentials" do
+        it "succeeds and redirects to dashboard with good credentials" do
           post "/users/sign_in", params: {user: {email: admin.email, password: password}}
-          expect(response).to redirect_to("/")
+          expect(response).to redirect_to("/dashboard")
         end
 
         it "fails with bad credentials" do
@@ -67,9 +67,9 @@ RSpec.describe "Users::Sessions" do
 
     context "when signed in", :as_member do
       describe "GET /users/sign_in" do
-        it "redirects to root" do
+        it "redirects to dashboard by default" do
           get "/users/sign_in"
-          expect(response).to redirect_to("/")
+          expect(response).to redirect_to("/dashboard")
         end
       end
     end
@@ -98,18 +98,18 @@ RSpec.describe "Users::Sessions" do
           expect(controller.current_user).to be_present
         end
 
-        it "redirects to root" do
+        it "redirects to dashboard by default" do
           get "/users/sign_in"
-          expect(response).to redirect_to("/")
+          expect(response).to redirect_to("/dashboard")
         end
       end
     end
 
     context "when signed in", :as_member do
       describe "GET /users/sign_in" do
-        it "redirects to root" do
+        it "redirects to dashboard by default" do
           get "/users/sign_in"
-          expect(response).to redirect_to("/")
+          expect(response).to redirect_to("/dashboard")
         end
       end
     end


### PR DESCRIPTION
The default landing page is shown when:

* anyone visits /
* anyone signs in or out
* a URL import happens
* Follow/unfollow remote actors
* after model deletion if no return path is set

Site wide setting affects all users (including logged out visitors), but individual user preference will override this if set.

Resolves #4961 