### PR TITLE
Catch SystemStackError in Assimp metadata extraction (fixes #5166)

### DIFF
--- a/app/uploaders/application_uploader.rb
+++ b/app/uploaders/application_uploader.rb
@@ -109,9 +109,11 @@ class ApplicationUploader < Shrine
           }
         }
       }
-    rescue => ex
+    rescue SystemStackError, StandardError => ex
       # Assimp doesn't raise a specific error for failed load,
-      # just throws a string, so we have to catch all and absorb
+      # just throws a string, so we have to catch all and absorb.
+      # SystemStackError is a direct child of Exception (not StandardError),
+      # so it escapes the default `rescue =>` — see #5166.
       Rails.logger.debug { "Load error: '#{ex.message}'" }
       nil
     end


### PR DESCRIPTION
## Summary

Fixes #5166.

`Assimp.import_file` in the `add_metadata :object` block can raise `SystemStackError` on certain 3MF files (large ones as in the original report, or 3MFs with deeply nested component/material structure — observed with Bambu Studio exports). The existing `rescue => ex` only catches `StandardError`, but `SystemStackError` is a direct child of `Exception`, so it escapes.

Side effect during a library scan via `Scan::Model::AddNewFilesJob`: the exception in the `after_create :attach_existing_file!` callback rolls back the entire transaction, so the `ModelFile` record is never persisted. Sidekiq retries 10 times, every retry crashes the same way, then the job moves to the dead queue. From the user's perspective the file is simply not indexed.

## Repro

1. Have a Manyfold library containing a 3MF that triggers `aiImportFileEx` recursion. Two ways to get one:
   - The 160 MB file from #5166 (map2model.com export)
   - Any Bambu Studio `.3mf` with a lot of `Auxiliaries/` and `Metadata/` entries plus multiple components
2. Trigger a scan that calls `Scan::Model::AddNewFilesJob` for the model.
3. Worker log shows `SystemStackError (stack level too deep)` with the assimp-ruby `import.rb:218` frames.
4. The model ends up with no `ModelFile` records for any of its source files (only `datapackage.json`), regardless of how many retries Sidekiq does.

I reproduced this on Manyfold v0.138.0, Ruby 3.4.8, Sidekiq 8.0.10, assimp-ruby bundler-git `a36639b6`. After the patch the same job processes the model in <1 s and logs `"Load error: '...'"` instead.

## Fix

One-line widening of the rescue clause:

```diff
-    rescue => ex
+    rescue SystemStackError, StandardError => ex
```

Plus a short comment explaining why `rescue => ex` alone is insufficient.

## Trade-off

For files that hit the assimp recursion, the `:object` metadata stays `nil`, so the bounding box is missing in the UI. Everything else (preview generation, downloads, listings) keeps working. Considering that the alternative right now is silently losing the file from the library entirely, this seems clearly better — and the existing `rescue => ex` already implicitly accepts a "best effort" stance for assimp errors.

## Tests

The existing rescue path was already untested, so I'm not adding a new spec here — happy to add one if you have a preferred fixture for an assimp-crashing input. Suggestion: mock `Assimp.import_file` to raise `SystemStackError`, attach a file, expect the record to persist with no `:object` metadata.

## Notes

- Root cause is really in `assimp-ruby` / native libassimp recursing into Ruby callbacks too deeply; fixing that upstream is out of scope here. This PR just keeps Manyfold from losing files because of it.
- Same rescue widening would also help #5719 (segfault / `SIGIOT`) for the cases where the C library raises before crashing the process — not all of them, but some.
