### PR TITLE
Add fallback icon for slicer links

### DIFF
--- a/app/frontend/images/window.svg
+++ b/app/frontend/images/window.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-window" viewBox="0 0 16 16">
+  <path d="M2.5 4a.5.5 0 1 0 0-1 .5.5 0 0 0 0 1m2-.5a.5.5 0 1 1-1 0 .5.5 0 0 1 1 0m1 .5a.5.5 0 1 0 0-1 .5.5 0 0 0 0 1"/>
+  <path d="M2 1a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V3a2 2 0 0 0-2-2zm13 2v2H1V3a1 1 0 0 1 1-1h12a1 1 0 0 1 1 1M2 14a1 1 0 0 1-1-1V6h14v7a1 1 0 0 1-1 1z"/>
+</svg>

--- a/app/helpers/model_files_helper.rb
+++ b/app/helpers/model_files_helper.rb
@@ -40,7 +40,7 @@ module ModelFilesHelper
         content_tag(:li, role: "presentation") {
           link_to safe_join(
             [
-              app_icon_tag(name, alt: t("model_files.download.%{name}" % {name: name})),
+              app_icon_tag(handler),
               t("model_files.download.%{name}" % {name: name})
             ].compact,
             " "
@@ -56,8 +56,10 @@ module ModelFilesHelper
     handler.open_url_for(signed_url, client_os: -> { client_os })
   end
 
-  def app_icon_tag(app, alt:)
-    vite_image_tag("images/external-icons/#{app}.png", class: "app-icon", alt: alt)
+  def app_icon_tag(handler)
+    handler.icon ?
+      vite_image_tag(handler.icon, class: "app-icon", role: "presentation") :
+      Icon(icon: "window", role: "presentation")
   end
 
   def tab_title(file)

--- a/app/lib/file_handlers/bambu_studio.rb
+++ b/app/lib/file_handlers/bambu_studio.rb
@@ -8,6 +8,10 @@ class FileHandlers::BambuStudio < FileHandlers::Slic3rFamily
     "bambustudio"
   end
 
+  def self.icon
+    "images/external-icons/bambu_studio.png"
+  end
+
   def self.open_url_for(target, client_os: nil)
     os = client_os&.call
     if os&.family == "Mac OS X"

--- a/app/lib/file_handlers/base.rb
+++ b/app/lib/file_handlers/base.rb
@@ -20,6 +20,10 @@ class FileHandlers::Base
       0
     end
 
+    def icon
+      nil
+    end
+
     # For test mocking only
     def input_types
       self::INPUT_TYPES

--- a/app/lib/file_handlers/creality_print.rb
+++ b/app/lib/file_handlers/creality_print.rb
@@ -7,4 +7,8 @@ class FileHandlers::CrealityPrint < FileHandlers::Slic3rFamily
   def self.scheme
     "crealityprintlink"
   end
+
+  def self.icon
+    "images/external-icons/creality_print.png"
+  end
 end

--- a/app/lib/file_handlers/cura.rb
+++ b/app/lib/file_handlers/cura.rb
@@ -6,4 +6,8 @@ class FileHandlers::Cura < FileHandlers::Slic3rFamily
   def self.scheme
     "cura"
   end
+
+  def self.icon
+    "images/external-icons/cura.png"
+  end
 end

--- a/app/lib/file_handlers/elegoo_slicer.rb
+++ b/app/lib/file_handlers/elegoo_slicer.rb
@@ -6,4 +6,8 @@ class FileHandlers::ElegooSlicer < FileHandlers::Slic3rFamily
   def self.scheme
     "elegooslicer"
   end
+
+  def self.icon
+    "images/external-icons/elegoo_slicer.png"
+  end
 end

--- a/app/lib/file_handlers/flock_xr.rb
+++ b/app/lib/file_handlers/flock_xr.rb
@@ -11,4 +11,8 @@ class FileHandlers::FlockXr < FileHandlers::Base
       {project: target}.to_query, nil
     ).to_s
   end
+
+  def self.icon
+    "images/external-icons/flock_xr.png"
+  end
 end

--- a/app/lib/file_handlers/lychee.rb
+++ b/app/lib/file_handlers/lychee.rb
@@ -13,4 +13,8 @@ class FileHandlers::Lychee < FileHandlers::Base
       nil, nil
     ).to_s
   end
+
+  def self.icon
+    "images/external-icons/lychee.png"
+  end
 end

--- a/app/lib/file_handlers/orca_slicer.rb
+++ b/app/lib/file_handlers/orca_slicer.rb
@@ -7,4 +7,8 @@ class FileHandlers::OrcaSlicer < FileHandlers::Slic3rFamily
   def self.scheme
     "orcaslicer"
   end
+
+  def self.icon
+    "images/external-icons/orca_slicer.png"
+  end
 end

--- a/app/lib/file_handlers/super_slicer.rb
+++ b/app/lib/file_handlers/super_slicer.rb
@@ -7,4 +7,8 @@ class FileHandlers::SuperSlicer < FileHandlers::Slic3rFamily
   def self.scheme
     "prusaslicer"
   end
+
+  def self.icon
+    "images/external-icons/super_slicer.png"
+  end
 end


### PR DESCRIPTION
This means we can have slicer links in plugins without having to work out asset delivery yet. And it's a good failsafe.