### PR TITLE
Configure PLUGINS_PATH for docker images

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -16,8 +16,12 @@ bundle exec rake tmp:cache:clear
 echo "Setting temporary directory permissions..."
 chown -R $PUID:$PGID tmp log
 
-echo "Setting plugin directory permissions..."
-chown -R $PUID:$PGID plugins
+if [ ! -d $PLUGINS_PATH ]; then
+  echo "Creating plugin directory..."
+  mkdir -p "$PLUGINS_PATH"
+fi
+echo "Setting plugin directory owner..."
+chown $PUID:$PGID "$PLUGINS_PATH"
 
 echo "Launching application..."
 export RAILS_PORT=$PORT

--- a/docker-compose.example.yml
+++ b/docker-compose.example.yml
@@ -13,6 +13,10 @@ services:
       # will scan and import them, or it could be empty.
       # The container path can be anything; you will need to enter it in the "new library" form.
       # - /local/path/to/your/models:/models
+      # If you want to use any plugins, you will also need a persistent plugins folder
+      # /usr/src/app/plugins is the default, but you can set a different path using the
+      # PLUGINS_PATH environment variable.
+      # - /local/path/to/plugins:/usr/src/app/plugins
     environment:
       PUID: 1000 # The ID of the user the app will run as
       PGID: 1000 # The ID of the group the app will run as

--- a/docker/manyfold-solo.dockerfile
+++ b/docker/manyfold-solo.dockerfile
@@ -18,3 +18,6 @@ COPY ./docker/s6-rc.d/redis/manyfold/dependencies.d/redis /etc/s6-overlay/s6-rc.
 ENV DATABASE_URL=sqlite3:/config/manyfold.sqlite3
 ENV REDIS_URL=redis://localhost:6379
 ENV DEFAULT_WORKER_CONCURRENCY=1
+
+# Default plugin folder
+ENV PLUGINS_PATH=/config/plugins

--- a/docker/runtime.dockerfile
+++ b/docker/runtime.dockerfile
@@ -46,6 +46,8 @@ ENV AWS_REQUEST_CHECKSUM_CALCULATION=when_required
 # else at runtime, and this default will be removed in future.
 ENV PUID=0
 ENV PGID=0
+# Default plugin folder
+ENV PLUGINS_PATH=/usr/src/app/plugins
 
 RUN gem install foreman
 


### PR DESCRIPTION
* `standard` uses the default `/usr/src/app/plugins` and requires a mount for persistence
* `solo` uses `/config/plugins` to keep it simple.

Docker entrypoint ensures that the location exists before setting ownership (mainly for solo).

This will need porting to linuxserver images; I've opened an issue at https://github.com/linuxserver/docker-manyfold/issues/23