### PR TITLE
Include all tags in dropdown

### DIFF
--- a/app/frontend/javascript/controllers/tag_input_controller.ts
+++ b/app/frontend/javascript/controllers/tag_input_controller.ts
@@ -9,6 +9,7 @@ export default class extends Controller {
   connect (): void {
     this.tomSelect = new TomSelect((this.element as HTMLSelectElement), { // eslint-disable-line no-new
       addPrecedence: true,
+      maxOptions: null,
       create: true,
       plugins: ['remove_button'],
       onItemAdd: function () {

--- a/app/frontend/javascript/controllers/tag_input_controller.ts
+++ b/app/frontend/javascript/controllers/tag_input_controller.ts
@@ -10,6 +10,7 @@ export default class extends Controller {
     this.tomSelect = new TomSelect((this.element as HTMLSelectElement), { // eslint-disable-line no-new
       addPrecedence: true,
       maxOptions: null,
+      refreshThrottle: 0,
       create: true,
       plugins: ['remove_button'],
       onItemAdd: function () {


### PR DESCRIPTION
Remove the maxOptions limit, so that if you want you can scroll through the lot. They're all in the page code already anyway.

This also speeds up the refresh when typing in the tag entry box so that you can type and tab quickly when adding tags.