### PR TITLE
Add Moonraker API (Klipper) print service

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -237,3 +237,5 @@ gem "marcel", "~> 1.2"
 gem "naturally", "~> 2.3"
 
 gem "rouge", "~> 5.0"
+
+gem "faraday-multipart", "~> 1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -276,6 +276,8 @@ GEM
       logger
     faraday-follow_redirects (0.5.0)
       faraday (>= 1, < 3)
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
     faraday-net_http (3.4.2)
       net-http (~> 0.5)
     fasp_client (0.6.0)
@@ -511,6 +513,7 @@ GEM
       mittsu (~> 0.4)
     msgpack (1.8.1)
     multi_json (1.21.1)
+    multipart-post (2.4.1)
     mutex_m (0.3.0)
     mysql2 (0.5.6)
     nanoid (2.0.0)
@@ -1018,6 +1021,7 @@ DEPENDENCIES
   erb_lint (~> 0.9)
   factory_bot
   faker (~> 3.8)
+  faraday-multipart (~> 1.2)
   fasp_client (~> 0.6)
   federails!
   federails-moderation (~> 0.4)
@@ -1204,6 +1208,7 @@ CHECKSUMS
   faker (3.8.0) sha256=c147b308df73a90f27a4fc84f18d4c22ef0ad9c2a64b2b61c86fd0ca71753efc
   faraday (2.14.2) sha256=73ccb9994a9e8648f010e32eca2ae82e41c57860aa10932cda29418b9e0223ad
   faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
+  faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
   fasp_client (0.6.0) sha256=c1fba106ec3608bc9e9d83b9384645e5339ad637169b696d28a1823164352775
   federails (0.8.0)
@@ -1294,6 +1299,7 @@ CHECKSUMS
   mittsu-mesh_analysis (0.1.0) sha256=13550c35e56bcd10cbe8284fe1b3cf3a43f7bb7133f47995e0c8a8b5d2a9cd50
   msgpack (1.8.1) sha256=3fef787cd3965fd119c08a22724a56a93ca25008c3421fc15039f603a8b7c86c
   multi_json (1.21.1) sha256=e6126a31808e3b4d19f483c775ceac34df190dffa62adfb63a165ee14ba68080
+  multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
   mutex_m (0.3.0) sha256=cfcb04ac16b69c4813777022fdceda24e9f798e48092a2b817eb4c0a782b0751
   mysql2 (0.5.6) sha256=70f447d45d6b3cc16b00f7dd30366f708a81b4093a35d026ff7135d778d8da33
   nanoid (2.0.0) sha256=78a5c93c1595981fb37712a166d7ea1ef15a679553e5d3c72337f231febd8bfc

--- a/app/services/moonraker_print_service.rb
+++ b/app/services/moonraker_print_service.rb
@@ -1,0 +1,28 @@
+require 'faraday'
+require 'faraday/multipart'
+
+class MoonrakerPrintService
+
+  def initialize(server_root:)
+    @server_root = server_root
+  end
+
+  def upload(file:, print: true)
+    payload = {}
+    conn = Faraday.new do |builder|
+      builder.request :multipart
+      payload[:print] = print ? "true" : "false"
+      payload[:file] = Faraday::Multipart::FilePart.new(
+        file.attachment.open,
+        'application/octet-stream',
+        file.filename
+      )
+    end
+    conn.post(uri, payload)
+  end
+
+  def uri
+    "#{@server_root}/server/files/upload"
+  end
+
+end

--- a/app/services/print/moonraker_service.rb
+++ b/app/services/print/moonraker_service.rb
@@ -6,18 +6,27 @@ class Print::MoonrakerService
     @server_root = server_root
   end
 
-  def upload(file:, print: true)
-    payload = {}
-    conn = Faraday.new do |builder|
-      builder.request :multipart
-      payload[:print] = print ? "true" : "false"
-      payload[:file] = Faraday::Multipart::FilePart.new(
+  def upload(file:, start_print: true)
+    connection.post(uri, payload(file: file, start_print: start_print))
+  end
+
+  private
+
+  def connection
+    Faraday.new do
+      it.request :multipart
+    end
+  end
+
+  def payload(file:, start_print: true)
+    {
+      print: start_print ? "true" : "false",
+      file: Faraday::Multipart::FilePart.new(
         file.attachment.open,
         file.mime_type.to_s,
         file.filename
       )
-    end
-    conn.post(uri, payload)
+    }
   end
 
   def uri

--- a/app/services/print/moonraker_service.rb
+++ b/app/services/print/moonraker_service.rb
@@ -8,6 +8,10 @@ class Print::MoonrakerService
   def initialize(print_host:)
     @print_host = print_host
   end
+
+  def ok?
+    response = connection.get(info_uri)
+    response.success?
   end
 
   def upload(file:, start_print: true)
@@ -32,6 +36,10 @@ class Print::MoonrakerService
         file.filename
       )
     }
