### PR TITLE
Add MakerWorld import support

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -100,6 +100,7 @@ class SettingsController < ApplicationController
     return unless settings
     SiteSettings.cults3d_api_username = settings[:cults3d_api_username]
     SiteSettings.cults3d_api_key = settings[:cults3d_api_key]
+    SiteSettings.makerworld_bambu_token = settings[:makerworld_bambu_token]
     SiteSettings.myminifactory_api_key = settings[:myminifactory_api_key]
     SiteSettings.thingiverse_api_key = settings[:thingiverse_api_key]
   end

--- a/app/deserializers/integrations/maker_world/base_deserializer.rb
+++ b/app/deserializers/integrations/maker_world/base_deserializer.rb
@@ -1,0 +1,86 @@
+module Integrations::MakerWorld
+  class BaseDeserializer < Integrations::BaseDeserializer
+    MAKERWORLD_API_BASE = "https://api.bambulab.com/v1/design-service"
+    MAKERWORLD_DOWNLOAD_BASE = "https://api.bambulab.com/v1/iot-service/api/user/profile"
+    MAKERWORLD_HOST = "makerworld.com"
+    MODEL_ID_PATTERN = %r{/models/(?<model_id>[[:digit:]]+)}
+    PROFILE_ID_PATTERN = /#profileId[-=](?<profile_id>[[:digit:]]+)/
+
+    private
+
+    def api_configured?
+      true
+    end
+
+    def download_configured?
+      SiteSettings.makerworld_bambu_token.present?
+    end
+
+    def fetch(api_path)
+      get_json("#{MAKERWORLD_API_BASE}/#{api_path}", request_headers)
+    end
+
+    def fetch_download(profile_id:, model_id:)
+      get_json(
+        "#{MAKERWORLD_DOWNLOAD_BASE}/#{CGI.escapeURIComponent(profile_id.to_s)}?model_id=#{CGI.escapeURIComponent(model_id.to_s)}",
+        request_headers.merge("Authorization" => "Bearer #{SiteSettings.makerworld_bambu_token}")
+      )
+    end
+
+    def get_json(url, headers)
+      connection.get(url, {}, headers)
+    end
+
+    def connection
+      Faraday.new do |builder|
+        builder.response :json
+        builder.response :raise_error
+      end
+    end
+
+    def request_headers
+      {
+        "Accept" => "application/json,*/*",
+        "Accept-Language" => "en-US,en;q=0.9",
+        "Referer" => "https://makerworld.com/"
+      }
+    end
+
+    def canonicalize(uri)
+      candidate = uri.to_s.strip
+      candidate = "https://#{candidate}" unless candidate.include?("://")
+      u = URI.parse(candidate)
+      return unless u.host == MAKERWORLD_HOST || u.host&.end_with?(".#{MAKERWORLD_HOST}")
+      return unless valid_path?(u.path, u.fragment)
+
+      u.host = MAKERWORLD_HOST
+      u.scheme = "https"
+      u.path = "/models/#{@model_id}"
+      u.query = nil
+      u.fragment = @profile_id ? "profileId-#{@profile_id}" : nil
+      u.to_s
+    rescue URI::InvalidURIError
+    end
+
+    def valid_path?(path, fragment = nil)
+      match = MODEL_ID_PATTERN.match(path)
+      return false unless match
+
+      @model_id = match[:model_id]
+      profile_match = PROFILE_ID_PATTERN.match("##{fragment}")
+      @profile_id = profile_match[:profile_id] if profile_match
+      true
+    end
+
+    def selected_profile_id(design)
+      if @profile_id.present?
+        selected = Array.wrap(design["instances"]).find { |instance| instance["id"].to_s == @profile_id.to_s }
+        return selected["profileId"] || selected["profile_id"] if selected
+
+        return @profile_id
+      end
+
+      Array.wrap(design["instances"]).filter_map { |instance| instance["profileId"] || instance["profile_id"] }.first
+    end
+  end
+end

