### PR TITLE
Add "printer" role to allow users access to start prints

### DIFF
--- a/app/helpers/model_files_helper.rb
+++ b/app/helpers/model_files_helper.rb
@@ -2,7 +2,7 @@ module ModelFilesHelper
   prepend MemoWise
 
   def can_print?(file)
-    print_hosts_for(file.mime_type).any?
+    policy(file).print? && print_hosts_for(file.mime_type).any?
   end
 
   def print_hosts_for(mime_type)

--- a/app/models/role.rb
+++ b/app/models/role.rb
@@ -7,7 +7,8 @@ class Role < ApplicationRecord
     :administrator,   # Can do everything
     :moderator,       # Can edit any models
     :contributor,     # Can upload models and edit their own
-    :member           # Can view models; read only access
+    :member,          # Can view models; read only access
+    :printer          # Can send models to configured printers
   ]
 
   has_many :users, through: :users_roles

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -122,7 +122,7 @@ class User < ApplicationRecord
   end
 
   def is_printer?
-    has_any_role_of? :printer
+    has_any_role_of? :administrator, :printer
   end
 
   def is_administrator?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -121,6 +121,10 @@ class User < ApplicationRecord
     listed?(file, :printed)
   end
 
+  def is_printer?
+    has_any_role_of? :printer
+  end
+
   def is_administrator?
     has_any_role_of? :administrator
   end

--- a/app/policies/model_file_policy.rb
+++ b/app/policies/model_file_policy.rb
@@ -9,7 +9,15 @@ class ModelFilePolicy < ApplicationPolicy
   end
 
   def print?
-    show?
+    all_of(
+      one_of(
+        @user&.is_printer?,
+        @user&.is_administrator?
+      ),
+      none_of(
+        SiteSettings.demo_mode_enabled?
+      )
+    )
   end
 
   def create?

--- a/app/policies/model_file_policy.rb
+++ b/app/policies/model_file_policy.rb
@@ -10,10 +10,7 @@ class ModelFilePolicy < ApplicationPolicy
 
   def print?
     all_of(
-      one_of(
-        @user&.is_printer?,
-        @user&.is_administrator?
-      ),
+      @user&.is_printer?,
       none_of(
         SiteSettings.demo_mode_enabled?
       )

--- a/app/policies/print_host_policy.rb
+++ b/app/policies/print_host_policy.rb
@@ -22,10 +22,7 @@ class PrintHostPolicy < ApplicationPolicy
 
   def print?
     all_of(
-      one_of(
-        @user&.is_printer?,
-        @user&.is_administrator?
-      ),
+      @user&.is_printer?,
       none_of(
         SiteSettings.demo_mode_enabled?
       )

--- a/app/policies/print_host_policy.rb
+++ b/app/policies/print_host_policy.rb
@@ -1,7 +1,7 @@
 class PrintHostPolicy < ApplicationPolicy
   def index?
     all_of(
-      user&.is_administrator?,
+      @user&.is_administrator?,
       none_of(
         SiteSettings.demo_mode_enabled?
       )
@@ -21,6 +21,14 @@ class PrintHostPolicy < ApplicationPolicy
   end
 
   def print?
-    index?
+    all_of(
+      one_of(
+        @user&.is_printer?,
+        @user&.is_administrator?
+      ),
+      none_of(
+        SiteSettings.demo_mode_enabled?
+      )
+    )
   end
 end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -15,5 +15,9 @@ FactoryBot.define do
     factory :contributor do
       after(:create) { |a| a.add_role :contributor }
     end
+
+    factory :printer do
+      after(:create) { |a| a.add_role :printer }
+    end
   end
 end

--- a/spec/models/role_spec.rb
+++ b/spec/models/role_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe Role do
     expect(user.has_role?(:batman)).to be false
   end
 
+  context "when printer" do
+    let(:admin) { create(:printer) }
+
+    it "has print permission" do
+      expect(admin.is_printer?).to be true
+    end
+
+    it "doesn't get administrator permission" do
+      expect(admin.is_administrator?).to be false
+    end
+  end
+
   context "when administrator" do
     let(:admin) { create(:admin) }
 

--- a/spec/requests/print_hosts_spec.rb
+++ b/spec/requests/print_hosts_spec.rb
@@ -18,6 +18,10 @@ RSpec.describe "PrintHosts", :after_first_run do
         expect(response).to have_http_status(:forbidden)
       end
 
+      it "denies permission to people with print-only permissions", :as_printer do
+        expect(response).to have_http_status(:forbidden)
+      end
+
       it "shows list to admins", :as_administrator do
         expect(response).to have_http_status(:success)
       end
@@ -33,6 +37,10 @@ RSpec.describe "PrintHosts", :after_first_run do
       it "is denied to non-admins", :as_moderator do
         expect(response).to have_http_status(:forbidden)
       end
+
+      it "denies permission to people with print-only permissions", :as_printer do
+        expect(response).to have_http_status(:forbidden)
+      end
     end
 
     describe "GET /print_hosts/new" do
@@ -45,6 +53,10 @@ RSpec.describe "PrintHosts", :after_first_run do
       it "is denied to non-admins", :as_moderator do
         expect(response).to have_http_status(:forbidden)
       end
+
+      it "denies permission to people with print-only permissions", :as_printer do
+        expect(response).to have_http_status(:forbidden)
+      end
     end
 
     describe "GET /print_hosts/:id/edit" do
@@ -55,6 +67,10 @@ RSpec.describe "PrintHosts", :after_first_run do
       end
 
       it "is denied to non-administrators", :as_moderator do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "denies permission to people with print-only permissions", :as_printer do
         expect(response).to have_http_status(:forbidden)
       end
     end
@@ -77,6 +93,10 @@ RSpec.describe "PrintHosts", :after_first_run do
       it "is denied to non-administrators", :as_moderator do
         expect(response).to have_http_status(:forbidden)
       end
+
+      it "denies permission to people with print-only permissions", :as_printer do
+        expect(response).to have_http_status(:forbidden)
+      end
     end
 
     describe "DELETE /print_hosts/:id" do
@@ -89,6 +109,10 @@ RSpec.describe "PrintHosts", :after_first_run do
       end
 
       it "is denied to non-administrators", :as_moderator do
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "denies permission to people with print-only permissions", :as_printer do
         expect(response).to have_http_status(:forbidden)
       end
     end
@@ -112,6 +136,12 @@ RSpec.describe "PrintHosts", :after_first_run do
       it "is denied to non-administrators", :as_moderator do
         post "/print_hosts/#{print_host.to_param}/print", params: {file_id: file.public_id}
         expect(response).to have_http_status(:forbidden)
+      end
+
+      it "accepts print requests from people with print-only permissions", :as_printer do
+        expect {
+          post "/print_hosts/#{print_host.to_param}/print", params: {file_id: file.public_id}
+        }.to have_enqueued_job(SendFileToPrintHostJob).with(print_host: print_host, file: file)
       end
     end
   end

--- a/spec/support/sign_in_role.rb
+++ b/spec/support/sign_in_role.rb
@@ -26,4 +26,9 @@ RSpec.configure do |config|
     @current_user = create(:user)
     sign_in @current_user
   end
+
+  config.before(:each, :as_printer) do
+    @current_user = create(:printer)
+    sign_in @current_user
+  end
 end


### PR DESCRIPTION
Affects all configured printers equally. Resolves #6450