### PR TITLE
Support sending gcode or SL1 to PrusaLink machines

### DIFF
--- a/app/services/print/prusa_link_service.rb
+++ b/app/services/print/prusa_link_service.rb
@@ -1,0 +1,67 @@
+require "faraday"
+require "faraday/multipart"
+
+class Print::PrusaLinkService
+  # i18n-tasks-use t("print_hosts.protocols.octoprint")
+  PROTOCOL = "prusalink".freeze
+
+  INPUT_TYPES = [Mime[:gcode]].freeze
+
+  def initialize(print_host:)
+    @print_host = print_host
+  end
+
+  def ok?
+    response = connection.get(info_uri, {}, headers)
+    Rails.logger.warn(response.inspect) unless response.success?
+    response.success?
+  rescue => ex
+    Rails.logger.warn(ex.message)
+    false
+  end
+
+  def upload(file:, start_print: true)
+    raise ArgumentError unless file.mime_type.to_sym == :gcode
+    raise PrintHost::NotReady unless ok?
+    response = v1_upload(file: file)
+    Rails.logger.warn(response.inspect) unless response.success?
+    response.success?
+  end
+
+  private
+
+  def connection
+    Faraday.new do
+      it.request :multipart
+    end
+  end
+
+  def info_uri
+    "#{@print_host.endpoint}/api/printer"
+  end
+
+  def v1_upload(file:)
+    connection.post(
+      "#{@print_host.endpoint}/api/files/local",
+      v1_payload(file: file),
+      headers
+    )
+  end
+
+  def v1_payload(file:, start_print: true)
+    {
+      select: start_print ? "true" : "false",
+      file: Faraday::Multipart::FilePart.new(
+        file.attachment.open,
+        file.mime_type.to_s,
+        file.filename
+      )
+    }
+  end
+
+  def headers
+    {
+      "X-Api-Key" => @print_host.credentials
+    }.compact_blank
+  end
+end

--- a/app/services/print/prusa_link_service.rb
+++ b/app/services/print/prusa_link_service.rb
@@ -5,7 +5,7 @@ class Print::PrusaLinkService
   # i18n-tasks-use t("print_hosts.protocols.octoprint")
   PROTOCOL = "prusalink".freeze
 
-  INPUT_TYPES = [Mime[:gcode]].freeze
+  INPUT_TYPES = [Mime[:gcode], Mime[:sl1]].freeze
 
   def initialize(print_host:)
     @print_host = print_host
@@ -21,7 +21,7 @@ class Print::PrusaLinkService
   end
 
   def upload(file:, start_print: true)
-    raise ArgumentError unless file.mime_type.to_sym == :gcode
+    raise ArgumentError unless file.mime_type.in? INPUT_TYPES
     raise PrintHost::NotReady unless ok?
     response = v1_upload(file: file)
     Rails.logger.warn(response.inspect) unless response.success?

--- a/spec/cassettes/Print_PrusaLinkService/with_bad_API_key/doesn_t_upload_file.yml
+++ b/spec/cassettes/Print_PrusaLinkService/with_bad_API_key/doesn_t_upload_file.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<PRUSALINK_ENDPOINT>/api/printer"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Manyfold/unknown
+      X-Api-Key:
+      - bad_api_key
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      X-Powered-By:
+      - Express
+      Www-Authenticate:
+      - ApiKey realm="401"
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '254'
+      Etag:
+      - W/"fe-5B4WR9YlBO102M9uQHh/K1b+qKU"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 19 Jun 2026 10:14:17 GMT
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=5
+    body:
+      encoding: UTF-8
+      string: '{"code":"#10405","title":"INVALID API KEY","message":"Please turn on
+        the HTTP digest (which is the recommended security option) or correct the
+        API key. You can find it in Settings > Network > Login credentials.","url":"https://help.prusa3d.com/en/10405"}'
+  recorded_at: Fri, 19 Jun 2026 10:14:17 GMT
+recorded_with: VCR 6.4.0

--- a/spec/cassettes/Print_PrusaLinkService/with_bad_API_key/flags_connection_error.yml
+++ b/spec/cassettes/Print_PrusaLinkService/with_bad_API_key/flags_connection_error.yml
@@ -1,0 +1,47 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<PRUSALINK_ENDPOINT>/api/printer"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Manyfold/unknown
+      X-Api-Key:
+      - bad_api_key
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      X-Powered-By:
+      - Express
+      Www-Authenticate:
+      - ApiKey realm="401"
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '254'
+      Etag:
+      - W/"fe-5B4WR9YlBO102M9uQHh/K1b+qKU"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 19 Jun 2026 10:14:16 GMT
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=5
+    body:
+      encoding: UTF-8
+      string: '{"code":"#10405","title":"INVALID API KEY","message":"Please turn on
+        the HTTP digest (which is the recommended security option) or correct the
+        API key. You can find it in Settings > Network > Login credentials.","url":"https://help.prusa3d.com/en/10405"}'
+  recorded_at: Fri, 19 Jun 2026 10:14:16 GMT
+recorded_with: VCR 6.4.0

