### PR TITLE
Fall back to matching creators and collections by name when parsing datapackages

### DIFF
--- a/app/deserializers/data_package/collection_deserializer.rb
+++ b/app/deserializers/data_package/collection_deserializer.rb
@@ -5,18 +5,24 @@ module DataPackage
       attributes = {
         name: @object["title"],
         caption: @object["caption"],
-        notes: @object["description"]
+        notes: @object["description"],
+        links_attributes: []
       }
       begin
         route_options = Rails.application.routes.recognize_path(@object["path"])
         if route_options[:controller] == "collections"
-          attributes[:id] = Collection.find_param(route_options[:id]).id
+          attributes[:id] = Collection.find_param(route_options[:id])&.id
         end
-      rescue ActionController::RoutingError, ActiveRecord::RecordNotFound
+      rescue ActiveRecord::RecordNotFound
+        # ID wasn't found, match by name instead (at least until we allow collections with the same name)
+        attributes[:id] = Collection.find_by(name: attributes[:name])&.id
+      rescue ActionController::RoutingError
+        # ID wasn't found, match by name instead
+        attributes[:id] = Collection.find_by(name: attributes[:name])&.id
+        attributes[:links_attributes] << {url: @object["path"]} if @object["path"]&.match?(URI::RFC2396_PARSER.make_regexp)
       end
-      attributes[:links_attributes] = @object["links"]&.map { |it| LinkDeserializer.new(it).deserialize } || []
-      attributes[:links_attributes] << {url: @object["path"]} unless attributes.has_key?(:id)
-      attributes.compact
+      attributes[:links_attributes].concat(@object["links"]&.map { |it| LinkDeserializer.new(it).deserialize } || [])
+      attributes.compact_blank
     end
   end
 end

--- a/app/deserializers/data_package/creator_deserializer.rb
+++ b/app/deserializers/data_package/creator_deserializer.rb
@@ -5,18 +5,24 @@ module DataPackage
       attributes = {
         name: @object["title"],
         caption: @object["caption"],
-        notes: @object["description"]
+        notes: @object["description"],
+        links_attributes: []
       }
       begin
         route_options = Rails.application.routes.recognize_path(@object["path"])
         if route_options[:controller] == "creators"
           attributes[:id] = Creator.find_param(route_options[:id]).id
         end
-      rescue ActionController::RoutingError, ActiveRecord::RecordNotFound
+      rescue ActiveRecord::RecordNotFound
+        # ID wasn't found, match by name instead
+        attributes[:id] = Creator.find_by(name: attributes[:name])&.id
+      rescue ActionController::RoutingError
+        # ID wasn't found, match by name instead
+        attributes[:id] = Creator.find_by(name: attributes[:name])&.id
+        attributes[:links_attributes] << {url: @object["path"]} if @object["path"]&.match?(URI::RFC2396_PARSER.make_regexp)
       end
-      attributes[:links_attributes] = @object["links"]&.map { |it| LinkDeserializer.new(it).deserialize } || []
-      attributes[:links_attributes] << {url: @object["path"]} unless attributes.has_key?(:id)
-      attributes.compact
+      attributes[:links_attributes].concat(@object["links"]&.map { |it| LinkDeserializer.new(it).deserialize } || [])
+      attributes.compact_blank
     end
   end
 end

--- a/spec/deserializers/data_package/collection_deserializer_spec.rb
+++ b/spec/deserializers/data_package/collection_deserializer_spec.rb
@@ -48,6 +48,42 @@ RSpec.describe DataPackage::CollectionDeserializer do
       end
     end
 
+    context "with a valid collection linked to this server but with the wrong ID" do
+      let(:collection) { create(:collection) }
+      let(:object) do
+        {
+          "title" => collection.name,
+          "path" => "http://localhost:3214/collections/#{collection.to_param.reverse}"
+        }
+      end
+
+      it "matches collection by name instead" do
+        expect(output[:id]).to eq collection.id
+      end
+
+      it "does not add main detected path as link" do
+        expect(output[:links_attributes]).to be_nil
+      end
+    end
+
+    context "with a valid collection linked to this server but with a bad path" do
+      let(:collection) { create(:collection) }
+      let(:object) do
+        {
+          "title" => collection.name,
+          "path" => "complete rubbish"
+        }
+      end
+
+      it "matches collection by name instead" do
+        expect(output[:id]).to eq collection.id
+      end
+
+      it "does not add main detected path as link" do
+        expect(output[:links_attributes]).to be_nil
+      end
+    end
+
     context "with a valid collection hosted elsewhere" do
       let(:object) do
         {

--- a/spec/deserializers/data_package/creator_deserializer_spec.rb
+++ b/spec/deserializers/data_package/creator_deserializer_spec.rb
@@ -49,6 +49,44 @@ RSpec.describe DataPackage::CreatorDeserializer do
       end
     end
 
+    context "with a valid creator linked to this server but with the wrong ID" do
+      let(:creator) { create(:creator) }
+      let(:object) do
+        {
+          "title" => creator.name,
+          "path" => "http://localhost:3214/creators/#{creator.to_param.reverse}",
+          "roles" => ["creator"]
+        }
+      end
+
+      it "matches creator on name instead of path" do
+        expect(output[:id]).to eq creator.id
+      end
+
+      it "does not add main detected path as link" do
+        expect(output[:links_attributes]).to be_nil
+      end
+    end
+
+    context "with a valid creator linked to this server but with a bad path" do
+      let(:creator) { create(:creator) }
+      let(:object) do
+        {
+          "title" => creator.name,
+          "path" => "complete rubbish",
+          "roles" => ["creator"]
+        }
+      end
+
+      it "matches creator on name instead of path" do
+        expect(output[:id]).to eq creator.id
+      end
+
+      it "does not add main detected path as link" do
+        expect(output[:links_attributes]).to be_nil
+      end
+    end
+
     context "with a valid creator hosted elsewhere" do
       let(:object) do
         {

--- a/spec/deserializers/data_package/model_deserializer_spec.rb
+++ b/spec/deserializers/data_package/model_deserializer_spec.rb
@@ -105,17 +105,9 @@ RSpec.describe DataPackage::ModelDeserializer do
       expect(output.dig(:creator, :id)).to eq creator.id
     end
 
-    it "parses creator link if creator doesn't exist" do
-      expect(output.dig(:creator, :links_attributes, 0, :url)).to eq "http://localhost:3214/creators/bruce-wayne"
-    end
-
     it "parses collection ID if collection exists" do
       collection = create(:collection, name: "Wonderful Toys", public_id: "abc123")
       expect(output.dig(:collections, 0, :id)).to eq collection.id
-    end
-
-    it "parses collection link if collection doesn't exist" do
-      expect(output.dig(:collections, 0, :links_attributes, 0, :url)).to eq "http://localhost:3214/collections/abc123"
     end
 
     it "parses sensitive flag" do


### PR DESCRIPTION
If a collection/creator was removed but the datapackage still references it, we get an error at the moment when parsing data. If there's a name match, use that, if not then create a new one.