### PR TITLE
Avoid IOErrors by reloading attachment data after detecting inefficient file formats

### DIFF
--- a/app/jobs/analysis/analyse_model_file_job.rb
+++ b/app/jobs/analysis/analyse_model_file_job.rb
@@ -73,9 +73,11 @@ class Analysis::AnalyseModelFileJob < ApplicationJob
   end
 
   def inefficiency_problem(file)
-    return "ASCII STL" if (file.extension === "stl") && (file.head(6) === "solid ")
+    head = file.head(16)
+    file.attachment_attacher.reload
+    return "ASCII STL" if (file.extension === "stl") && (head.slice(0, 6) === "solid ")
     return "Wavefront OBJ" if file.extension === "obj"
-    return "ASCII PLY" if (file.extension === "ply") && (file.head(16) === "ply\rformat ascii")
+    return "ASCII PLY" if (file.extension === "ply") && (head === "ply\rformat ascii")
     nil
   end
 

--- a/spec/jobs/analysis/analyse_model_file_job_spec.rb
+++ b/spec/jobs/analysis/analyse_model_file_job_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Analysis::AnalyseModelFileJob do
 
     it "detects ASCII STL files and creates a Problem record" do # rubocop:todo RSpec/ExampleLength, RSpec/MultipleExpectations
       allow(file).to receive_messages(extension: "stl", size: 1234)
-      allow(file).to receive(:head).with(6).once.and_return("solid ")
+      allow(file).to receive(:head).with(16).once.and_return("solid xxxxxxxxxx")
       expect { described_class.perform_now file.id }.to change(Problem, :count).from(0).to(1)
       expect(Problem.first.category).to eq "inefficient"
       expect(Problem.first.note).to eq "ASCII STL"


### PR DESCRIPTION
This was breaking model analysis for STL and PLY files