### PR TITLE
Fix imagemagick download error in CI builds

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -9,7 +9,7 @@ runs:
       with:
         packages: libassimp-dev f3d
     - name: Install imagemagick
-      uses: mfinelli/setup-imagemagick@e5a049b136cb833d5c0474b38d166f0bdb0e4497
+      uses: Haerezis/setup-imagemagick@236c0697dd7233bedfdc007308e6566c1eb83cdb # temporarily using fork until https://github.com/mfinelli/setup-imagemagick/issues/571 is fixed
     - name: Set up Ruby and install gems
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
See https://github.com/mfinelli/setup-imagemagick/issues/571, the imagemagick setup action we're using now 404s because ImageMagick moved their download archives to GitHub. This PR moves us to using the code in https://github.com/mfinelli/setup-imagemagick/pull/572, and once that's merged we can go back to the mainline.