### PR TITLE
Move uploaded archives into models before extracting

### DIFF
--- a/app/controllers/plugins_controller.rb
+++ b/app/controllers/plugins_controller.rb
@@ -30,14 +30,10 @@ class PluginsController < ApplicationController
     rescue Errno::EEXIST
       Rails.logger.warn("Plugin path #{plugin_path} exists, files will be overwritten")
     end
-    flags = [
-      Archive::EXTRACT_TIME,
-      Archive::EXTRACT_SECURE_NODOTDOT
-    ].reduce(:|).to_i
     strip = count_common_path_components(archive)
     Archive::Reader.open_filename(archive.tempfile.path, strip_components: strip) do |reader|
       reader.each_entry do |entry|
-        reader.extract(entry, flags, destination: plugin_path.to_s)
+        reader.extract(entry, Archive::EXTRACT_SECURE_WITH_OVERWRITE, destination: plugin_path.to_s)
       end
     end
     # Set the flag that a restart is now needed

--- a/app/controllers/plugins_controller.rb
+++ b/app/controllers/plugins_controller.rb
@@ -1,4 +1,6 @@
 class PluginsController < ApplicationController
+  include ArchiveHelpers
+
   layout "settings"
 
   def index
@@ -40,28 +42,5 @@ class PluginsController < ApplicationController
     end
     # Set the flag that a restart is now needed
     Rails.cache.write("restart_required", true)
-  end
-
-  def count_common_path_components(archive)
-    # Generate full list of directories in the archive
-    paths = []
-    files_in_root = false
-    Archive::Reader.open_filename(archive.path) do |reader|
-      reader.each_entry do |entry|
-        paths << entry.pathname if entry.directory?
-        files_in_root = true if entry.file? && entry.pathname.exclude?(File::SEPARATOR)
-      end
-    end
-    return 0 if files_in_root
-    paths = paths.map { |path| path.split(File::SEPARATOR) }
-    # Count the common elements in the paths
-    count_common_elements(paths)
-  end
-
-  def count_common_elements(arrays)
-    return 0 if arrays.empty?
-    first = arrays.shift
-    zip = first.zip(*arrays)
-    zip.count { it.uniq.count == 1 }
   end
 end

--- a/app/jobs/extract_archive_job.rb
+++ b/app/jobs/extract_archive_job.rb
@@ -1,0 +1,44 @@
+class ExtractArchiveJob < ApplicationJob
+  include ArchiveHelpers
+
+  queue_as :high
+
+  def perform(file_id, remove_when_complete: false)
+    file = ModelFile.find(file_id)
+    return unless file.is_archive?
+
+    unzip_into_model(file)
+
+    if remove_when_complete
+      file.destroy
+    end
+  end
+
+  private
+
+  def unzip_into_model(file)
+    ModelFileUploader.with_file(file.attachment.open) do |archive|
+      strip = count_common_path_components(archive)
+      Archive::Reader.open_filename(archive.path, strip_components: strip) do |reader|
+        reader.each_entry do |entry|
+          extract_entry_to_model_file(reader, entry, file.model)
+        end
+      end
+    end
+  end
+
+  def extract_entry_to_model_file(reader, entry, model)
+    return if !entry.file? || entry.size > SiteSettings.max_file_extract_size
+
+    filename = begin
+      entry.pathname.encode(Encoding::UTF_8).scrub
+    rescue EncodingError
+      entry.pathname.force_encoding(Encoding::UTF_8).scrub
+    end
+    return if SiteSettings.ignored_file?(filename)
+
+    reader.extract(entry, Archive::EXTRACT_SECURE, destination: File.join(model.library.path, model.path))
+    new_file = ApplicationRecord.suppressing_turbo_broadcasts { model.model_files.find_or_create_by(filename: filename) }
+    new_file.parse_metadata_later
+  end
+end

--- a/app/jobs/extract_archive_job.rb
+++ b/app/jobs/extract_archive_job.rb
@@ -37,8 +37,17 @@ class ExtractArchiveJob < ApplicationJob
     end
     return if SiteSettings.ignored_file?(filename)
 
