### PR TITLE
Detect plugins regardless of folder naming

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,20 +21,19 @@ require "rack/contrib"
 Bundler.require(:sqlite3, :postgres, :mysql, *Rails.groups)
 
 # Require any engines inside plugins folder
-plugin_folders = Dir.glob(File.expand_path("../plugins/*", __dir__))
-  .select { FileTest.directory? it }
-  .map { File.split(it).last }.freeze
-
 PLUGINS = {}
+Dir.glob(File.expand_path("../plugins/*/*.gemspec", __dir__)).each do |gemspec|
+  directory = File.dirname(gemspec)
+  plugin_key = File.basename(gemspec, ".*")
 
-plugin_folders.each do |plugin|
   # Load metadata
-  PLUGINS[plugin] = Gem::Specification.load(File.expand_path("../plugins/#{plugin}/#{plugin}.gemspec", __dir__).to_s)
+  PLUGINS[plugin_key] = Gem::Specification.load(gemspec.to_s)
+  PLUGINS[plugin_key].metadata = {path: directory}
   # Add to load path
-  $: << File.expand_path("../plugins/#{plugin}", __dir__)
-  $: << File.expand_path("../plugins/#{plugin}/lib", __dir__)
+  $: << directory
+  $: << File.join(directory, "lib")
   # Require the actual plugin
-  require plugin
+  require plugin_key
 end
 
 module Manyfold

--- a/config/initializers/phlex.rb
+++ b/config/initializers/phlex.rb
@@ -15,9 +15,9 @@ Rails.autoloaders.main.push_dir(
   Rails.root.join("app/components"), namespace: Components
 )
 
-PLUGINS.keys.each do
-  plugin_component_dir = Rails.root.join("plugins/#{it}/app/components")
-  Rails.autoloaders.main.push_dir(plugin_component_dir, namespace: Components) if plugin_component_dir.exist?
-  plugin_view_dir = Rails.root.join("plugins/#{it}/app/views")
-  Rails.autoloaders.main.push_dir(plugin_view_dir, namespace: Views) if plugin_view_dir.exist?
+PLUGINS.each do |key, gemspec|
+  plugin_component_dir = "#{gemspec.metadata[:path]}/app/components"
+  Rails.autoloaders.main.push_dir(plugin_component_dir, namespace: Components) if Dir.exist?(plugin_component_dir)
+  plugin_view_dir = "#{gemspec.metadata[:path]}/app/views"
+  Rails.autoloaders.main.push_dir(plugin_view_dir, namespace: Views) if Dir.exist?(plugin_view_dir)
 end


### PR DESCRIPTION
Now that plugins have gemspecs, we can use that file to infer everything we need, regardless of actual folder naming.