+  end
+
+  def info_uri
+    "#{@print_host.endpoint}/server/info"
   end
 
   def upload_uri

--- a/app/services/print/moonraker_service.rb
+++ b/app/services/print/moonraker_service.rb
@@ -12,6 +12,8 @@ class Print::MoonrakerService
   def ok?
     response = connection.get(info_uri)
     response.success?
+  rescue
+    false
   end
 
   def upload(file:, start_print: true)

--- a/app/services/print/moonraker_service.rb
+++ b/app/services/print/moonraker_service.rb
@@ -1,8 +1,7 @@
-require 'faraday'
-require 'faraday/multipart'
+require "faraday"
+require "faraday/multipart"
 
-class MoonrakerPrintService
-
+class Print::MoonrakerService
   def initialize(server_root:)
     @server_root = server_root
   end
@@ -14,7 +13,7 @@ class MoonrakerPrintService
       payload[:print] = print ? "true" : "false"
       payload[:file] = Faraday::Multipart::FilePart.new(
         file.attachment.open,
-        'application/octet-stream',
+        file.mime_type.to_s,
         file.filename
       )
     end
@@ -24,5 +23,4 @@ class MoonrakerPrintService
   def uri
     "#{@server_root}/server/files/upload"
   end
-
 end

--- a/app/services/print/moonraker_service.rb
+++ b/app/services/print/moonraker_service.rb
@@ -5,13 +5,14 @@ class Print::MoonrakerService
   # i18n-tasks-use t("print_hosts.protocols.moonraker")
   PROTOCOL = "moonraker".freeze
 
-  def initialize(server_root:)
-    @server_root = server_root
+  def initialize(print_host:)
+    @print_host = print_host
+  end
   end
 
   def upload(file:, start_print: true)
     raise ArgumentError unless file.mime_type.to_sym == :gcode
-    connection.post(uri, payload(file: file, start_print: start_print))
+    connection.post(upload_uri, payload(file: file, start_print: start_print))
   end
 
   private
@@ -33,7 +34,7 @@ class Print::MoonrakerService
     }
   end
 
-  def uri
-    "#{@server_root}/server/files/upload"
+  def upload_uri
+    "#{@print_host.endpoint}/server/files/upload"
   end
 end

--- a/app/services/print/moonraker_service.rb
+++ b/app/services/print/moonraker_service.rb
@@ -12,7 +12,7 @@ class Print::MoonrakerService
   end
 
   def ok?
-    response = connection.get(info_uri)
+    response = connection.get(info_uri, {}, headers)
     response.success?
   rescue
     false
@@ -20,7 +20,7 @@ class Print::MoonrakerService
 
   def upload(file:, start_print: true)
     raise ArgumentError unless file.mime_type.to_sym == :gcode
-    connection.post(upload_uri, payload(file: file, start_print: start_print))
+    connection.post(upload_uri, payload(file: file, start_print: start_print), headers)
   end
 
   private
@@ -48,5 +48,11 @@ class Print::MoonrakerService
 
   def upload_uri
     "#{@print_host.endpoint}/server/files/upload"
+  end
+
+  def headers
+    {
+      "X-Api-Key" => @print_host.credentials
+    }.compact_blank
   end
 end

--- a/app/services/print/moonraker_service.rb
+++ b/app/services/print/moonraker_service.rb
@@ -5,6 +5,8 @@ class Print::MoonrakerService
   # i18n-tasks-use t("print_hosts.protocols.moonraker")
   PROTOCOL = "moonraker".freeze
 
+  INPUT_TYPES = [Mime[:gcode]].freeze
+
   def initialize(print_host:)
     @print_host = print_host
   end

--- a/app/services/print/moonraker_service.rb
+++ b/app/services/print/moonraker_service.rb
@@ -7,6 +7,7 @@ class Print::MoonrakerService
   end
 
   def upload(file:, start_print: true)
+    raise ArgumentError unless file.mime_type.to_sym == :gcode
     connection.post(uri, payload(file: file, start_print: start_print))
   end
 

--- a/app/services/print/moonraker_service.rb
+++ b/app/services/print/moonraker_service.rb
@@ -2,6 +2,9 @@ require "faraday"
 require "faraday/multipart"
 
 class Print::MoonrakerService
+  # i18n-tasks-use t("print_hosts.protocols.moonraker")
+  PROTOCOL = "moonraker".freeze
+
   def initialize(server_root:)
     @server_root = server_root
   end


### PR DESCRIPTION
Experimental service to print gcode files to Moonraker printers. But it works! Depends on some UI and configuration work first though before I merge this, at the moment you can only do it on the console: 

```ruby
f = ModelFile.where("filename LIKE '%gcode'").first
s = Print::MoonrakerService.new(server_root: "http://{your-printer}.local")
s.upload(file: f, start_print: true)
```

But, that *does* work 😁 

EDIT:

Done now! Resolves #6434 
