### PR TITLE
Use Faker::UniquenessGenerator to stop name clashes in tests

### DIFF
--- a/spec/factories/collection.rb
+++ b/spec/factories/collection.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :collection do
-    name { Faker::Name.name }
+    name { Faker::Name.unique.name }
     caption { Faker::Lorem.sentence }
     notes { Faker::Lorem.paragraph }
     links_attributes { [{url: "http://example.com", text: "anchor text"}] }

--- a/spec/factories/doorkeeper/application.rb
+++ b/spec/factories/doorkeeper/application.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :oauth_application, class: "Doorkeeper::Application" do
-    name { Faker::Appliance.equipment }
+    name { Faker::Appliance.unique.equipment }
     redirect_uri { "urn:ietf:wg:oauth:2.0:oob" }
     scopes { ["read", "write", "delete"] }
     confidential { true }

--- a/spec/factories/federails/actor.rb
+++ b/spec/factories/federails/actor.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :actor, class: "Federails::Actor" do
-    name { Faker::Name.name }
+    name { Faker::Name.unique.name }
     actor_type { "Person" }
     entity { nil }
     extensions {

--- a/spec/factories/group.rb
+++ b/spec/factories/group.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :group do
-    name { Faker::Commerce.product_name }
+    name { Faker::Commerce.unique.product_name }
     creator
   end
 end

--- a/spec/factories/link.rb
+++ b/spec/factories/link.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :link do
-    url { Faker::Internet.url }
+    url { Faker::Internet.unique.url }
     text { Faker::Internet.username }
   end
 end

--- a/spec/factories/list.rb
+++ b/spec/factories/list.rb
@@ -1,5 +1,5 @@
 FactoryBot.define do
   factory :list do
-    name { Faker::Name.name }
+    name { Faker::Name.unique.name }
   end
 end

--- a/spec/factories/model_file.rb
+++ b/spec/factories/model_file.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :model_file do
     model
-    filename { Faker::File.file_name(ext: "stl") }
+    filename { Faker::File.unique.file_name(ext: "stl") }
     attachment { filename ? Rack::Test::UploadedFile.new(StringIO.new, original_filename: filename) : nil }
 
     after :create do |file, context|

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
-    email { Faker::Internet.email }
-    username { Faker::Internet.username specifier: 8, separators: [] }
+    email { Faker::Internet.unique.email }
+    username { Faker::Internet.unique.username specifier: 8, separators: [] }
     password { Faker::Internet.password max_length: 32, min_length: 32, mix_case: true, special_characters: true }
 
     factory :admin do

--- a/spec/models/library_spec.rb
+++ b/spec/models/library_spec.rb
@@ -285,8 +285,14 @@ RSpec.describe Library do
   end
 
   context "with multiple libraries" do
-    let!(:first_library) { create(:library) }
-    let!(:second_library) { create(:library) }
+    let(:first_library) { create(:library) }
+    let(:second_library) { create(:library) }
+
+    before do
+      # Ensure correct order of creation
+      first_library
+      second_library
+    end
 
     it "uses first library as default if not explicitly set" do
       expect(described_class.default).to eq first_library

--- a/spec/support/faker.rb
+++ b/spec/support/faker.rb
@@ -1,0 +1,5 @@
+RSpec.configure do |config|
+  config.after do
+    Faker::UniqueGenerator.clear
+  end
+end


### PR DESCRIPTION
Should fix some parts of #6483 