### PR TITLE
Core plugin architecture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ node_modules
 # Vite uses dotenv and suggests to ignore local-only env files. See
 # https://vitejs.dev/guide/env-and-mode.html#env-files
 *.local
+
+# Plugins folder
+/plugins/*
+!/plugins/.keep

--- a/app/lib/plugin_hooks.rb
+++ b/app/lib/plugin_hooks.rb
@@ -1,0 +1,20 @@
+class PluginHooks
+  include Singleton
+
+  def initialize
+    @hooks = {}
+  end
+
+  def register(hook, component)
+    @hooks[hook] ||= []
+    @hooks[hook] << component
+  end
+
+  def self.register(hook, component)
+    instance.register(hook, component)
+  end
+
+  def components_for(hook)
+    @hooks[hook] || []
+  end
+end

--- a/app/views/application/_navbar.html.erb
+++ b/app/views/application/_navbar.html.erb
@@ -36,6 +36,11 @@
             </li>
           <% end %>
         <% end %>
+        <% PluginHooks.instance.components_for(:navbar).each do %>
+          <li class="nav-item" role="presentation">
+            <%= render it.new %>
+          </li>
+        <% end %>
       </ul>
       <ul class="navbar-nav col-auto pe-4 align-self-start justify-content-end" role="presentation">
         <li class="nav-item" role="presentation">

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,10 +21,11 @@ require "rack/contrib"
 Bundler.require(:sqlite3, :postgres, :mysql, *Rails.groups)
 
 # Require any engines inside plugins folder
-Dir.glob(File.expand_path("../plugins/*", __dir__))
+PLUGINS = Dir.glob(File.expand_path("../plugins/*", __dir__))
   .select { FileTest.directory? it }
-  .map { File.split(it).last }
-  .each do |plugin|
+  .map { File.split(it).last }.freeze
+
+PLUGINS.each do |plugin|
   $: << File.expand_path("../plugins/#{plugin}", __dir__)
   $: << File.expand_path("../plugins/#{plugin}/lib", __dir__)
   require plugin
@@ -49,6 +50,14 @@ module Manyfold
     config.eager_load_paths << config.root.join("app/uploaders")
 
     config.autoload_once_paths << "#{root}/app/lib"
+
+    PLUGINS.each do |plugin|
+      initializer "#{plugin}.add_routing_paths" do |app|
+        app.routes.append do
+          mount Object.const_get("#{plugin.classify}::Engine") => "/#{plugin}"
+        end
+      end
+    end
 
     # Load locale files in nested folders as well as locale root
     config.i18n.load_path += Rails.root.glob("config/locales/**/*.{rb,yml}")

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,16 @@ require "rack/contrib"
 # you've limited to :test, :development, or :production.
 Bundler.require(:sqlite3, :postgres, :mysql, *Rails.groups)
 
+# Require any engines inside plugins folder
+Dir.glob(File.expand_path("../plugins/*", __dir__))
+  .select { FileTest.directory? it }
+  .map { File.split(it).last }
+  .each do |plugin|
+  $: << File.expand_path("../plugins/#{plugin}", __dir__)
+  $: << File.expand_path("../plugins/#{plugin}/lib", __dir__)
+  require plugin
+end
+
 module Manyfold
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.

--- a/config/initializers/phlex.rb
+++ b/config/initializers/phlex.rb
@@ -14,3 +14,10 @@ Rails.autoloaders.main.push_dir(
 Rails.autoloaders.main.push_dir(
   Rails.root.join("app/components"), namespace: Components
 )
+
+PLUGINS.each do
+  plugin_component_dir = Rails.root.join("plugins/#{it}/app/components")
+  Rails.autoloaders.main.push_dir(plugin_component_dir, namespace: Components) if plugin_component_dir.exist?
+  plugin_view_dir = Rails.root.join("plugins/#{it}/app/views")
+  Rails.autoloaders.main.push_dir(plugin_view_dir, namespace: Views) if plugin_view_dir.exist?
+end


### PR DESCRIPTION
This PR adds the code for the main Manyfold application to be able to load "plugins", which are Rails engines which register a specific set of hooks into Manyfold itself.

Example plugin code at https://github.com/manyfold3d/example_plugin/

Resolves #6503 

Lots of inspiration taken from Redmine's plugin system: https://www.redmine.org/projects/redmine/wiki/Plugin_Tutorial

Other changes made to support this:

* #6498 
* #6501 
* #6502