### PR TITLE
Add support for a whole load of new file types supported by F3D

### DIFF
--- a/app/lib/supported_mime_types.rb
+++ b/app/lib/supported_mime_types.rb
@@ -111,7 +111,21 @@ module SupportedMimeTypes
         "application/x-amf",
         "application/x-ldraw",
         "application/vnd.flock+json",
-        "application/vnd.dragonfruit.voxl"
+        "application/vnd.dragonfruit.voxl",
+        "application/dicom",
+        "application/gml+xml",
+        "application/vnd.pts",
+        "application/vnd.vtk",
+        "application/vnd.vtp",
+        "application/vnd.off",
+        "application/vnd.x",
+        "application/vnd.xbf",
+        "application/vnd.mdl",
+        "application/vnd.ifc",
+        "application/vnd.mhd",
+        "application/vnd.nrrd",
+        "application/vnd.splat",
+        "application/vnd.spz"
       ]
       type.to_s.start_with?("model/") || extras.include?(type.to_s)
     end

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -41,6 +41,21 @@ Mime::Type.register "model/x-hfp", :hfp
 Mime::Type.register "model/x-speedtree", :speedtree, [], ["spm"]
 Mime::Type.register "model/x3d", :x3d, ["model/x3d+xml", "model/x3d-vrml", "model/x3d+fastinfoset"]
 
+Mime::Type.register "application/dicom", :dcm, [], [] # DICOM
+Mime::Type.register "application/gml+xml", :gml, [], [] # CityGML
+Mime::Type.register "application/vnd.pts", :pts, [], [] # Point Cloud
+Mime::Type.register "application/vnd.vtk", :vtk, [], [] # VTK Legacy
+Mime::Type.register "application/vnd.vtp", :vtp, ["application/vnd.vtu", "application/vnd.vti", "application/vnd.vtr", "application/vnd.vts"], ["vtu", "vti", "vtr", "vts"] # VTK XML
+Mime::Type.register "application/vnd.off", :off, [], [] # Object File Format
+Mime::Type.register "application/vnd.x", :x, [], [] # DirectX
+Mime::Type.register "application/vnd.xbf", :xbf, [], [] # Open CASCADE Technology XBF format
+Mime::Type.register "application/vnd.mdl", :mdl, [], [] # QuakeMDL
+Mime::Type.register "application/vnd.ifc", :ifc, [], [] # Industry Foundation Classes
+Mime::Type.register "application/vnd.mhd", :mha, [], ["mhd"] # MetaHeader MetaIO
+Mime::Type.register "application/vnd.nrrd", :nrrd, [], ["nhdr"] # NRRD ("nearly raw raster data")
+Mime::Type.register "application/vnd.splat", :splat, [], [] # 3D Gaussian Splatting
+Mime::Type.register "application/vnd.spz", :spz, [], [] # Compressed 3D Gaussian Splatting
+
 # Slicer formats
 Mime::Type.register "text/x-gcode", :gcode, [], ["bgcode"]
 Mime::Type.register "model/x-lychee", :lychee, [], ["lys", "lyt"]


### PR DESCRIPTION
DICOM, CityGML, Point clouds, VTK, OFF, DirectX, XBF, Quake MDL, IFC, MetaIO, NRRD, and Splat/Spz for 3D Gaussian Splatting. Most of these should get previews, and some will even get an interactive view once #6325 is done.