--- a/app/deserializers/integrations/maker_world/model_deserializer.rb
+++ b/app/deserializers/integrations/maker_world/model_deserializer.rb
@@ -1,0 +1,121 @@
+class Integrations::MakerWorld::ModelDeserializer < Integrations::MakerWorld::BaseDeserializer
+  attr_reader :model_id, :profile_id
+
+  def deserialize
+    return {} unless valid?
+
+    design = fetch("design/#{CGI.escapeURIComponent(@model_id)}").body
+    {
+      name: design["title"],
+      slug: design["title"]&.parameterize,
+      notes: design["summary"],
+      tag_list: tags_from(design),
+      file_urls: file_urls_from(design),
+      preview_filename: preview_filename_from(design),
+      license: license_from(design)
+    }.merge(creator_attributes(design))
+  end
+
+  def capabilities
+    {
+      class: Model,
+      name: true,
+      notes: true,
+      images: true,
+      model_files: download_configured?,
+      creator: true,
+      tags: true,
+      sensitive: false,
+      license: true
+    }
+  end
+
+  private
+
+  def tags_from(design)
+    [
+      Array.wrap(design["tags"]).filter_map { |tag| tag.is_a?(Hash) ? (tag["name"] || tag["tagName"]) : tag },
+      Array.wrap(design["categories"]).filter_map { |category| category.is_a?(Hash) ? category["name"] : category }
+    ].flatten.compact.uniq
+  end
+
+  def file_urls_from(design)
+    [
+      image_urls_from(design),
+      download_url_from(design)
+    ].flatten.compact
+  end
+
+  def image_urls_from(design)
+    urls = [
+      design["coverUrl"],
+      design["cover"],
+      design["thumbnail"],
+      Array.wrap(design["pictures"]).filter_map { |picture| picture.is_a?(Hash) ? (picture["url"] || picture["imageUrl"]) : picture },
+      Array.wrap(design["images"]).filter_map { |image| image.is_a?(Hash) ? (image["url"] || image["imageUrl"]) : image }
+    ].flatten.compact.uniq
+
+    urls.filter_map { |url| {url: url, filename: File.join("images", filename_from_url(url))} if filename_from_url(url).present? }
+  end
+
+  def download_url_from(design)
+    return unless download_configured?
+
+    profile_id = selected_profile_id(design)
+    model_id = design["modelId"]
+    return if profile_id.blank? || model_id.blank?
+
+    manifest = fetch_download(profile_id: profile_id, model_id: model_id).body
+    url = manifest["url"]
+    return if url.blank?
+
+    filename = manifest["filename"].presence || manifest["name"].presence || "#{design["title"].presence || "makerworld-#{@model_id}"}.3mf"
+    {url: url, filename: File.join("files", File.basename(CGI.unescape(filename)))}
+  end
+
+  def preview_filename_from(design)
+    url = design["coverUrl"] || design["cover"] || design["thumbnail"]
+    File.join("images", filename_from_url(url)) if filename_from_url(url).present?
+  end
+
+  def license_from(design)
+    license = design["license"]
+    value = design.dig("licenseInfo", "spdxId")
+    value ||= license["spdxId"] if license.is_a?(Hash)
+    value ||= license
+    value if value.is_a?(String) && value.match?(/\A[A-Za-z0-9.-]+\z/)
+  end
+
+  def creator_attributes(design)
+    creator = creator_from(design)
+    return {} unless creator.is_a?(Hash)
+
+    name = creator_name(creator)
+    return {} if name.blank?
+
+    attributes = {
+      name: name,
+      slug: name.parameterize
+    }
+    url = creator_url(creator)
+    attributes[:links_attributes] = [{url: url}] if url.present?
+    attempt_creator_match(attributes)
+  end
+
+  def creator_from(design)
+    design["designer"] || design["user"] || design["creator"]
+  end
+
+  def creator_name(creator)
+    creator["name"] || creator["nickname"] || creator["handle"] || creator["userName"]
+  end
+
+  def creator_url(creator)
+    creator["profileUrl"] || creator["url"] || creator_handle_url(creator)
+  end
+
+  def creator_handle_url(creator)
+    handle = creator["handle"] || creator["userName"]
+    "https://makerworld.com/en/@#{handle}" if handle.present?
+  end
+end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -41,6 +41,7 @@ class Link < ApplicationRecord
     [
       Integrations::Cults3d::CreatorDeserializer,
       Integrations::Cults3d::ModelDeserializer,
+      Integrations::MakerWorld::ModelDeserializer,
       Integrations::MyMiniFactory::CreatorDeserializer,
       Integrations::MyMiniFactory::CollectionDeserializer,
       Integrations::MyMiniFactory::ModelDeserializer,

--- a/app/models/site_settings.rb
+++ b/app/models/site_settings.rb
@@ -56,6 +56,7 @@ class SiteSettings < RailsSettings::Base
   field :thingiverse_api_key, type: :string
   field :cults3d_api_key, type: :string
   field :cults3d_api_username, type: :string
+  field :makerworld_bambu_token, type: :string
 
   validates :model_ignored_files, regex_array: {strict: true}
 

--- a/app/views/imports/new.html.erb
+++ b/app/views/imports/new.html.erb
@@ -34,6 +34,7 @@
             <h5><%= t ".supported_sites" %></h5>
             <ul class="list-unstyled">
               <li><%= ((SiteSettings.cults3d_api_key.present? && SiteSettings.cults3d_api_username.present?) ? "✅" : "❌") %> <%= t "sites.cults3d" %></li>
+              <li>✅ <%= t "sites.makerworld" %> <%= SiteSettings.makerworld_bambu_token.present? ? "" : t(".metadata_only") %></li>
               <li><%= (SiteSettings.myminifactory_api_key.present? ? "✅" : "❌") %> <%= t "sites.myminifactory" %></li>
               <li><%= (SiteSettings.thingiverse_api_key.present? ? "✅" : "❌") %> <%= t "sites.thingiverse" %></li>
             </ul>

--- a/app/views/settings/integrations.html.erb
+++ b/app/views/settings/integrations.html.erb
@@ -15,6 +15,11 @@
       <%= text_input_row form, "integrations[myminifactory_api_key]", label: t(".myminifactory_api_key.label"), value: SiteSettings.myminifactory_api_key, help: t(".myminifactory_api_key.help_html") %>
     </div>
   <% end %>
+  <%= Accordion(title: [t("sites.makerworld"), (SiteSettings.makerworld_bambu_token.present? ? "✅" : "⚠️")].join(" "), id: "makerworld-integration") do %>
+    <div class="tabular-form">
+      <%= text_input_row form, "integrations[makerworld_bambu_token]", label: t(".makerworld_bambu_token.label"), value: SiteSettings.makerworld_bambu_token, help: t(".makerworld_bambu_token.help_html") %>
+    </div>
+  <% end %>
   <%= Accordion(title: [t("sites.thingiverse"), (SiteSettings.thingiverse_api_key.present? ? "✅" : "❌")].join(" "), id: "thingiverse-integration") do %>
     <div class="tabular-form">
       <%= text_input_row form, "integrations[thingiverse_api_key]", label: t(".thingiverse_api_key.label"), value: SiteSettings.thingiverse_api_key, help: t(".thingiverse_api_key.help_html") %>

--- a/config/locales/cs.yml
+++ b/config/locales/cs.yml
@@ -876,6 +876,7 @@ cs:
       import_capabilities:
       import_type_html:
       integration_settings:
+      metadata_only:
       placeholder:
       submit:
       supported_sites:

--- a/config/locales/de.yml
+++ b/config/locales/de.yml
@@ -878,6 +878,7 @@ de:
       import_capabilities: Wir können Modelle, Ersteller und Sammlungen von verschiedenen anderen Hosting-Sites importieren. Was genau wir für deine URL importieren können, wird angezeigt, nachdem Du sie eingegeben hast.
       import_type_html: "<code>%{url}</code> wird als neue %{object_type} hinzugefügt. Die folgenden Daten können automatisch importiert werden:"
       integration_settings: Integrationseinstellungen bearbeiten
+      metadata_only:
       placeholder: Füge die Adresse des Inhalts ein, den du importieren möchtest (z. B. https://thingiverse.com/thing:1234)
       submit: Importieren
       supported_sites: Unterstützte Seiten

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -876,7 +876,8 @@ en:
       import_capabilities: We can import models, creators and collections from various other hosting sites. Exactly what we can import for your URL will be displayed after you enter it.
       import_type_html: "<code>%{url}</code> will be added as a new %{object_type}. The following data can be imported automatically:"
       integration_settings: Edit integration settings
-      placeholder: Paste the address of the content you want to import (e.g. https://thingiverse.com/thing:1234)
+      metadata_only: (metadata only)
+      placeholder: Paste the address of the content you want to import (e.g. https://makerworld.com/models/1234)
       submit: Import
       supported_sites: Supported sites
   jobs:

--- a/config/locales/es.yml
+++ b/config/locales/es.yml
@@ -876,6 +876,7 @@ es:
       import_capabilities: Podemos importar modelos, creadores y colecciones de MyMiniFactory, Thingiverse y Cults3D. Lo que podemos importar exactamente para tu URL se mostrará después de que la introduzcas.
       import_type_html: "[<code>%{url}]</code> se añadirá como un nuevo %{object_type}. Los siguientes datos pueden importarse automáticamente:"
       integration_settings: Editar los ajustes de integración
+      metadata_only:
       placeholder: Pegue la dirección del contenido que desea importar (por ejemplo, https://thingiverse.com/thing:1234)
       submit: Importar
       supported_sites: Sitios compatibles

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -878,6 +878,7 @@ fr:
       import_capabilities:
       import_type_html:
       integration_settings:
+      metadata_only:
       placeholder:
       submit: Importer
       supported_sites: Sites soutenus

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -876,6 +876,7 @@ ja:
       import_capabilities:
       import_type_html:
       integration_settings:
+      metadata_only:
       placeholder:
       submit:
       supported_sites:

--- a/config/locales/nl.yml
+++ b/config/locales/nl.yml
@@ -876,6 +876,7 @@ nl:
       import_capabilities:
       import_type_html:
       integration_settings:
+      metadata_only:
       placeholder:
       submit:
       supported_sites:

--- a/config/locales/pl.yml
+++ b/config/locales/pl.yml
@@ -876,6 +876,7 @@ pl:
       import_capabilities:
       import_type_html:
       integration_settings:
+      metadata_only:
       placeholder:
       submit:
       supported_sites:

--- a/config/locales/pt.yml
+++ b/config/locales/pt.yml
@@ -876,6 +876,7 @@ pt:
       import_capabilities:
       import_type_html:
       integration_settings:
+      metadata_only:
       placeholder:
       submit:
       supported_sites:

--- a/config/locales/ru.yml
+++ b/config/locales/ru.yml
@@ -876,6 +876,7 @@ ru:
       import_capabilities:
       import_type_html:
       integration_settings:
+      metadata_only:
       placeholder:
       submit:
       supported_sites:

--- a/config/locales/settings/cs.yml
+++ b/config/locales/settings/cs.yml
@@ -105,6 +105,9 @@ cs:
       myminifactory_api_key:
         help_html:
         label:
+      makerworld_bambu_token:
+        help_html:
+        label:
       thingiverse_api_key:
         help_html:
         label:

--- a/config/locales/settings/de.yml
+++ b/config/locales/settings/de.yml
@@ -109,6 +109,9 @@ de:
       myminifactory_api_key:
         help_html: Erstelle eine Anwendung in den <a href="https://www.myminifactory.com/settings/developer">Entwicklereinstellungen von MyMiniFactory</a>und füge den erzeugten API-Schlüssel hier ein.
         label: API-Schlüssel
+      makerworld_bambu_token:
+        help_html:
+        label:
       thingiverse_api_key:
         help_html: Erstelle eine "Web App" in der <a href="https://www.thingiverse.com/developers/my-apps">Entwicklerkonsole von Thingiverse</a>und füge den App Token hier ein.
         label: API-Schlüssel

--- a/config/locales/settings/en.yml
+++ b/config/locales/settings/en.yml
@@ -105,6 +105,9 @@ en:
       myminifactory_api_key:
         help_html: Create an application in the <a href="https://www.myminifactory.com/settings/developer">MyMiniFactory developer settings</a>, and paste in the generated API key.
         label: API key
+      makerworld_bambu_token:
+        help_html: Paste a Bambu Cloud bearer token. MakerWorld metadata works without this, but downloading 3MF files requires it. To get a token, sign in to MakerWorld in your browser, open developer tools, go to Application/Storage, then Cookies for <code>makerworld.com</code>, and copy the value of the <code>token</code> cookie. Treat this token like a password.
+        label: Bambu Cloud token
       thingiverse_api_key:
         help_html: Create a "web app" in the <a href="https://www.thingiverse.com/developers/my-apps">Thingiverse developer console</a>, and paste the "app token" here.
         label: API key

--- a/config/locales/settings/es.yml
+++ b/config/locales/settings/es.yml
@@ -105,6 +105,9 @@ es:
       myminifactory_api_key:
         help_html: Cree una aplicación en la <a href="https://www.myminifactory.com/settings/developer">configuración de desarrollador de MyMiniFactory</a> y pegue la clave de API generada.
         label: Clave API
+      makerworld_bambu_token:
+        help_html:
+        label:
       thingiverse_api_key:
         help_html: Cree una "aplicación web" en la <a href="https://www.thingiverse.com/developers/my-apps">consola de desarrollador de Thingiverse</a> y pegue aquí el "token de aplicación".
         label: Clave API

--- a/config/locales/settings/fr.yml
+++ b/config/locales/settings/fr.yml
@@ -105,6 +105,9 @@ fr:
       myminifactory_api_key:
         help_html:
         label: Clé API
+      makerworld_bambu_token:
+        help_html:
+        label:
       thingiverse_api_key:
         help_html:
         label: Clé API

--- a/config/locales/settings/ja.yml
+++ b/config/locales/settings/ja.yml
@@ -105,6 +105,9 @@ ja:
       myminifactory_api_key:
         help_html:
         label:
+      makerworld_bambu_token:
+        help_html:
+        label:
       thingiverse_api_key:
         help_html:
         label:

--- a/config/locales/settings/nl.yml
+++ b/config/locales/settings/nl.yml
@@ -105,6 +105,9 @@ nl:
       myminifactory_api_key:
         help_html:
         label:
+      makerworld_bambu_token:
+        help_html:
+        label:
       thingiverse_api_key:
         help_html:
         label:

--- a/config/locales/settings/pl.yml
+++ b/config/locales/settings/pl.yml
@@ -105,6 +105,9 @@ pl:
       myminifactory_api_key:
         help_html:
         label:
+      makerworld_bambu_token:
+        help_html:
+        label:
       thingiverse_api_key:
         help_html:
         label:

--- a/config/locales/settings/pt.yml
+++ b/config/locales/settings/pt.yml
@@ -105,6 +105,9 @@ pt:
       myminifactory_api_key:
         help_html:
         label:
+      makerworld_bambu_token:
+        help_html:
+        label:
       thingiverse_api_key:
         help_html:
         label:

--- a/config/locales/settings/ru.yml
+++ b/config/locales/settings/ru.yml
@@ -105,6 +105,9 @@ ru:
       myminifactory_api_key:
         help_html:
         label:
+      makerworld_bambu_token:
+        help_html:
+        label:
       thingiverse_api_key:
         help_html:
         label:

--- a/config/locales/settings/zh-CN.yml
+++ b/config/locales/settings/zh-CN.yml
@@ -105,6 +105,9 @@ zh-CN:
       myminifactory_api_key:
         help_html: 在 <a href="https://www.myminifactory.com/settings/developer">MyMiniFactory 开发人员设置</a> 中创建应用程序，并粘贴生成的 API 密钥。
         label: API 密钥
+      makerworld_bambu_token:
+        help_html:
+        label:
       thingiverse_api_key:
         help_html: 在 <a href="https://www.thingiverse.com/developers/my-apps">Thingiverse 开发者控制台</a> 创建一个 "网络应用程序"，并在此粘贴 "应用程序令牌"。
         label: API 密钥

--- a/config/locales/zh-CN.yml
+++ b/config/locales/zh-CN.yml
@@ -876,6 +876,7 @@ zh-CN:
       import_capabilities: 我们可以从其它托管网站导入模型、创建者和收藏。您输入网址后，将显示可以导入的内容。
       import_type_html: "<code>%{url}</code> 将被添加为新的 %{object_type}。可自动导入以下数据："
       integration_settings: 编辑集成设置
+      metadata_only:
       placeholder: 粘贴要导入内容的地址（如 https://thingiverse.com/thing:1234）
       submit: 导入
       supported_sites: 支持的网站

--- a/spec/deserializers/integrations/maker_world/model_deserializer_spec.rb
+++ b/spec/deserializers/integrations/maker_world/model_deserializer_spec.rb
@@ -1,0 +1,156 @@
+require "rails_helper"
+
+RSpec.describe Integrations::MakerWorld::ModelDeserializer do
+  include WebMock::API
+
+  let(:uri) { "https://makerworld.com/en/models/1400373-example-model#profileId-1452154" }
+  let(:design_url) { "https://api.bambulab.com/v1/design-service/design/1400373" }
+  let(:download_url) { "https://api.bambulab.com/v1/iot-service/api/user/profile/298919107?model_id=US2bb73b106683e5" }
+  let(:signed_url) { "https://makerworld.bblmw.com/makerworld/model/example.3mf?at=1&exp=2&key=signed" }
+  let(:design_body) do
+    {
+      title: "Stackable Painting Cone",
+      summary: "A small shop helper.",
+      modelId: "US2bb73b106683e5",
+      coverUrl: "https://makerworld.bblmw.com/makerworld/model/cover.png",
+      tags: [{name: "shop"}, {tagName: "painting"}],
+      categories: [{name: "Tools"}],
+      license: {spdxId: "CC-BY-4.0"},
+      designer: {
+        name: "Created Workshop",
+        handle: "createdworkshop"
+      },
+      instances: [
+        {id: 1452154, profileId: 298919107}
+      ]
+    }.to_json
+  end
+
+  before do
+    stub_request(:get, design_url).to_return(status: 200, body: design_body, headers: {"Content-Type" => "application/json"})
+  end
+
+  context "when creating from URI" do
+    it "accepts model URIs and canonicalizes them" do # rubocop:disable RSpec/MultipleExpectations
+      deserializer = described_class.new(uri: uri)
+      expect(deserializer).to be_valid
+      expect(deserializer.uri).to eq "https://makerworld.com/models/1400373#profileId-1452154"
+    end
+
+    it "accepts scheme-less MakerWorld URIs" do # rubocop:disable RSpec/MultipleExpectations
+      deserializer = described_class.new(uri: "makerworld.com/models/1400373")
+      expect(deserializer).to be_valid
+      expect(deserializer.uri).to eq "https://makerworld.com/models/1400373"
+    end
+
+    it "rejects non-model URIs" do
+      deserializer = described_class.new(uri: "https://makerworld.com/en/@createdworkshop")
+      expect(deserializer).not_to be_valid
+    end
+
+    it "extracts model and profile IDs" do # rubocop:disable RSpec/MultipleExpectations
+      deserializer = described_class.new(uri: uri)
+      expect(deserializer.model_id).to eq "1400373"
+      expect(deserializer.profile_id).to eq "1452154"
+    end
+  end
+
+  context "when pulling data from API" do
+    subject(:deserialized) { described_class.new(uri: uri).deserialize }
+
+    it "extracts metadata" do # rubocop:disable RSpec/ExampleLength
+      expect(deserialized).to include(
+        name: "Stackable Painting Cone",
+        slug: "stackable-painting-cone",
+        notes: "A small shop helper.",
+        tag_list: contain_exactly("shop", "painting", "Tools"),
+        license: "CC-BY-4.0"
+      )
+    end
+
+    it "handles string license values" do # rubocop:disable RSpec/ExampleLength
+      stub_request(:get, design_url).to_return(
+        status: 200,
+        body: JSON.parse(design_body).merge("license" => "CC-BY-NC-SA-4.0").to_json,
+        headers: {"Content-Type" => "application/json"}
+      )
+
+      expect(deserialized[:license]).to eq "CC-BY-NC-SA-4.0"
+    end
+
+    it "extracts image info" do # rubocop:disable RSpec/MultipleExpectations
+      expect(deserialized[:file_urls]).to include({
+        url: "https://makerworld.bblmw.com/makerworld/model/cover.png",
+        filename: "images/cover.png"
+      })
+      expect(deserialized[:preview_filename]).to eq "images/cover.png"
+    end
+
+    it "adds new creator if missing" do
+      expect(deserialized[:creator_attributes]).to include({
+        name: "Created Workshop",
+        slug: "created-workshop",
+        links_attributes: [{url: "https://makerworld.com/en/@createdworkshop"}]
+      })
+    end
+
+    it "matches existing creator" do
+      creator = create(:creator, links_attributes: [{url: "https://makerworld.com/en/@createdworkshop"}])
+      expect(deserialized[:creator]).to eq creator
+    end
+  end
+
+  context "without a Bambu token" do
+    before do
+      allow(SiteSettings).to receive(:makerworld_bambu_token).and_return(nil)
+    end
+
+    it "is metadata-only" do # rubocop:disable RSpec/MultipleExpectations
+      deserializer = described_class.new(uri: uri)
+      expect(deserializer.capabilities[:model_files]).to be false
+      expect(deserializer.deserialize[:file_urls]).not_to include(hash_including(filename: end_with(".3mf")))
+    end
+  end
+
+  context "with a Bambu token" do
+    before do
+      allow(SiteSettings).to receive(:makerworld_bambu_token).and_return("token-123")
+      stub_request(:get, download_url)
+        .with(headers: {"Authorization" => "Bearer token-123"})
+        .to_return(
+          status: 200,
+          body: {url: signed_url, filename: "Stackable%20Painting%20Cone.3mf", name: "Profile title"}.to_json,
+          headers: {"Content-Type" => "application/json"}
+        )
+    end
+
+    it "adds a signed 3MF URL" do # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+      deserializer = described_class.new(uri: uri)
+      expect(deserializer.capabilities[:model_files]).to be true
+      expect(deserializer.deserialize[:file_urls]).to include({
+        url: signed_url,
+        filename: "files/Stackable Painting Cone.3mf"
+      })
+    end
+  end
+
+  context "with a valid URI" do
+    it "deserializes to a Model" do
+      expect(described_class.new(uri: uri).capabilities[:class]).to eq Model
+    end
+
+    it "is valid for deserialization to Model" do
+      expect(described_class.new(uri: uri).valid?(for_class: Model)).to be true
+    end
+
+    it "is not valid for deserialization to Creator" do
+      expect(described_class.new(uri: uri).valid?(for_class: Creator)).to be false
+    end
+
+    it "is created for this URI by a link object" do # rubocop:disable RSpec/MultipleExpectations
+      deserializer = create(:link, url: uri, linkable: create(:model)).deserializer
+      expect(deserializer).to be_a(described_class)
+      expect(deserializer).to be_valid
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add a MakerWorld importer for model URLs, including metadata, preview image, creator, tags, license, and profile-aware 3MF download support
- add an optional MakerWorld Bambu Cloud token setting with in-app instructions for getting your own token from the MakerWorld browser session
- show MakerWorld in the import UI, including a metadata-only state when no token is configured

## Testing
- `bundle exec rspec spec/deserializers/integrations/maker_world/model_deserializer_spec.rb spec/models/link_spec.rb spec/requests/imports_spec.rb`
- `bundle exec rubocop app/deserializers/integrations/maker_world/base_deserializer.rb app/deserializers/integrations/maker_world/model_deserializer.rb app/models/link.rb app/models/model_file.rb app/models/site_settings.rb app/controllers/settings_controller.rb spec/deserializers/integrations/maker_world/model_deserializer_spec.rb`
- live smoke test on a self-hosted Manyfold instance: MakerWorld URL imported metadata and attached the signed 3MF file successfully before the Codacy cleanup; the PR now uses the existing Faraday/Shrine HTTP paths instead of the temporary shell-fetch fallback

## Notes
- No personal Bambu token or local deployment details are included. The tests use a fake token value only.
