### PR TITLE
Fix OBJ files rendering in a dark material

### DIFF
--- a/app/uploaders/application_uploader.rb
+++ b/app/uploaders/application_uploader.rb
@@ -135,6 +135,7 @@ class ApplicationUploader < Shrine
           "up" => up,
           "camera-direction" => CAMERA_OPTS[up]
         )
+        options["color"] = "1,1,1" if context[:record].mime_type.to_s == "model/obj"
         if (plane = context[:record]&.planar?)
           options["grid"] = "0"
           options["up"] = {


### PR DESCRIPTION
Resolves #6255 

This may be a workaround for a bug in VTK, not currently sure. We might be able to get rid of it later.