-    reader.extract(entry, Archive::EXTRACT_SECURE, destination: File.join(model.library.path, model.path))
-    new_file = ApplicationRecord.suppressing_turbo_broadcasts { model.model_files.find_or_create_by(filename: filename) }
-    new_file.parse_metadata_later
+    # Find if file exists already
+    if (existing_file = model.model_files.find_by(filename: filename))
+      # If the existing file is not the same as the one in the archive, overwrite it
+      if existing_file.size != entry.size
+        reader.extract(entry, Archive::EXTRACT_SECURE_WITH_OVERWRITE, destination: File.join(model.library.path, model.path))
+        existing_file.refresh_metadata!
+      end
+    else
+      reader.extract(entry, Archive::EXTRACT_SECURE, destination: File.join(model.library.path, model.path))
+      new_file = ApplicationRecord.suppressing_turbo_broadcasts { model.model_files.find_or_create_by(filename: filename) }
+      new_file.parse_metadata_later
+    end
   end
 end

--- a/app/jobs/process_uploaded_file_job.rb
+++ b/app/jobs/process_uploaded_file_job.rb
@@ -24,10 +24,12 @@ class ProcessUploadedFileJob < ApplicationJob
       model ||= create_new_model(library, name: name, owner: owner, creator_id: creator_id, collection_ids: collection_ids, tag_list: tag_list, license: license, sensitive: sensitive, permission_preset: permission_preset)
 
       attachers.each do
-        new_files << if new_model && (attachers.length == 1) && is_archive?(it.file)
-          unzip_into_model(model, it.file)
+        if new_model && (attachers.length == 1) && is_archive?(it.file)
+          # This is a single zipfile going into a new model, so automatically run extract job
+          f = add_single_file_to_model(model, it.file)
+          ExtractArchiveJob.perform_later(f.id, remove_when_complete: true) if f&.valid?
         else
-          add_single_file_to_model(model, it.file)
+          new_files << add_single_file_to_model(model, it.file)
         end
       end
     end

--- a/app/jobs/process_uploaded_file_job.rb
+++ b/app/jobs/process_uploaded_file_job.rb
@@ -1,4 +1,6 @@
 class ProcessUploadedFileJob < ApplicationJob
+  include ArchiveHelpers
+
   queue_as :critical
 
   def perform(library_id, uploaded_file, name: nil, owner: nil, creator_id: nil, collection_ids: [], tag_list: nil, license: nil, model: nil, sensitive: nil, permission_preset: nil)
@@ -109,28 +111,5 @@ class ProcessUploadedFileJob < ApplicationJob
       end
     end
     new_files
-  end
-
-  def count_common_path_components(archive)
-    # Generate full list of directories in the archive
-    paths = []
-    files_in_root = false
-    Archive::Reader.open_filename(archive.path) do |reader|
-      reader.each_entry do |entry|
-        paths << entry.pathname if entry.directory?
-        files_in_root = true if entry.file? && entry.pathname.exclude?(File::SEPARATOR)
-      end
-    end
-    return 0 if files_in_root
-    paths = paths.map { |path| path.split(File::SEPARATOR) }
-    # Count the common elements in the paths
-    count_common_elements(paths)
-  end
-
-  def count_common_elements(arrays)
-    return 0 if arrays.empty?
-    first = arrays.shift
-    zip = first.zip(*arrays)
-    zip.count { it.uniq.count == 1 }
   end
 end

--- a/app/lib/archive_helpers.rb
+++ b/app/lib/archive_helpers.rb
@@ -1,0 +1,24 @@
+module ArchiveHelpers
+  def count_common_path_components(archive)
+    # Generate full list of directories in the archive
+    paths = []
+    files_in_root = false
+    Archive::Reader.open_filename(archive.path) do |reader|
+      reader.each_entry do |entry|
+        paths << entry.pathname if entry.directory?
+        files_in_root = true if entry.file? && entry.pathname.exclude?(File::SEPARATOR)
+      end
+    end
+    return 0 if files_in_root
+    paths = paths.map { |path| path.split(File::SEPARATOR) }
+    # Count the common elements in the paths
+    count_common_elements(paths)
+  end
+
+  def count_common_elements(arrays)
+    return 0 if arrays.empty?
+    first = arrays.shift
+    zip = first.zip(*arrays)
+    zip.count { it.uniq.count == 1 }
+  end
+end

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -76,6 +76,10 @@ class ModelFile < ApplicationRecord
     MediaType.model_extensions.include? extension
   end
 
+  def is_archive?
+    MediaType.archive_extensions.include? extension
+  end
+
   def has_render?
     is_3d_model? && attachment_attacher.derivatives.key?(:render)
   end

--- a/config/initializers/libarchive_security.rb
+++ b/config/initializers/libarchive_security.rb
@@ -1,10 +1,14 @@
 module Archive
