### PR TITLE
Only set plugin path owner if writable

### DIFF
--- a/bin/docker-entrypoint.sh
+++ b/bin/docker-entrypoint.sh
@@ -20,8 +20,10 @@ if [ ! -d $PLUGINS_PATH ]; then
   echo "Creating plugin directory..."
   mkdir -p "$PLUGINS_PATH"
 fi
-echo "Setting plugin directory owner..."
-chown $PUID:$PGID "$PLUGINS_PATH"
+if [ -w $PLUGINS_PATH ]; then
+  echo "Setting plugin directory owner..."
+  chown $PUID:$PGID "$PLUGINS_PATH"
+fi
 
 echo "Launching application..."
 export RAILS_PORT=$PORT


### PR DESCRIPTION
FIxes startup error on readonly filesystems
