### PR TITLE
Update F3D to enable STEP file rendering

### DIFF
--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -19,12 +19,11 @@ RUN apk add --no-cache \
   imagemagick-jpeg \
   imagemagick-webp \
   imagemagick-heic \
-  imath \
   assimp-dev \
   mesa-egl
 
 # Install latest VTK and OpenCascade from Alpine edge
-RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community vtk opencascade
+RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community vtk opencascade imath alembic-libs  openexr-libopenexr
 
 # Scripts for cross-platform architecture detection
 COPY --from=tonistiigi/xx / /

--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -22,14 +22,13 @@ RUN apk add --no-cache \
   assimp-dev \
   mesa-egl
 
-# Install latest VTK from Alpine edge
-RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
-  vtk
+# Install latest VTK and OpenCascade from Alpine edge
+RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community vtk opencascade
 
 # Scripts for cross-platform architecture detection
 COPY --from=tonistiigi/xx / /
 
 # Install custom f3d package
-RUN wget "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.5.0-r0/f3d-3.5.0-r0.`xx-info alpine-arch`.apk" -O /tmp/f3d.apk
+RUN wget "https://github.com/manyfold3d/f3d-alpine/releases/download/v3.5.0-r0-1/f3d-3.5.0-r0.`xx-info alpine-arch`.apk" -O /tmp/f3d.apk
 RUN apk add --no-cache --allow-untrusted /tmp/f3d.apk
 RUN rm /tmp/f3d.apk

--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -4,26 +4,31 @@ FROM ruby:3.4.9-alpine3.23 AS base
 WORKDIR /usr/src/app
 
 RUN apk add --no-cache \
-  tzdata
+  tzdata=2026b-r0
 
 RUN gem install bundler -v 2.5.23
 RUN bundle config set --local deployment 'true'
 RUN bundle config set --local without 'development test'
 
 RUN apk add --no-cache \
-  file \
-  s6-overlay \
-  gcompat \
-  jemalloc \
-  imagemagick \
-  imagemagick-jpeg \
-  imagemagick-webp \
-  imagemagick-heic \
-  assimp-dev \
-  mesa-egl
+  file=5.46-r2 \
+  s6-overlay=3.2.0.3-r0 \
+  gcompat=1.1.0-r4 \
+  jemalloc=5.3.0-r6 \
+  imagemagick=7.1.2.24-r0 \
+  imagemagick-jpeg=7.1.2.24-r0 \
+  imagemagick-webp=7.1.2.24-r0 \
+  imagemagick-heic=7.1.2.24-r0 \
+  assimp-dev=6.0.4-r0 \
+  mesa-egl=25.2.7-r1
 
 # Install latest VTK and OpenCascade from Alpine edge
-RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community vtk opencascade imath alembic-libs  openexr-libopenexr
+RUN apk add --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/community \
+  vtk=9.5.2-r2 \
+  opencascade=7.9.3-r2 \
+  imath=3.2.2-r1 \
+  alembic-libs=1.8.11-r0 \
+  openexr-libopenexr=3.4.11-r0
 
 # Scripts for cross-platform architecture detection
 COPY --from=tonistiigi/xx / /

--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -19,6 +19,7 @@ RUN apk add --no-cache \
   imagemagick-jpeg \
   imagemagick-webp \
   imagemagick-heic \
+  imath \
   assimp-dev \
   mesa-egl
 


### PR DESCRIPTION
This *should* automatically give us STEP, IGES, and BREP static rendering.

```
IGES          occt       Initial Graphics Exchange Specification    NO                 igs       model/iges            
                                                                                       iges                            
STEP          occt       STEP ISO 10303                             NO                 stp       application/vnd.step  
                                                                                       step                            
                                                                                       stpnc                           
                                                                                       p21                             
                                                                                       210                             
BREP          occt       Open CASCADE BRep                          NO                 brep      application/vnd.brep  
XBF           occt       Open CASCADE XBF                           NO                 xbf       application/vnd.xbf   
```

XBF needs adding to the indexer.

Resolves #2571 