+  EXTRACT_SECURE_WITH_OVERWRITE = [
+    Archive::EXTRACT_TIME,
+    Archive::EXTRACT_SECURE_NODOTDOT
+  ].reduce(:|).to_i
+
   # Create a preset "secure extraction" flag combination for libarchive to make sure we avoid security problems
   # See https://github.com/libarchive/libarchive/blob/6ee1eebefdf41f36ef1a548c9a7000d132c453f3/libarchive/archive.h#L662
   EXTRACT_SECURE = [
-    Archive::EXTRACT_TIME,
+    Archive::EXTRACT_SECURE_WITH_OVERWRITE,
     Archive::EXTRACT_NO_OVERWRITE,
-    Archive::EXTRACT_NO_OVERWRITE_NEWER,
-    Archive::EXTRACT_SECURE_NODOTDOT
+    Archive::EXTRACT_NO_OVERWRITE_NEWER
   ].reduce(:|).to_i
 end

--- a/spec/jobs/extract_archive_job_spec.rb
+++ b/spec/jobs/extract_archive_job_spec.rb
@@ -62,4 +62,16 @@ RSpec.describe ExtractArchiveJob do
       expect(model.model_files.map(&:filename)).to contain_exactly("subfolder/more.stl", "test.stl")
     end
   end
+
+  it "overwrites existing files that are a different size" do # rubocop:todo RSpec/ExampleLength
+    Tempfile.create(%w[test .zip]) do |file|
+      Zip::File.open(file, create: true) do |zipfile|
+        zipfile.get_output_stream("test.stl") { |f| f.puts "solid" }
+      end
+      model_file = create(:model_file, model: model, filename: "test.stl")
+      zip = model.model_files.create(filename: "test.zip", attachment: Rack::Test::UploadedFile.new(file))
+      expect { described_class.perform_now(zip.id, remove_when_complete: true) }
+        .to change { model_file.reload.size }
+    end
+  end
 end

--- a/spec/jobs/extract_archive_job_spec.rb
+++ b/spec/jobs/extract_archive_job_spec.rb
@@ -1,0 +1,65 @@
+require "rails_helper"
+
+RSpec.describe ExtractArchiveJob do
+  subject(:job) { described_class.new }
+
+  let(:model) { create(:model) }
+
+  it "extracts files" do # rubocop:todo RSpec/ExampleLength,RSpec/MultipleExpectations
+    Tempfile.create(%w[test .zip]) do |file|
+      Zip::File.open(file, create: true) do |zipfile|
+        zipfile.get_output_stream("test.stl") { |f| f.puts "solid" }
+      end
+      model_file = model.model_files.create(filename: "test.zip", attachment: Rack::Test::UploadedFile.new(file))
+      expect { described_class.perform_now(model_file.id) }.to change(ModelFile, :count).by(1)
+      expect(File.size(model.model_files.last.attachment)).to eq 6
+    end
+  end
+
+  it "extracts subfolders" do # rubocop:todo RSpec/ExampleLength,RSpec/MultipleExpectations
+    Tempfile.create(%w[test .zip]) do |file|
+      Zip::File.open(file, create: true) do |zipfile|
+        zipfile.mkdir("one")
+        zipfile.mkdir("two")
+        zipfile.get_output_stream("one/test.stl") { |f| f.puts "solid" }
+        zipfile.get_output_stream("two/more.stl") { |f| f.puts "solid" }
+      end
+      model_file = model.model_files.create(filename: "test.zip", attachment: Rack::Test::UploadedFile.new(file))
+      described_class.perform_now(model_file.id, remove_when_complete: true)
+      model.reload
+      expect(model.model_files.count).to eq 2
+      expect(model.model_files.map(&:filename)).to contain_exactly("one/test.stl", "two/more.stl")
+    end
+  end
+
+  it "strips common subfolders" do # rubocop:todo RSpec/ExampleLength,RSpec/MultipleExpectations
+    Tempfile.create(%w[test .zip]) do |file|
+      Zip::File.open(file, create: true) do |zipfile|
+        zipfile.mkdir("sub")
+        zipfile.mkdir("sub/folder")
+        zipfile.get_output_stream("sub/test.stl") { |f| f.puts "solid" }
+        zipfile.get_output_stream("sub/folder/test2.stl") { |f| f.puts "solid" }
+      end
+      model_file = model.model_files.create(filename: "test.zip", attachment: Rack::Test::UploadedFile.new(file))
+      described_class.perform_now(model_file.id, remove_when_complete: true)
+      model.reload
+      expect(model.model_files.count).to eq 2
+      expect(model.model_files.map(&:filename)).to contain_exactly("folder/test2.stl", "test.stl")
+    end
+  end
+
+  it "handles files in root and single subfolder" do # rubocop:todo RSpec/ExampleLength,RSpec/MultipleExpectations
+    Tempfile.create(%w[test .zip]) do |file|
+      Zip::File.open(file, create: true) do |zipfile|
+        zipfile.mkdir("subfolder")
+        zipfile.get_output_stream("test.stl") { |f| f.puts "solid" }
+        zipfile.get_output_stream("subfolder/more.stl") { |f| f.puts "solid" }
+      end
+      model_file = model.model_files.create(filename: "test.zip", attachment: Rack::Test::UploadedFile.new(file))
+      described_class.perform_now(model_file.id, remove_when_complete: true)
+      model.reload
+      expect(model.model_files.count).to eq 2
+      expect(model.model_files.map(&:filename)).to contain_exactly("subfolder/more.stl", "test.stl")
+    end
+  end
+end

