### PR TITLE
Disable autoloading by default

### DIFF
--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -145,6 +145,7 @@ class SiteSettings < RailsSettings::Base
 
   module UserDefaults
     RENDERER = ActiveSupport::HashWithIndifferentAccess.new(
+      auto_load_max_size: 0,
       grid_width: 200,
       grid_depth: 200,
       show_grid: true,


### PR DESCRIPTION
Now that we have 3d renders for most files, autoloading is undesirable. (It probably was anyway)