--- a/spec/cassettes/Print_PrusaLinkService/with_good_connection_details/uploads_a_file.yml
+++ b/spec/cassettes/Print_PrusaLinkService/with_good_connection_details/uploads_a_file.yml
@@ -1,0 +1,90 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<PRUSALINK_ENDPOINT>/api/printer"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Manyfold/unknown
+      X-Api-Key:
+      - "<PRUSALINK_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Express
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '668'
+      Etag:
+      - W/"29c-nT9PeheX0pALRDhE3c+qhvfF4kM"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 19 Jun 2026 10:14:17 GMT
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=5
+    body:
+      encoding: UTF-8
+      string: '{"telemetry":{"tempCpu":59.56909349283287,"tempUvLed":0,"tempAmbient":16.62789234121469,"fanUvLed":0,"fanBlower":0,"fanRear":0,"coverClosed":true},"temperature":{"tool0":{"actual":3.0866652537920536,"target":0,"offset":0},"bed":{"actual":59.56909349283287,"target":0,"offset":0},"chamber":{"actual":16.62789234121469,"target":0,"offset":0}},"sd":{"ready":true},"state":{"text":"Operational","flags":{"operational":true,"paused":false,"printing":false,"cancelling":false,"pausing":false,"sdReady":true,"error":false,"ready":true,"closedOrError":false,"checked":false}},"storage":{"local":{"free_space":123,"total_space":256},"usb":{"free_space":256,"total_space":512}}}'
+  recorded_at: Fri, 19 Jun 2026 10:14:17 GMT
+- request:
+    method: post
+    uri: "<PRUSALINK_ENDPOINT>/api/files/local"
+    body:
+      encoding: UTF-8
+      string: "-------------RubyMultipartPost-59a18a9516b78de31acbe3ecb9979fb0\r\nContent-Disposition:
+        form-data; name=\"select\"\r\n\r\ntrue\r\n-------------RubyMultipartPost-59a18a9516b78de31acbe3ecb9979fb0\r\nContent-Disposition:
+        form-data; name=\"file\"; filename=\"test.gcode\"\r\nContent-Length: 0\r\nContent-Type:
+        text/x-gcode\r\nContent-Transfer-Encoding: binary\r\n\r\n\r\n-------------RubyMultipartPost-59a18a9516b78de31acbe3ecb9979fb0--\r\n"
+    headers:
+      User-Agent:
+      - Manyfold/unknown
+      X-Api-Key:
+      - "<PRUSALINK_API_KEY>"
+      Content-Type:
+      - multipart/form-data; boundary=-----------RubyMultipartPost-59a18a9516b78de31acbe3ecb9979fb0
+      Content-Length:
+      - '406'
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 201
+      message: Created
+    headers:
+      X-Powered-By:
+      - Express
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '207'
+      Etag:
+      - W/"cf-CM7Y59Vn4gyhQV2HRxo00O1YoKg"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 19 Jun 2026 10:14:17 GMT
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=5
+    body:
+      encoding: UTF-8
+      string: '{"files":{"local":{"name":"test.gcode","origin":"local","refs":{"resource":"<PRUSALINK_ENDPOINT>/api/files/local/test.gcode","download":"<PRUSALINK_ENDPOINT>/api/downloads/local/test.gcode"}}},"done":true}'
+  recorded_at: Fri, 19 Jun 2026 10:14:17 GMT
+recorded_with: VCR 6.4.0