--- a/spec/jobs/process_uploaded_file_job_spec.rb
+++ b/spec/jobs/process_uploaded_file_job_spec.rb
@@ -3,49 +3,6 @@ require "rails_helper"
 RSpec.describe ProcessUploadedFileJob do
   subject(:job) { described_class.new }
 
-  context "when counting common path prefixes" do
-    it "returns zero if there are no directories at all" do
-      expect(job.send(:count_common_elements, [])).to eq 0
-    end
-
-    it "returns zero if there are no common prefixes" do
-      expect(job.send(:count_common_elements, [
-        ["folder1"],
-        ["folder2"],
-        []
-      ])).to eq 0
-    end
-
-    it "returns the number of common prefixes if present" do
-      expect(job.send(:count_common_elements, [
-        ["root", "sub", "folder1"],
-        ["root", "sub", "folder2"]
-      ])).to eq 2
-    end
-
-    it "returns correct count where all prefixes are the same" do
-      expect(job.send(:count_common_elements, [
-        ["root", "sub", "folder"],
-        ["root", "sub", "folder"]
-      ])).to eq 3
-    end
-
-    it "returns correct count where a common folder has a subfolder" do
-      expect(job.send(:count_common_elements, [
-        ["root", "sub"],
-        ["root", "sub", "folder2"]
-      ])).to eq 2
-    end
-
-    it "returns zero for *some* common prefixes but not on everything" do
-      expect(job.send(:count_common_elements, [
-        ["folder1", "sub1"],
-        ["folder1", "sub2"],
-        ["folder2", "sub1"]
-      ])).to eq 0
-    end
-  end
-
   context "when uploading a file", :after_first_run do
     let(:uploader) { create(:contributor) }
     let(:library) { create(:library) }

--- a/spec/jobs/process_uploaded_file_job_spec.rb
+++ b/spec/jobs/process_uploaded_file_job_spec.rb
@@ -97,78 +97,16 @@ RSpec.describe ProcessUploadedFileJob do
     end
   end
 
-  context "when errors occur during processing" do
-    let(:library) { create(:library) }
-    let(:file) { Rack::Test::UploadedFile.new(StringIO.new, original_filename: "test.zip") }
-
-    it "removes the created model" do # rubocop:todo RSpec/ExampleLength
-      job = described_class.new
-      allow(job).to receive(:unzip_into_model).and_raise(StandardError)
-      expect {
-        begin
-          job.perform(library.id, file)
-        rescue
-          nil
-        end
-      }.not_to change(Model, :count)
-    end
-
-    it "leaves the uploaded file in place"
-  end
-
   context "when extracting a zip file" do
-    let(:model) { create(:model) }
+    let(:library) { create(:library) }
+    let(:upload) { Rack::Test::UploadedFile.new(StringIO.new, original_filename: "test.zip") }
 
-    it "extracts files" do # rubocop:todo RSpec/ExampleLength,RSpec/MultipleExpectations
-      Tempfile.create(%w[test .zip]) do |file|
-        Zip::File.open(file, create: true) do |zipfile|
-          zipfile.get_output_stream("test.stl") { |f| f.puts "solid" }
-        end
-        upload = Rack::Test::UploadedFile.new(file)
-        expect { described_class.new.send(:unzip_into_model, model, upload) }.to change(ModelFile, :count).by(1)
-        expect(File.size(model.model_files.first.attachment)).to eq 6
-      end
+    it "adds file to model" do
+      expect { job.perform(library.id, upload) }.to change(ModelFile, :count).by(1)
     end
 
