### PR TITLE
Fix page errors caused by using default parameter in nested blocks

### DIFF
--- a/app/components/lists_card.rb
+++ b/app/components/lists_card.rb
@@ -76,11 +76,11 @@ class Components::ListsCard < Components::Base
   def on_lists
     span { t("components.lists_card.on_lists") }
     table class: "table table-striped" do
-      @on_lists.map do
+      @on_lists.map do |list|
         tr do
-          td { link_to it.name, list_path(it) }
+          td { link_to list.name, list_path(list) }
           td do
-            link_to remove_path(list: it), method: :patch, class: "link-danger link-underline-opacity-0" do
+            link_to remove_path(list: list), method: :patch, class: "link-danger link-underline-opacity-0" do
               Icon(icon: "trash", label: t("components.lists_card.remove"))
             end
           end

--- a/app/views/robots/sitemap.xml.builder
+++ b/app/views/robots/sitemap.xml.builder
@@ -5,22 +5,22 @@ xml.urlset "xmlns:xsi": "http://www.w3.org/2001/XMLSchema-instance",
   xml.url { xml.loc creators_url }
   xml.url { xml.loc collections_url }
   xml.url { xml.loc models_url }
-  @creators.each do
+  @creators.each do |creator|
     xml.url do
-      xml.loc creator_url(it)
-      xml.lastmod it.updated_at.iso8601
+      xml.loc creator_url(creator)
+      xml.lastmod creator.updated_at.iso8601
     end
   end
-  @collections.each do
+  @collections.each do |collection|
     xml.url do
-      xml.loc collection_url(it)
-      xml.lastmod it.updated_at.iso8601
+      xml.loc collection_url(collection)
+      xml.lastmod collection.updated_at.iso8601
     end
   end
-  @models.each do
+  @models.each do |model|
     xml.url do
-      xml.loc model_url(it)
-      xml.lastmod it.updated_at.iso8601
+      xml.loc model_url(model)
+      xml.lastmod model.updated_at.iso8601
     end
   end
 end


### PR DESCRIPTION
Resolves #6396.

Caused by a couple of situations where the default block parameter (it) was being used inside *another* block. Removing the explicit parameters in #6362 meant that the implicit one was used from the *inner* blocks, not outer. I've checked that PR for any instances where it could have happened, should be OK now.