### PR TITLE
Add syntax highlighting for some files using Rouge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -237,3 +237,5 @@ gem "user_agent_parser", "~> 2.21"
 gem "marcel", "~> 1.1"
 
 gem "naturally", "~> 2.3"
+
+gem "rouge", "~> 4.7"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -714,6 +714,7 @@ GEM
     roda (3.98.0)
       rack
     rolify (6.0.1)
+    rouge (4.7.0)
     rspec (3.13.2)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -1042,6 +1043,7 @@ DEPENDENCIES
   redis-namespace
   reverse_markdown (~> 3.0)
   rolify (~> 6.0)
+  rouge (~> 4.7)
   rspec-rails
   rswag (~> 2.17)
   rubocop-capybara
@@ -1342,6 +1344,7 @@ CHECKSUMS
   rexml (3.4.4) sha256=19e0a2c3425dfbf2d4fc1189747bdb2f849b6c5e74180401b15734bc97b5d142
   roda (3.98.0) sha256=c1147d42322305168df91f9a13b7dcadf4b1fe7171fb9598ca444e7618362428
   rolify (6.0.1) sha256=fe45fbf70c4033ccada6f9ccc02b946eeaad044ea5d3e38546ae408d3adeb5b6
+  rouge (4.7.0) sha256=dba5896715c0325c362e895460a6d350803dbf6427454f49a47500f3193ea739
   rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
   rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
   rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836

--- a/app/components/renderers/rouge.rb
+++ b/app/components/renderers/rouge.rb
@@ -1,0 +1,23 @@
+class Components::Renderers::Rouge < Components::Base
+  def self.supports?(file)
+    FileHandlers::Rouge.can_load? file&.mime_type
+  end
+
+  def initialize(file:)
+    @file = file
+  end
+
+  def before_template
+    @formatter = ::Rouge::Formatters::HTMLLineTable.new(::Rouge::Formatters::HTML.new)
+    @lexer = ::Rouge::Lexer.all.find { |it| @file.mime_type.in? it.mimetypes } # rubocop:disable Pundit/UsePolicyScope
+  end
+
+  def view_template
+    style do
+      style { raw(safe(::Rouge::Themes::ThankfulEyes.render(scope: ".rouge"))) } # rubocop:disable Rails/OutputSafety
+    end
+    div class: "rouge" do
+      raw(safe(@formatter.format(@lexer.lex(@file.attachment.read)))) # rubocop:disable Rails/OutputSafety
+    end
+  end
+end

--- a/app/lib/file_handlers/base.rb
+++ b/app/lib/file_handlers/base.rb
@@ -2,6 +2,10 @@ class FileHandlers::Base
   class << self
     extend Memoist
 
+    def priority
+      0
+    end
+
     def environments
       # Derived classes should return an array of places that this handler applies to.
       # Any of:
@@ -38,6 +42,7 @@ class FileHandlers::Base
     def handlers_for(environment:, load_file:)
       FileHandlers.constants
         .map { |it| FileHandlers.const_get(it) }
+        .sort { |a, b| b&.priority <=> a&.priority }
         .select { |it| it.environments.include? environment }
         .select { |it| it.can_load? Mime[load_file.mime_type] }
     end

--- a/app/lib/file_handlers/iframe_tag.rb
+++ b/app/lib/file_handlers/iframe_tag.rb
@@ -4,12 +4,16 @@ class FileHandlers::IframeTag < FileHandlers::Base
       [:browser]
     end
 
+    def priority
+      200
+    end
+
     def component
       Components::Renderers::IframeTag
     end
 
     def input_types
-      SupportedMimeTypes.document_types
+      Mime::EXTENSION_LOOKUP.slice("pdf", "html", "text", "md").values
     end
   end
 end

--- a/app/lib/file_handlers/rouge.rb
+++ b/app/lib/file_handlers/rouge.rb
@@ -1,0 +1,21 @@
+class FileHandlers::Rouge < FileHandlers::Base
+  class << self
+    def environments
+      [:browser]
+    end
+
+    def priority
+      100
+    end
+
+    def component
+      Components::Renderers::Rouge
+    end
+
+    def input_types
+      ::Rouge::Lexer.all.filter_map do |lexer| # rubocop:disable Pundit/UsePolicyScope
+        (Mime::LOOKUP.keys & lexer.mimetypes).map { |it| Mime::LOOKUP[it] }.uniq
+      end.flatten
+    end
+  end
+end


### PR DESCRIPTION
To prove that we can now easily add custom viewers (#4968), this PR adds syntax highlighting with rouge (plus a couple of extra things to support it, like file handler priorities).

You can now add a custom renderer for a file type by simply:

1. adding a FileHandler with the `:browser` environment and the right MIME types
2. implementing a `Components::Renderers` Phlex component to go with it

The FileHandler manages the capability, the component handles the view. The same structure works for generating URLs for client-side apps, and for server-side processing tools as well like f3d and assimp.

@coderofsalvation, I'm not sure if this system is enough for what you need, or if you want fully dynamic configuration of renderers via the web UI.

Currently this is just used on the model file details page, but it should extend to the preview cards and embed views soon.