--- a/spec/cassettes/Print_PrusaLinkService/with_good_connection_details/verifies_connection.yml
+++ b/spec/cassettes/Print_PrusaLinkService/with_good_connection_details/verifies_connection.yml
@@ -1,0 +1,43 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: "<PRUSALINK_ENDPOINT>/api/printer"
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Manyfold/unknown
+      X-Api-Key:
+      - "<PRUSALINK_API_KEY>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      X-Powered-By:
+      - Express
+      Content-Type:
+      - application/json; charset=utf-8
+      Content-Length:
+      - '664'
+      Etag:
+      - W/"298-6+4fvypG/uxKzf+x4Qv3VEzFicg"
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 19 Jun 2026 10:14:17 GMT
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - timeout=5
+    body:
+      encoding: UTF-8
+      string: '{"telemetry":{"tempCpu":97.2173389200903,"tempUvLed":0,"tempAmbient":78.06711891305206,"fanUvLed":0,"fanBlower":0,"fanRear":0,"coverClosed":true},"temperature":{"tool0":{"actual":66.4630782228566,"target":0,"offset":0},"bed":{"actual":97.2173389200903,"target":0,"offset":0},"chamber":{"actual":78.06711891305206,"target":0,"offset":0}},"sd":{"ready":true},"state":{"text":"Operational","flags":{"operational":true,"paused":false,"printing":false,"cancelling":false,"pausing":false,"sdReady":true,"error":false,"ready":true,"closedOrError":false,"checked":false}},"storage":{"local":{"free_space":123,"total_space":256},"usb":{"free_space":256,"total_space":512}}}'
+  recorded_at: Fri, 19 Jun 2026 10:14:17 GMT
+recorded_with: VCR 6.4.0

--- a/spec/services/print/prusa_link_service_spec.rb
+++ b/spec/services/print/prusa_link_service_spec.rb
@@ -1,0 +1,58 @@
+require "rails_helper"
+
+RSpec.describe Print::PrusaLinkService, :after_first_run, :vcr do
+  subject(:service) {
+    described_class.new(
+    print_host: create(:print_host,
+      protocol: "prusalink",
+      name: "PrusaLink",
+      endpoint: endpoint,
+      credentials: credentials)
+  )
+  }
+
+  let(:endpoint) { ENV.fetch("PRUSALINK_ENDPOINT", "http://prusalink.example.com") }
+  let(:credentials) { ENV.fetch("PRUSALINK_API_KEY", "fake_api_key") }
+  let(:file) { create(:model_file, filename: "test.gcode") }
+
+  before :all do # rubocop:disable RSpec/BeforeAfterAll
+    VCR.configure do |c|
+      c.filter_sensitive_data("<PRUSALINK_API_KEY>") { credentials }
+      c.filter_sensitive_data("<PRUSALINK_ENDPOINT>") { endpoint }
+    end
+  end
+
+  context "with good connection details" do
+    it "verifies connection" do
+      expect(service.ok?).to be true
+    end
+
+    it "uploads a file" do
+      expect(service.upload(file: file, start_print: true)).to be true
+    end
+  end
+
+  context "with bad API key" do
+    let(:credentials) { "bad_api_key" }
+
+    it "flags connection error" do
+      expect(service.ok?).to be false
+    end
+
+    it "doesn't upload file" do
+      expect { service.upload(file: file, start_print: true) }.to raise_error(PrintHost::NotReady)
+    end
+  end
+
+  context "with bad endpoint" do
+    let(:endpoint) { "not-a-url" }
+
+    it "flags connection error" do
+      expect(service.ok?).to be false
+    end
+
+    it "doesn't upload file" do
+      expect { service.upload(file: file, start_print: true) }.to raise_error(PrintHost::NotReady)
+    end
+  end
+end


### PR DESCRIPTION
Resolves #6435.

This PR is a simple example of how to implement a new print API service. If you want to implement another one, follow these steps:

1. Copy the spec file and change the various names at the top of the file - most of the actual tests shouldn't need changing, at least at first.
2. Put endpoint and credentials in `.env.test.local` so you can talk to the API
3. If your API is running on localhost, temporarily comment out `config.ignore_localhost = true` in `spec/support/vcr.rb` but don't commit it
4. Copy a print service in `app/services/print` and implement the changes for your new service
5. API interactions will be recorded by vcr so it can be tested without the real API. Remove the `:vcr` metadata tag at the start of your test file to disable this while you're developing, but put it back when you're done to record the test interactions. Make sure the filtering has worked and that the credentials you've used for development aren't in the cassettes.
6. Run `bundle exec i18n-tasks add-missing --nil-value`. That should add the new translation key for your service name. Set the name in `en.yml` and leave the rest blank. I actually forgot to do this in this PR because I forgot to change the `i18n-tasks-use` line; see https://github.com/manyfold3d/manyfold/pull/6452 for the changes to expect.
8. Once it's all working, remove the credentials set in `.env.test.local` and make sure the tests pass against the cassettes.
9. Run `bundle exec rubocop -a` to autofix any style differences.
10. Open a PR, and have a cup of tea to celebrate 🎉 