-    it "extracts subfolders" do # rubocop:todo RSpec/ExampleLength,RSpec/MultipleExpectations
-      Tempfile.create(%w[test .zip]) do |file|
-        Zip::File.open(file, create: true) do |zipfile|
-          zipfile.mkdir("one")
-          zipfile.mkdir("two")
-          zipfile.get_output_stream("one/test.stl") { |f| f.puts "solid" }
-          zipfile.get_output_stream("two/more.stl") { |f| f.puts "solid" }
-        end
-        described_class.new.send(:unzip_into_model, model, Rack::Test::UploadedFile.new(file))
-        expect(model.model_files.count).to be 2
-        expect(model.model_files.map(&:filename)).to contain_exactly("one/test.stl", "two/more.stl")
-      end
-    end
-
-    it "strips common subfolders" do # rubocop:todo RSpec/ExampleLength,RSpec/MultipleExpectations
-      Tempfile.create(%w[test .zip]) do |file|
-        Zip::File.open(file, create: true) do |zipfile|
-          zipfile.mkdir("sub")
-          zipfile.mkdir("sub/folder")
-          zipfile.get_output_stream("sub/test.stl") { |f| f.puts "solid" }
-          zipfile.get_output_stream("sub/folder/test2.stl") { |f| f.puts "solid" }
-        end
-        described_class.new.send(:unzip_into_model, model, Rack::Test::UploadedFile.new(file))
-        expect(model.model_files.count).to eq 2
-        expect(model.model_files.map(&:filename)).to contain_exactly("folder/test2.stl", "test.stl")
-      end
-    end
-
-    it "handles files in root and single subfolder" do # rubocop:todo RSpec/ExampleLength,RSpec/MultipleExpectations
-      Tempfile.create(%w[test .zip]) do |file|
-        Zip::File.open(file, create: true) do |zipfile|
-          zipfile.mkdir("subfolder")
-          zipfile.get_output_stream("test.stl") { |f| f.puts "solid" }
-          zipfile.get_output_stream("subfolder/more.stl") { |f| f.puts "solid" }
-        end
-        described_class.new.send(:unzip_into_model, model, Rack::Test::UploadedFile.new(file))
-        expect(model.model_files.count).to eq 2
-        expect(model.model_files.map(&:filename)).to contain_exactly("subfolder/more.stl", "test.stl")
-      end
+    it "queues up extraction job" do
+      expect { job.perform(library.id, upload) }.to have_enqueued_job(ExtractArchiveJob).once
     end
   end
 end

--- a/spec/lib/archive_helpers_spec.rb
+++ b/spec/lib/archive_helpers_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+class ArchiveHelpersTestHarness
+  include ArchiveHelpers
+end
+
+RSpec.describe ArchiveHelpers do
+  subject(:harness) { ArchiveHelpersTestHarness.new }
+
+  context "when counting common path prefixes" do
+    it "returns zero if there are no directories at all" do
+      expect(harness.count_common_elements([])).to eq 0
+    end
+
+    it "returns zero if there are no common prefixes" do
+      expect(harness.count_common_elements([
+        ["folder1"],
+        ["folder2"],
+        []
+      ])).to eq 0
+    end
+
+    it "returns the number of common prefixes if present" do
+      expect(harness.count_common_elements([
+        ["root", "sub", "folder1"],
+        ["root", "sub", "folder2"]
+      ])).to eq 2
+    end
+
+    it "returns correct count where all prefixes are the same" do
+      expect(harness.count_common_elements([
+        ["root", "sub", "folder"],
+        ["root", "sub", "folder"]
+      ])).to eq 3
+    end
+
+    it "returns correct count where a common folder has a subfolder" do
+      expect(harness.count_common_elements([
+        ["root", "sub"],
+        ["root", "sub", "folder2"]
+      ])).to eq 2
+    end
+
+    it "returns zero for *some* common prefixes but not on everything" do
+      expect(harness.count_common_elements([
+        ["folder1", "sub1"],
+        ["folder1", "sub2"],
+        ["folder2", "sub1"]
+      ])).to eq 0
+    end
+  end
+end


### PR DESCRIPTION
Hopefully this will help sort out #6293 - it changes the upload process to move the zipfile directly into its model, *then* extracting it in place. It will also allow some more functionality in future!

This should make the extraction process idempotent; if the extract job doesn't complete, it will rerun and overwrite the same files, rather than creating another model as it does now.