### PR TITLE
Improve model upload process - redirect to model immediately and extract archives later

### DIFF
--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -60,7 +60,7 @@ class ModelFilesController < ApplicationController
       redirect_back_or_to [@model, file], notice: t(".conversion_started")
     elsif !(p = upload_params).empty?
       p.dig(:model, :file).each_pair do |_id, file|
-        ProcessUploadedFileJob.perform_later(
+        AddUploadedFileToModelJob.perform_later(
           @model.library.id,
           {
             id: file[:id],

--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -59,18 +59,8 @@ class ModelFilesController < ApplicationController
       file.convert_later params[:convert][:to]
       redirect_back_or_to [@model, file], notice: t(".conversion_started")
     elsif !(p = upload_params).empty?
-      p.dig(:model, :file).each_pair do |_id, file|
-        AddUploadedFileToModelJob.perform_later(
-          @model.id,
-          {
-            id: file[:id],
-            storage: "cache",
-            metadata: {
-              filename: Zaru.sanitize!(File.basename(file[:name]))
-            }
-          },
-          model: @model
-        )
+      p.dig(:model, :file).each_pair do |_id, tus_upload|
+        AddUploadedFileToModelJob.perform_later(@model.id, tus_upload)
       end
       respond_to do |format|
         format.html { redirect_to @model, notice: t(".success") }

--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -61,7 +61,7 @@ class ModelFilesController < ApplicationController
     elsif !(p = upload_params).empty?
       p.dig(:model, :file).each_pair do |_id, file|
         AddUploadedFileToModelJob.perform_later(
-          @model.library.id,
+          @model.id,
           {
             id: file[:id],
             storage: "cache",

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -86,7 +86,7 @@ class ModelsController < ApplicationController
     multi_model = (num_files > 1) && p[:file]&.values&.all? { is_archive?(it) }
     # Then run validations on a dummy object
     common_attributes = {
-      name: multi_model ? nil : (p[:name]&.presence || File.basename(p.dig(:file, 0, :name), ".*").careful_titleize),
+      name: multi_model ? nil : (p[:name]&.presence || File.basename(p.dig(:file, "0", :name), ".*").careful_titleize),
       owner: current_user,
       creator_id: p[:creator_id],
       collection_ids: p[:collections]&.map(&:id),

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -82,10 +82,11 @@ class ModelsController < ApplicationController
     authorize :model
     p = upload_params
     # First, is this a single or multi-model event?
-    multiple = p[:file]&.values&.all? { MediaType.archive_extensions.include? File.extname(it[:name]).delete(".").downcase }
+    num_files = p[:file].keys.count
+    multi_model = (num_files > 1) && p[:file]&.values&.all? { is_archive?(it) }
     # Then run validations on a dummy object
     common_attributes = {
-      name: multiple ? nil : p[:name],
+      name: multi_model ? nil : (p[:name]&.presence || File.basename(p.dig(:file, 0, :name), ".*").careful_titleize),
       owner: current_user,
       creator_id: p[:creator_id],
       collection_ids: p[:collections]&.map(&:id),
@@ -96,25 +97,30 @@ class ModelsController < ApplicationController
       library: SiteSettings.show_libraries ? Library.find_param(p[:library]) : Library.default
     }
     @model = Model.new(common_attributes) # dummy model object
-    if @model.valid?(multiple ? :multi_upload : :single_upload)
+    if @model.valid?(multi_model ? :multi_upload : :single_upload)
       # Create model if there's just one
-      single_model = create_model!(common_attributes) unless multiple
+      single_model = create_model!(common_attributes) unless multi_model
       # Add files
       p[:file]&.values&.each do
-        # If @model is nil, this will create a model for each file
+        # If single_model is nil, this will create a model for each file
         # otherwise they get added to the passed model
-        add_upload_to_model(tus_upload: it, model: single_model, attributes: common_attributes, auto_extract: multiple)
+        add_upload_to_model(
+          tus_upload: it,
+          model: single_model,
+          attributes: common_attributes,
+          auto_extract: multi_model || (num_files == 1 && is_archive?(it))
+        )
       end
       respond_to do |format|
         format.html do
-          if multiple
+          if multi_model
             redirect_to models_path, notice: t(".success")
           else
             redirect_to single_model, notice: t(".success")
           end
         end
         format.manyfold_api_v0 {
-          if multiple
+          if multi_model
             head :accepted
           else
             head :created, location: model_path(single_model)
@@ -306,6 +312,10 @@ class ModelsController < ApplicationController
       name: File.basename(tus_upload[:name], ".*").careful_titleize
     )
     # Add file to model
-    AddUploadedFileToModelJob.perform_later(model.id, tus_upload, auto_extract: auto_extract) if model.persisted?
+    AddUploadedFileToModelJob.perform_later(model.id, tus_upload.to_h.symbolize_keys, auto_extract: auto_extract) if model.persisted?
+  end
+
+  def is_archive?(tus_upload)
+    MediaType.archive_extensions.include? File.extname(tus_upload[:name]).delete(".").downcase
   end
 end

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -84,7 +84,7 @@ class ModelsController < ApplicationController
     # First, is this a single or multi-model event?
     multiple = p[:file]&.values&.all? { MediaType.archive_extensions.include? File.extname(it[:name]).delete(".").downcase }
     # Then run validations on a dummy object
-    common_args = {
+    common_attributes = {
       name: multiple ? nil : p[:name],
       owner: current_user,
       creator_id: p[:creator_id],
@@ -92,24 +92,27 @@ class ModelsController < ApplicationController
       license: p[:license],
       sensitive: (p[:sensitive] == "1"),
       tag_list: p[:tag_list],
-      permission_preset: p[:permission_preset]
+      permission_preset: p[:permission_preset],
+      library: SiteSettings.show_libraries ? Library.find_param(p[:library]) : Library.default
     }
-    library = SiteSettings.show_libraries ? Library.find_param(p[:library]) : Library.default
-    @model = Model.new(common_args.merge(library: library)) # dummy model object
+    @model = Model.new(common_attributes) # dummy model object
     if @model.valid?(multiple ? :multi_upload : :single_upload)
-      # Handle actual files
-      jobs = if multiple
-        # If this is all separate archives, enqueue separate jobs for each
-        p[:file]&.values&.map { cached_file_data(it) }
-      else
-        # Otherwise, enqueue one job for all files and add name to args
-        [p[:file]&.values&.map { cached_file_data(it) }]
-      end
-      jobs&.each do
-        ProcessUploadedFileJob.perform_later(library.id, it, **common_args)
+      # Create model if there's just one
+      single_model = create_model!(common_attributes) unless multiple
+      # Add files
+      p[:file]&.values&.each do
+        # If @model is nil, this will create a model for each file
+        # otherwise they get added to the passed model
+        add_upload_to_model(upload: it, model: single_model, attributes: common_attributes)
       end
       respond_to do |format|
-        format.html { redirect_to models_path, notice: t(".success") }
+        format.html do
+          if multiple
+            redirect_to models_path, notice: t(".success")
+          else
+            redirect_to single_model, notice: t(".success")
+          end
+        end
         format.manyfold_api_v0 { head :accepted }
       end
     else
@@ -292,5 +295,21 @@ class ModelsController < ApplicationController
         filename: Zaru.sanitize!(File.basename(file[:name]))
       }
     }
+  end
+
+  def create_model!(attributes, name: nil)
+    model = Model.create(attributes.merge({name: name, path: SecureRandom.uuid}.compact))
+    Model.suppressing_turbo_broadcasts { model.organize! } if model
+    model
+  end
+
+  def add_upload_to_model(upload:, model: nil, attributes: {})
+    # Create a model for this file if we've not been given one
+    model ||= create_model!(
+      attributes,
+      name: File.basename(upload["name"], ".*").careful_titleize
+    )
+    # Add file to model
+    ProcessUploadedFileJob.perform_later(model.id, cached_file_data(upload)) if model.persisted?
   end
 end

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -113,7 +113,13 @@ class ModelsController < ApplicationController
             redirect_to single_model, notice: t(".success")
           end
         end
-        format.manyfold_api_v0 { head :accepted }
+        format.manyfold_api_v0 {
+          if multiple
+            head :accepted
+          else
+            head :created, location: model_path(single_model)
+          end
+        }
       end
     else
       get_creators_and_collections

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -310,6 +310,6 @@ class ModelsController < ApplicationController
       name: File.basename(upload["name"], ".*").careful_titleize
     )
     # Add file to model
-    ProcessUploadedFileJob.perform_later(model.id, cached_file_data(upload)) if model.persisted?
+    AddUploadedFileToModelJob.perform_later(model.id, cached_file_data(upload)) if model.persisted?
   end
 end

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -103,7 +103,7 @@ class ModelsController < ApplicationController
       p[:file]&.values&.each do
         # If @model is nil, this will create a model for each file
         # otherwise they get added to the passed model
-        add_upload_to_model(upload: it, model: single_model, attributes: common_attributes, auto_extract: multiple)
+        add_upload_to_model(tus_upload: it, model: single_model, attributes: common_attributes, auto_extract: multiple)
       end
       respond_to do |format|
         format.html do
@@ -287,29 +287,19 @@ class ModelsController < ApplicationController
     end
   end
 
-  def cached_file_data(file)
-    {
-      id: file[:id],
-      storage: "cache",
-      metadata: {
-        filename: Zaru.sanitize!(File.basename(file[:name]))
-      }
-    }
-  end
-
   def create_model!(attributes, name: nil)
     model = Model.create(attributes.merge({name: name, path: SecureRandom.uuid}.compact))
     Model.suppressing_turbo_broadcasts { model.organize! } if model
     model
   end
 
-  def add_upload_to_model(upload:, model: nil, attributes: {}, auto_extract: false)
+  def add_upload_to_model(tus_upload:, model: nil, attributes: {}, auto_extract: false)
     # Create a model for this file if we've not been given one
     model ||= create_model!(
       attributes,
-      name: File.basename(upload["name"], ".*").careful_titleize
+      name: File.basename(tus_upload[:name], ".*").careful_titleize
     )
     # Add file to model
-    AddUploadedFileToModelJob.perform_later(model.id, cached_file_data(upload), auto_extract: auto_extract) if model.persisted?
+    AddUploadedFileToModelJob.perform_later(model.id, tus_upload, auto_extract: auto_extract) if model.persisted?
   end
 end

--- a/app/controllers/models_controller.rb
+++ b/app/controllers/models_controller.rb
@@ -103,7 +103,7 @@ class ModelsController < ApplicationController
       p[:file]&.values&.each do
         # If @model is nil, this will create a model for each file
         # otherwise they get added to the passed model
-        add_upload_to_model(upload: it, model: single_model, attributes: common_attributes)
+        add_upload_to_model(upload: it, model: single_model, attributes: common_attributes, auto_extract: multiple)
       end
       respond_to do |format|
         format.html do
@@ -303,13 +303,13 @@ class ModelsController < ApplicationController
     model
   end
 
-  def add_upload_to_model(upload:, model: nil, attributes: {})
+  def add_upload_to_model(upload:, model: nil, attributes: {}, auto_extract: false)
     # Create a model for this file if we've not been given one
     model ||= create_model!(
       attributes,
       name: File.basename(upload["name"], ".*").careful_titleize
     )
     # Add file to model
-    AddUploadedFileToModelJob.perform_later(model.id, cached_file_data(upload)) if model.persisted?
+    AddUploadedFileToModelJob.perform_later(model.id, cached_file_data(upload), auto_extract: auto_extract) if model.persisted?
   end
 end

--- a/app/deserializers/manyfold_api/v0/uploaded_file_deserializer.rb
+++ b/app/deserializers/manyfold_api/v0/uploaded_file_deserializer.rb
@@ -4,7 +4,7 @@ module ManyfoldApi::V0
       return unless @object
       {
         model: {
-          file: @object.dig("files")&.each_with_index.to_h.invert
+          file: @object.expect("files" => [["id", "name"]])&.each_with_index.to_h.invert
         }
       }.compact
     end

--- a/app/deserializers/manyfold_api/v0/uploaded_model_deserializer.rb
+++ b/app/deserializers/manyfold_api/v0/uploaded_model_deserializer.rb
@@ -4,7 +4,7 @@ module ManyfoldApi::V0
       return unless @object
       {
         name: @object["name"],
-        file: @object.dig("files")&.each_with_index.to_h.invert,
+        file: @object.expect("files" => [["id", "name"]])&.each_with_index.to_h.invert,
         creator_id: dereference(@object.dig("creator", "@id"), Creator)&.id,
         collections: @object["isPartOf"]&.filter_map { dereference(it["@id"], Collection) },
         license: @object.dig("spdx:license", "licenseId"),

--- a/app/jobs/README.md
+++ b/app/jobs/README.md
@@ -13,7 +13,7 @@ flowchart TD
     CA[Scan::CheckAllJob]
     CM[Scan::CheckModelJob]
     OM[OrganizeModelJob]
-    PUF[ProcessUploadedFileJob]
+    PUF[AddUploadedFileToModelJob]
     AMF[Analysis::AnalyseModelFileJob]
     FC[Analysis::FileConversionJob]
     GA[Analysis::GeometricAnalysisJob]

--- a/app/jobs/add_uploaded_file_to_model_job.rb
+++ b/app/jobs/add_uploaded_file_to_model_job.rb
@@ -1,4 +1,4 @@
-class ProcessUploadedFileJob < ApplicationJob
+class AddUploadedFileToModelJob < ApplicationJob
   include ArchiveHelpers
 
   queue_as :critical

--- a/app/jobs/add_uploaded_file_to_model_job.rb
+++ b/app/jobs/add_uploaded_file_to_model_job.rb
@@ -20,10 +20,6 @@ class AddUploadedFileToModelJob < ApplicationJob
     model.check_for_problems_later
   end
 
-  def is_archive?(file)
-    MediaType.archive_extensions.include? File.extname(file.original_filename).delete(".").downcase
-  end
-
   def add_single_file_to_model(model, file)
     # Handle different file types
     case File.extname(file.original_filename).delete(".").downcase

--- a/app/jobs/add_uploaded_file_to_model_job.rb
+++ b/app/jobs/add_uploaded_file_to_model_job.rb
@@ -3,14 +3,14 @@ class AddUploadedFileToModelJob < ApplicationJob
 
   queue_as :critical
 
-  def perform(model_id, uploaded_file)
+  def perform(model_id, uploaded_file, auto_extract: false)
     model = Model.find(model_id)
 
     file = add_single_file_to_model(model, uploaded_file)
 
     if file&.valid?
       file.parse_metadata_later
-      if file.is_archive?
+      if auto_extract && file.is_archive?
         # Automatically run extract job
         ExtractArchiveJob.perform_later(file.id, remove_when_complete: true)
       end

--- a/app/jobs/add_uploaded_file_to_model_job.rb
+++ b/app/jobs/add_uploaded_file_to_model_job.rb
@@ -9,10 +9,11 @@ class AddUploadedFileToModelJob < ApplicationJob
     file = add_single_file_to_model(model, uploaded_file)
 
     if file&.valid?
-      file.parse_metadata_later
       if auto_extract && file.is_archive?
         # Automatically run extract job
         ExtractArchiveJob.perform_later(file.id, remove_when_complete: true)
+      else
+        file.parse_metadata_later
       end
     end
 

--- a/app/jobs/add_uploaded_file_to_model_job.rb
+++ b/app/jobs/add_uploaded_file_to_model_job.rb
@@ -21,7 +21,7 @@ class AddUploadedFileToModelJob < ApplicationJob
   end
 
   def add_single_file_to_model(model, tus_upload)
-    filename = tus_upload[:name]
+    filename = sanitized_filename(tus_upload)
     # Handle different file types
     case extension(tus_upload)
     when *MediaType.indexable_extensions
@@ -36,12 +36,16 @@ class AddUploadedFileToModelJob < ApplicationJob
     end
   end
 
+  def sanitized_filename(tus_upload)
+    Zaru.sanitize!(File.basename(tus_upload[:name]))
+  end
+
   def attachment(tus_upload)
     {
       id: tus_upload[:id],
       storage: "cache",
       metadata: {
-        filename: tus_upload[:name]
+        filename: sanitized_filename(tus_upload)
       }
     }
   end

--- a/app/jobs/add_uploaded_file_to_model_job.rb
+++ b/app/jobs/add_uploaded_file_to_model_job.rb
@@ -3,10 +3,10 @@ class AddUploadedFileToModelJob < ApplicationJob
 
   queue_as :critical
 
-  def perform(model_id, uploaded_file, auto_extract: false)
+  def perform(model_id, tus_upload, auto_extract: false)
     model = Model.find(model_id)
 
-    file = add_single_file_to_model(model, uploaded_file)
+    file = add_single_file_to_model(model, tus_upload)
 
     if file&.valid?
       if auto_extract && file.is_archive?
@@ -20,18 +20,33 @@ class AddUploadedFileToModelJob < ApplicationJob
     model.check_for_problems_later
   end
 
-  def add_single_file_to_model(model, file)
+  def add_single_file_to_model(model, tus_upload)
+    filename = tus_upload[:name]
     # Handle different file types
-    case File.extname(file.original_filename).delete(".").downcase
+    case extension(tus_upload)
     when *MediaType.indexable_extensions
-      if (existing_file = model.model_files.where(filename: file.original_filename).first)
-        existing_file.update(attachment: file)
+      if (existing_file = model.model_files.where(filename: filename).first)
+        existing_file.update(attachment: attachment(tus_upload))
         existing_file
       else
-        model.model_files.create(filename: file.original_filename, attachment: file)
+        model.model_files.create(filename: filename, attachment: attachment(tus_upload))
       end
     else
-      Rails.logger.warn("Ignoring #{file.inspect}")
+      Rails.logger.warn("Ignoring #{tus_upload.inspect}")
     end
+  end
+
+  def attachment(tus_upload)
+    {
+      id: tus_upload[:id],
+      storage: "cache",
+      metadata: {
+        filename: tus_upload[:name]
+      }
+    }
+  end
+
+  def extension(tus_upload)
+    File.extname(tus_upload[:name]).delete(".").downcase
   end
 end

--- a/app/jobs/process_uploaded_file_job.rb
+++ b/app/jobs/process_uploaded_file_job.rb
@@ -3,71 +3,24 @@ class ProcessUploadedFileJob < ApplicationJob
 
   queue_as :critical
 
-  def perform(library_id, uploaded_file, name: nil, owner: nil, creator_id: nil, collection_ids: [], tag_list: nil, license: nil, model: nil, sensitive: nil, permission_preset: nil)
-    new_files = []
-    new_model = model.nil?
-    attachers = []
+  def perform(model_id, uploaded_file)
+    model = Model.find(model_id)
 
-    ActiveRecord::Base.transaction do
-      # Find library
-      library = Library.find(library_id)
-      return if library.nil?
+    file = add_single_file_to_model(model, uploaded_file)
 
-      attachers = Array.wrap(uploaded_file).map do
-        # Attach cached upload file
-        attacher = ModelFileUploader::Attacher.new
-        attacher.attach_cached(it)
-        attacher
-      end
-
-      name ||= File.basename(attachers.first.file.original_filename, ".*").humanize.tr("+", " ").careful_titleize
-      model ||= create_new_model(library, name: name, owner: owner, creator_id: creator_id, collection_ids: collection_ids, tag_list: tag_list, license: license, sensitive: sensitive, permission_preset: permission_preset)
-
-      attachers.each do
-        if new_model && (attachers.length == 1) && is_archive?(it.file)
-          # This is a single zipfile going into a new model, so automatically run extract job
-          f = add_single_file_to_model(model, it.file)
-          ExtractArchiveJob.perform_later(f.id, remove_when_complete: true) if f&.valid?
-        else
-          new_files << add_single_file_to_model(model, it.file)
-        end
+    if file&.valid?
+      file.parse_metadata_later
+      if file.is_archive?
+        # Automatically run extract job
+        ExtractArchiveJob.perform_later(file.id, remove_when_complete: true)
       end
     end
 
-    # Queue scans to fill in data or update things
-    if new_model
-      model.add_new_files_later(include_all_subfolders: true)
-    else
-      model.check_for_problems_later
-    end
-    new_files.flatten.each(&:parse_metadata_later)
-
-    attachers.each do
-      # Discard cached file
-      it.destroy
-    end
+    model.check_for_problems_later
   end
 
   def is_archive?(file)
     MediaType.archive_extensions.include? File.extname(file.original_filename).delete(".").downcase
-  end
-
-  def create_new_model(library, name: nil, owner: nil, creator_id: nil, collection_ids: [], tag_list: nil, license: nil, sensitive: nil, permission_preset: nil)
-    params = {
-      name: name,
-      path: SecureRandom.uuid,
-      creator_id: creator_id,
-      collections: collection_ids.map { Collection.find(it) },
-      tag_list: tag_list,
-      license: license,
-      sensitive: sensitive,
-      permission_preset: permission_preset,
-      owner: owner
-    }.compact_blank
-    # Create model
-    model = library.models.create!(params)
-    model.organize!
-    model
   end
 
   def add_single_file_to_model(model, file)
@@ -83,35 +36,5 @@ class ProcessUploadedFileJob < ApplicationJob
     else
       Rails.logger.warn("Ignoring #{file.inspect}")
     end
-  end
-
-  private
-
-  def unzip_into_model(model, file)
-    new_files = []
-    ModelFileUploader.with_file(file) do |archive|
-      dirname = SecureRandom.uuid
-      tmpdir = ModelFileUploader.find_storage(:cache).directory.join(dirname)
-      tmpdir.mkdir
-      strip = count_common_path_components(archive)
-      Archive::Reader.open_filename(archive.path, strip_components: strip) do |reader|
-        reader.each_entry do |entry|
-          next if !entry.file? || entry.size > SiteSettings.max_file_extract_size
-          filename = begin
-            entry.pathname.encode(Encoding::UTF_8).scrub
-          rescue EncodingError
-            entry.pathname.force_encoding(Encoding::UTF_8).scrub
-          end
-          next if SiteSettings.ignored_file?(filename)
-          reader.extract(entry, Archive::EXTRACT_SECURE, destination: tmpdir.to_s)
-          new_files << model.model_files.create(filename: filename, attachment: ModelFileUploader.uploaded_file(
-            storage: :cache,
-            id: File.join(dirname, filename),
-            metadata: {filename: File.basename(filename)}
-          ))
-        end
-      end
-    end
-    new_files
   end
 end

--- a/app/uploaders/application_uploader.rb
+++ b/app/uploaders/application_uploader.rb
@@ -65,7 +65,7 @@ class ApplicationUploader < Shrine
   end
 
   def generate_location(io, record: nil, derivative: nil, metadata: {}, **)
-    ".manyfold/#{super}"
+    (storage_key == :cache) ? super : ".manyfold/#{super}"
   end
 
   add_metadata :ctime do |io|

--- a/app/validators/stable_mime_type_validator.rb
+++ b/app/validators/stable_mime_type_validator.rb
@@ -2,7 +2,8 @@ class StableMimeTypeValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if !record.persisted? || record.attachment.nil? || value.nil?
     # i18n-tasks-use t("activerecord.errors.models.model_file.attributes.filename.cannot_change_type")
-    record.errors.add attribute, :cannot_change_type if mime(value) != mime(record.attachment.id)
+    new_filename = (record.attachment.storage_key == :cache) ? record.attachment.metadata["filename"] : record.attachment.id
+    record.errors.add attribute, :cannot_change_type if mime(value) != mime(new_filename)
   end
 
   def mime(value)

--- a/app/validators/stable_mime_type_validator.rb
+++ b/app/validators/stable_mime_type_validator.rb
@@ -1,6 +1,6 @@
 class StableMimeTypeValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
-    return if record.attachment.nil? || value.nil?
+    return if !record.persisted? || record.attachment.nil? || value.nil?
     # i18n-tasks-use t("activerecord.errors.models.model_file.attributes.filename.cannot_change_type")
     record.errors.add attribute, :cannot_change_type if mime(value) != mime(record.attachment.id)
   end

--- a/app/validators/stable_mime_type_validator.rb
+++ b/app/validators/stable_mime_type_validator.rb
@@ -2,7 +2,7 @@ class StableMimeTypeValidator < ActiveModel::EachValidator
   def validate_each(record, attribute, value)
     return if !record.persisted? || record.attachment.nil? || value.nil?
     # i18n-tasks-use t("activerecord.errors.models.model_file.attributes.filename.cannot_change_type")
-    new_filename = (record.attachment.storage_key == :cache) ? record.attachment.metadata["filename"] : record.attachment.id
+    new_filename = record.attachment.metadata["filename"] || record.attachment.id
     record.errors.add attribute, :cannot_change_type if mime(value) != mime(new_filename)
   end
 

--- a/spec/jobs/add_uploaded_file_to_model_job_spec.rb
+++ b/spec/jobs/add_uploaded_file_to_model_job_spec.rb
@@ -70,6 +70,18 @@ RSpec.describe AddUploadedFileToModelJob do
       end
     end
   end
+
+  context "when uploading a file with attempted path traversal" do
+    let(:upload) {
+      {
+        id: ModelFileUploader.upload(StringIO.new("solid\n"), "cache").id,
+        name: "../test.stl"
+      }
+    }
+
+    it "sanitizes path" do # rubocop:disable RSpec/ExampleLength
+      job.perform(model.id, upload)
+      expect(model.model_files.last.filename).to eq "test.stl"
     end
   end
 end

--- a/spec/jobs/add_uploaded_file_to_model_job_spec.rb
+++ b/spec/jobs/add_uploaded_file_to_model_job_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ProcessUploadedFileJob do
+RSpec.describe AddUploadedFileToModelJob do
   subject(:job) { described_class.new }
 
   context "when uploading a file" do

--- a/spec/jobs/add_uploaded_file_to_model_job_spec.rb
+++ b/spec/jobs/add_uploaded_file_to_model_job_spec.rb
@@ -7,34 +7,44 @@ RSpec.describe AddUploadedFileToModelJob do
   let(:model) { create(:model) }
 
   context "when uploading a file" do
-    let(:file) { Rack::Test::UploadedFile.new(StringIO.new("solid\n"), original_filename: "test.stl") }
+    let(:upload) {
+      {
+        id: ModelFileUploader.upload(StringIO.new("solid\n"), "cache").id,
+        name: "test.stl"
+      }
+    }
 
     it "adds the file to the model" do
-      expect { job.perform(model.id, file) }.to change(model.model_files, :count).by(1)
+      expect { job.perform(model.id, upload) }.to change(model.model_files, :count).by(1)
     end
 
     it "doesn't increase model count if uploading the same filename" do
       create(:model_file, model: model, filename: "test.stl")
-      expect { job.perform(model.id, file) }.not_to change(model.model_files, :count)
+      expect { job.perform(model.id, upload) }.not_to change { model.model_files.count }
     end
 
     it "overwrites existing file with the same filename" do
       create(:model_file, model: model, filename: "test.stl")
-      expect { job.perform(model.id, file) }.to change { model.model_files.first.attachment.read }.to("solid\n")
+      expect { job.perform(model.id, upload) }.to change { model.model_files.first.attachment.read }.to("solid\n")
     end
 
     it "promotes the file to proper storage" do
-      job.perform(model.id, file)
+      job.perform(model.id, upload)
       expect(model.model_files.last.attachment.storage_key).to eq :library_1
     end
 
     it "queues up file metadata parsing" do
-      expect { job.perform(model.id, file) }.to have_enqueued_job(Scan::ModelFile::ParseMetadataJob).once
+      expect { job.perform(model.id, upload) }.to have_enqueued_job(Scan::ModelFile::ParseMetadataJob).once
     end
   end
 
   context "when extracting a zip file" do
-    let(:upload) { Rack::Test::UploadedFile.new(StringIO.new, original_filename: "test.zip") }
+    let(:upload) {
+      {
+        id: ModelFileUploader.upload(StringIO.new, "cache").id,
+        name: "test.zip"
+      }
+    }
 
     it "adds file to model" do
       expect { job.perform(model.id, upload) }.to change(ModelFile, :count).by(1)

--- a/spec/jobs/add_uploaded_file_to_model_job_spec.rb
+++ b/spec/jobs/add_uploaded_file_to_model_job_spec.rb
@@ -40,12 +40,26 @@ RSpec.describe AddUploadedFileToModelJob do
       expect { job.perform(model.id, upload) }.to change(ModelFile, :count).by(1)
     end
 
-    it "queues up extraction job if told to" do
-      expect { job.perform(model.id, upload, auto_extract: true) }.to have_enqueued_job(ExtractArchiveJob).once
+    context "when autoextracting" do
+      it "queues up extraction job" do
+        expect { job.perform(model.id, upload, auto_extract: true) }.to have_enqueued_job(ExtractArchiveJob).once
+      end
+
+      it "skips file metadata parsing" do
+        expect { job.perform(model.id, upload, auto_extract: true) }.not_to have_enqueued_job(Scan::ModelFile::ParseMetadataJob)
+      end
     end
 
-    it "skips extraction job by default" do
-      expect { job.perform(model.id, upload) }.not_to have_enqueued_job(ExtractArchiveJob)
+    context "when not autoextracting" do
+      it "queues up file metadata parsing" do
+        expect { job.perform(model.id, upload) }.to have_enqueued_job(Scan::ModelFile::ParseMetadataJob).once
+      end
+
+      it "skips extraction job by default" do
+        expect { job.perform(model.id, upload) }.not_to have_enqueued_job(ExtractArchiveJob)
+      end
+    end
+  end
     end
   end
 end

--- a/spec/jobs/add_uploaded_file_to_model_job_spec.rb
+++ b/spec/jobs/add_uploaded_file_to_model_job_spec.rb
@@ -40,8 +40,12 @@ RSpec.describe AddUploadedFileToModelJob do
       expect { job.perform(model.id, upload) }.to change(ModelFile, :count).by(1)
     end
 
-    it "queues up extraction job" do
-      expect { job.perform(model.id, upload) }.to have_enqueued_job(ExtractArchiveJob).once
+    it "queues up extraction job if told to" do
+      expect { job.perform(model.id, upload, auto_extract: true) }.to have_enqueued_job(ExtractArchiveJob).once
+    end
+
+    it "skips extraction job by default" do
+      expect { job.perform(model.id, upload) }.not_to have_enqueued_job(ExtractArchiveJob)
     end
   end
 end

--- a/spec/jobs/add_uploaded_file_to_model_job_spec.rb
+++ b/spec/jobs/add_uploaded_file_to_model_job_spec.rb
@@ -3,9 +3,10 @@ require "rails_helper"
 RSpec.describe AddUploadedFileToModelJob do
   subject(:job) { described_class.new }
 
+  let(:uploader) { create(:contributor) }
+  let(:model) { create(:model) }
+
   context "when uploading a file" do
-    let(:uploader) { create(:contributor) }
-    let(:model) { create(:model) }
     let(:file) { Rack::Test::UploadedFile.new(StringIO.new("solid\n"), original_filename: "test.stl") }
 
     it "adds the file to the model" do
@@ -34,7 +35,6 @@ RSpec.describe AddUploadedFileToModelJob do
 
   context "when extracting a zip file" do
     let(:upload) { Rack::Test::UploadedFile.new(StringIO.new, original_filename: "test.zip") }
-    let(:model) { create(:model) }
 
     it "adds file to model" do
       expect { job.perform(model.id, upload) }.to change(ModelFile, :count).by(1)

--- a/spec/jobs/process_uploaded_file_job_spec.rb
+++ b/spec/jobs/process_uploaded_file_job_spec.rb
@@ -3,110 +3,45 @@ require "rails_helper"
 RSpec.describe ProcessUploadedFileJob do
   subject(:job) { described_class.new }
 
-  context "when uploading a file", :after_first_run do
+  context "when uploading a file" do
     let(:uploader) { create(:contributor) }
-    let(:library) { create(:library) }
+    let(:model) { create(:model) }
     let(:file) { Rack::Test::UploadedFile.new(StringIO.new("solid\n"), original_filename: "test.stl") }
-
-    it "Creates a new model" do
-      expect { job.perform(library.id, file) }.to change(Model, :count).by(1)
-    end
-
-    it "has no owner if no owner is explicitly set" do
-      job.perform(library.id, file)
-      expect(Model.last.owners).to be_empty
-    end
-
-    it "Sets owner permission to provided user" do
-      job.perform(library.id, file, owner: uploader)
-      expect(Model.last.owners).to include uploader
-    end
-
-    it "Sets default visibility even if a owner is provided" do
-      allow(SiteSettings).to receive(:default_viewer_role).and_return("member")
-      job.perform(library.id, file, owner: uploader)
-      expect(Model.last.permitted_roles.with_permission(:view)).to include Role.find_by(name: "member")
-    end
-
-    it "Stores creator if provided" do
-      creator = create(:creator)
-      job.perform(library.id, file, creator_id: creator.id)
-      expect(Model.last.creator).to eq creator
-    end
-
-    it "Stores collection if provided" do
-      collection = create(:collection)
-      job.perform(library.id, file, collection_ids: [collection.id])
-      expect(Model.last.collections).to include collection
-    end
-
-    it "Stores multiple collections if provided"
-
-    it "Stores license if provided" do
-      job.perform(library.id, file, license: "CC-BY-NC-SA-4.0")
-      expect(Model.last.license).to eq "CC-BY-NC-SA-4.0"
-    end
-
-    it "Stores tags if provided" do
-      job.perform(library.id, file, tag_list: "tag1, tag2, tag3")
-      expect(Model.last.tag_list).to contain_exactly("tag1", "tag2", "tag3")
-    end
-
-    it "sets path using auto-organize" do
-      job.perform(library.id, file, tag_list: "tag1")
-      m = Model.last
-      expect(m.path).to eq "tag1/test##{m.id}"
-    end
-
-    it "queues up model new file scan" do
-      expect { job.perform(library.id, file) }.to have_enqueued_job(Scan::Model::AddNewFilesJob).once
-    end
-  end
-
-  context "when uploading a file to an existing model" do
-    let(:uploader) { create(:contributor) }
-    let(:library) { create(:library) }
-    let!(:model) { create(:model, library: library) }
-    let(:file) { Rack::Test::UploadedFile.new(StringIO.new("solid\n"), original_filename: "test.stl") }
-
-    it "doesn't create a new model" do
-      expect { job.perform(library.id, file, model: model) }.not_to change(Model, :count)
-    end
 
     it "adds the file to the model" do
-      expect { job.perform(library.id, file, model: model) }.to change(model.model_files, :count).by(1)
+      expect { job.perform(model.id, file) }.to change(model.model_files, :count).by(1)
     end
 
     it "doesn't increase model count if uploading the same filename" do
       create(:model_file, model: model, filename: "test.stl")
-      expect { job.perform(library.id, file, model: model) }.not_to change(model.model_files, :count)
+      expect { job.perform(model.id, file) }.not_to change(model.model_files, :count)
     end
 
     it "overwrites existing file with the same filename" do
       create(:model_file, model: model, filename: "test.stl")
-      expect { job.perform(library.id, file, model: model) }.to change { model.model_files.first.attachment.read }.to("solid\n")
+      expect { job.perform(model.id, file) }.to change { model.model_files.first.attachment.read }.to("solid\n")
     end
 
     it "promotes the file to proper storage" do
-      job.perform(library.id, file, model: model)
+      job.perform(model.id, file)
       expect(model.model_files.last.attachment.storage_key).to eq :library_1
     end
 
     it "queues up file metadata parsing" do
-      expect { job.perform(library.id, file, model: model) }.to have_enqueued_job(Scan::ModelFile::ParseMetadataJob).once
+      expect { job.perform(model.id, file) }.to have_enqueued_job(Scan::ModelFile::ParseMetadataJob).once
     end
   end
 
   context "when extracting a zip file" do
-    let(:library) { create(:library) }
     let(:upload) { Rack::Test::UploadedFile.new(StringIO.new, original_filename: "test.zip") }
+    let(:model) { create(:model) }
 
     it "adds file to model" do
-      expect { job.perform(library.id, upload) }.to change(ModelFile, :count).by(1)
+      expect { job.perform(model.id, upload) }.to change(ModelFile, :count).by(1)
     end
 
     it "queues up extraction job" do
-      expect { job.perform(library.id, upload) }.to have_enqueued_job(ExtractArchiveJob).once
+      expect { job.perform(model.id, upload) }.to have_enqueued_job(ExtractArchiveJob).once
     end
   end
 end

--- a/spec/requests/api/v0/model_files_spec.rb
+++ b/spec/requests/api/v0/model_files_spec.rb
@@ -27,13 +27,10 @@ describe "ModelFiles", :after_first_run, :multiuser do # rubocop:disable RSpec/E
         }
 
         run_test! do # rubocop:disable RSpec/ExampleLength
-          expect(AddUploadedFileToModelJob).to have_been_enqueued.with(Library.default.id, {
+          expect(AddUploadedFileToModelJob).to have_been_enqueued.with(model.id, {
             id: "https://example.com/uploads/tus_id",
-            storage: "cache",
-            metadata: {
-              filename: "test.stl"
-            }
-          }, model: model).once
+            name: "test.stl"
+          }).once
         end
       end
 

--- a/spec/requests/api/v0/model_files_spec.rb
+++ b/spec/requests/api/v0/model_files_spec.rb
@@ -27,7 +27,7 @@ describe "ModelFiles", :after_first_run, :multiuser do # rubocop:disable RSpec/E
         }
 
         run_test! do # rubocop:disable RSpec/ExampleLength
-          expect(ProcessUploadedFileJob).to have_been_enqueued.with(Library.default.id, {
+          expect(AddUploadedFileToModelJob).to have_been_enqueued.with(Library.default.id, {
             id: "https://example.com/uploads/tus_id",
             storage: "cache",
             metadata: {

--- a/spec/requests/api/v0/models_spec.rb
+++ b/spec/requests/api/v0/models_spec.rb
@@ -115,7 +115,7 @@ describe "Models", :after_first_run, :multiuser do # rubocop:disable RSpec/Empty
           }
 
           run_test! do # rubocop:disable RSpec/ExampleLength
-            expect(ProcessUploadedFileJob).to have_been_enqueued.with(
+            expect(AddUploadedFileToModelJob).to have_been_enqueued.with(
               Library.first.id,
               [{
                 id: "https://example.com/uploads/tus_id",

--- a/spec/requests/api/v0/models_spec.rb
+++ b/spec/requests/api/v0/models_spec.rb
@@ -86,67 +86,85 @@ describe "Models", :after_first_run, :multiuser do # rubocop:disable RSpec/Empty
       end
     end
 
-    path "/models" do
-      post "Create new models from uploaded files" do
-        tags "Models"
-        consumes Mime[:manyfold_api_v0].to_s
-        produces Mime[:manyfold_api_v0].to_s
-        security [client_credentials: ["write"]]
+    post "Create new models from uploaded files" do
+      tags "Models"
+      consumes Mime[:manyfold_api_v0].to_s
+      produces Mime[:manyfold_api_v0].to_s
+      security [client_credentials: ["write"]]
 
-        parameter name: :body, in: :body, schema: ManyfoldApi::V0::UploadedModelDeserializer.schema_ref
+      parameter name: :body, in: :body, schema: ManyfoldApi::V0::UploadedModelDeserializer.schema_ref
 
-        before { create(:library) }
+      before { create(:library) }
 
-        response "202", "Accepted; the files will be processed and turned into new models" do
-          let(:Authorization) { "Bearer #{create(:oauth_access_token, scopes: "write").plaintext_token}" } # rubocop:disable RSpec/VariableName
-          let(:body) {
-            {
-              files: [
-                id: "https://example.com/uploads/tus_id",
-                name: "test.stl"
-              ],
-              "spdx:license": {
-                licenseId: "MIT"
-              },
-              name: "My New Model",
-              sensitive: true,
-              keywords: ["tag1", "tag2"]
-            }
+      response "201", "Created; a single model was created and the files will be added into it shortly" do
+        let(:Authorization) { "Bearer #{create(:oauth_access_token, scopes: "write").plaintext_token}" } # rubocop:disable RSpec/VariableName
+        let(:body) {
+          {
+            files: [{
+              id: "https://example.com/uploads/tus_id",
+              name: "test.stl"
+            }],
+            "spdx:license": {
+              licenseId: "MIT"
+            },
+            name: "My New Model",
+            sensitive: true,
+            keywords: ["tag1", "tag2"]
           }
+        }
 
-          run_test! do # rubocop:disable RSpec/ExampleLength
-            expect(AddUploadedFileToModelJob).to have_been_enqueued.with(
-              Library.first.id,
-              [{
-                id: "https://example.com/uploads/tus_id",
-                storage: "cache",
-                metadata: {
-                  filename: "test.stl"
-                }
-              }],
-              name: "My New Model",
-              owner: User.last,
-              creator_id: nil,
-              collection_ids: nil,
-              license: "MIT",
-              sensitive: true,
-              permission_preset: nil,
-              tag_list: ["tag1", "tag2"]
-            ).once
-          end
+        run_test! do # rubocop:disable RSpec/ExampleLength
+          expect(AddUploadedFileToModelJob).to have_been_enqueued.with(
+            Model.last.id,
+            {
+              id: "https://example.com/uploads/tus_id",
+              name: "test.stl"
+            },
+            auto_extract: false
+          ).once
         end
+      end
 
-        response "401", "Unauthorized; the request did not provide valid authentication details" do
-          let(:Authorization) { nil } # rubocop:disable RSpec/VariableName
+      response "202", "Accepted; multiple models were created, one for each archive, and the files will be extracted into them shortly" do
+        let(:Authorization) { "Bearer #{create(:oauth_access_token, scopes: "write").plaintext_token}" } # rubocop:disable RSpec/VariableName
+        let(:body) {
+          {
+            files: [{
+              id: "https://example.com/uploads/tus_id",
+              name: "test.zip"
+            }, {
+              id: "https://example.com/uploads/tus_id2",
+              name: "example.zip"
+            }],
+            "spdx:license": {
+              licenseId: "MIT"
+            },
+            sensitive: true,
+            keywords: ["tag1", "tag2"]
+          }
+        }
 
-          run_test!
+        run_test! do # rubocop:disable RSpec/ExampleLength
+          example_model = Model.find_by(name: "Example")
+          test_model = Model.find_by(name: "Test")
+          expect(AddUploadedFileToModelJob).to have_been_enqueued.with(
+            test_model.id, {id: "https://example.com/uploads/tus_id", name: "test.zip"}, auto_extract: true
+          ).and have_been_enqueued.with(
+            example_model.id, {id: "https://example.com/uploads/tus_id2", name: "example.zip"}, auto_extract: true
+          ).once
         end
+      end
 
-        response "403", "Forbidden; the provided credentials do not have permission to perform the requested action" do
-          let(:Authorization) { "Bearer #{create(:oauth_access_token, scopes: "").plaintext_token}" } # rubocop:disable RSpec/VariableName
+      response "401", "Unauthorized; the request did not provide valid authentication details" do
+        let(:Authorization) { nil } # rubocop:disable RSpec/VariableName
 
-          run_test!
-        end
+        run_test!
+      end
+
+      response "403", "Forbidden; the provided credentials do not have permission to perform the requested action" do
+        let(:Authorization) { "Bearer #{create(:oauth_access_token, scopes: "").plaintext_token}" } # rubocop:disable RSpec/VariableName
+
+        run_test!
       end
     end
   end

--- a/spec/requests/model_files_spec.rb
+++ b/spec/requests/model_files_spec.rb
@@ -214,7 +214,7 @@ RSpec.describe "Model Files" do
         it "queues post-upload job" do # rubocop:disable RSpec/ExampleLength
           expect { post model_model_files_path(model, params: params) }
             .to have_enqueued_job(AddUploadedFileToModelJob)
-            .with(Library.first.id, {
+            .with(model.id, {
               id: "upload_key",
               storage: "cache",
               metadata: {

--- a/spec/requests/model_files_spec.rb
+++ b/spec/requests/model_files_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe "Model Files" do
 
         it "queues post-upload job" do # rubocop:disable RSpec/ExampleLength
           expect { post model_model_files_path(model, params: params) }
-            .to have_enqueued_job(ProcessUploadedFileJob)
+            .to have_enqueued_job(AddUploadedFileToModelJob)
             .with(Library.first.id, {
               id: "upload_key",
               storage: "cache",
@@ -246,7 +246,7 @@ RSpec.describe "Model Files" do
 
         it "queues post-upload job with sanitized path" do # rubocop:disable RSpec/ExampleLength
           expect { post model_model_files_path(model, params: params) }
-            .to have_enqueued_job(ProcessUploadedFileJob)
+            .to have_enqueued_job(AddUploadedFileToModelJob)
             .with(Library.first.id, {
               id: "upload_key",
               storage: "cache",

--- a/spec/requests/model_files_spec.rb
+++ b/spec/requests/model_files_spec.rb
@@ -227,33 +227,6 @@ RSpec.describe "Model Files" do
         end
       end
 
-      context "when uploading a file with attempted path traversal" do
-        let(:params) {
-          {
-            model: {
-              file: {
-                "0" => {
-                  id: "upload_key",
-                  name: "../test.stl"
-                }
-              }
-            }
-          }
-        }
-
-        it "queues post-upload job with sanitized path" do # rubocop:disable RSpec/ExampleLength
-          expect { post model_model_files_path(model, params: params) }
-            .to have_enqueued_job(AddUploadedFileToModelJob)
-            .with(Library.first.id, {
-              id: "upload_key",
-              storage: "cache",
-              metadata: {
-                filename: "test.stl"
-              }
-            }, model: model).once
-        end
-      end
-
       it "shows an error with missing parameters" do
         post model_model_files_path(model, params: {})
         expect(response).to have_http_status(:unprocessable_content)

--- a/spec/requests/model_files_spec.rb
+++ b/spec/requests/model_files_spec.rb
@@ -216,11 +216,8 @@ RSpec.describe "Model Files" do
             .to have_enqueued_job(AddUploadedFileToModelJob)
             .with(model.id, {
               id: "upload_key",
-              storage: "cache",
-              metadata: {
-                filename: "test.stl"
-              }
-            }, model: model).once
+              name: "test.stl"
+            }).once
         end
 
         it "rate limits file uploads" do

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -659,15 +659,7 @@ RSpec.describe "Models", :after_first_run do
 
           it "enqueues processing job to add file parameters" do # rubocop:disable RSpec/ExampleLength
             post_models
-            expect(AddUploadedFileToModelJob).to have_been_enqueued.with(Model.last.id,
-              {
-                id: "upload_key",
-                storage: "cache",
-                metadata: {
-                  filename: "test.stl"
-                }
-              },
-              auto_extract: false).once
+            expect(AddUploadedFileToModelJob).to have_been_enqueued.with(Model.last.id, {id: "upload_key", name: "test.stl"}, auto_extract: false).once
           end
 
           it "redirect to model after upload" do
@@ -734,9 +726,9 @@ RSpec.describe "Models", :after_first_run do
             example_model = Model.find_by(name: "Example")
             test_model = Model.find_by(name: "Test")
             expect(AddUploadedFileToModelJob).to have_been_enqueued
-              .with(test_model.id, hash_including({metadata: {filename: "test.zip"}}), auto_extract: true).once
+              .with(test_model.id, hash_including({name: "test.zip"}), auto_extract: true).once
               .and have_been_enqueued
-              .with(example_model.id, hash_including({metadata: {filename: "example.zip"}}), auto_extract: true).once
+              .with(example_model.id, hash_including({name: "example.zip"}), auto_extract: true).once
           end
         end
 
@@ -761,9 +753,9 @@ RSpec.describe "Models", :after_first_run do
           it "enqueues a processing job for each file" do # rubocop:disable RSpec/ExampleLength
             post_models
             expect(AddUploadedFileToModelJob).to have_been_enqueued
-              .with(Model.last.id, hash_including({metadata: {filename: "test.stl"}}), auto_extract: false).once
+              .with(Model.last.id, hash_including({name: "test.stl"}), auto_extract: false).once
               .and have_been_enqueued
-              .with(Model.last.id, hash_including({metadata: {filename: "readme.txt"}}), auto_extract: false).once
+              .with(Model.last.id, hash_including({name: "readme.txt"}), auto_extract: false).once
           end
         end
 
@@ -784,9 +776,9 @@ RSpec.describe "Models", :after_first_run do
           it "enqueues jobs to add all files to the same model" do # rubocop:disable RSpec/ExampleLength
             post_models
             expect(AddUploadedFileToModelJob).to have_been_enqueued
-              .with(Model.last.id, hash_including({metadata: {filename: "test.zip"}}), auto_extract: false).once
+              .with(Model.last.id, hash_including({name: "test.zip"}), auto_extract: false).once
               .and have_been_enqueued
-              .with(Model.last.id, hash_including({metadata: {filename: "model.stl"}}), auto_extract: false).once
+              .with(Model.last.id, hash_including({name: "model.stl"}), auto_extract: false).once
           end
         end
 

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -674,25 +674,6 @@ RSpec.describe "Models", :after_first_run do
           end
         end
 
-        context "with a filename including path traversal", :as_contributor do
-          let(:files) {
-            {
-              "0" => {
-                id: "upload_key",
-                name: "../test.stl"
-              }
-            }
-          }
-
-          it "sanitizes filename" do
-            post_models
-            expect(AddUploadedFileToModelJob).to have_been_enqueued
-              .with(Model.last.id,
-                hash_including({metadata: {filename: "test.stl"}}),
-                auto_extract: false).once
-          end
-        end
-
         context "with multiple compressed files", :as_contributor do
           let(:files) {
             {

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -666,7 +666,8 @@ RSpec.describe "Models", :after_first_run do
                 metadata: {
                   filename: "test.stl"
                 }
-              }).once
+              },
+              auto_extract: false).once
           end
 
           it "redirect to model after upload" do
@@ -695,7 +696,8 @@ RSpec.describe "Models", :after_first_run do
             post_models
             expect(AddUploadedFileToModelJob).to have_been_enqueued
               .with(Model.last.id,
-                hash_including({metadata: {filename: "test.stl"}})).once
+                hash_including({metadata: {filename: "test.stl"}}),
+                auto_extract: false).once
           end
         end
 
@@ -732,9 +734,9 @@ RSpec.describe "Models", :after_first_run do
             example_model = Model.find_by(name: "Example")
             test_model = Model.find_by(name: "Test")
             expect(AddUploadedFileToModelJob).to have_been_enqueued
-              .with(test_model.id, hash_including({metadata: {filename: "test.zip"}})).once
+              .with(test_model.id, hash_including({metadata: {filename: "test.zip"}}), auto_extract: true).once
               .and have_been_enqueued
-              .with(example_model.id, hash_including({metadata: {filename: "example.zip"}})).once
+              .with(example_model.id, hash_including({metadata: {filename: "example.zip"}}), auto_extract: true).once
           end
         end
 
@@ -759,9 +761,9 @@ RSpec.describe "Models", :after_first_run do
           it "enqueues a processing job for each file" do # rubocop:disable RSpec/ExampleLength
             post_models
             expect(AddUploadedFileToModelJob).to have_been_enqueued
-              .with(Model.last.id, hash_including({metadata: {filename: "test.stl"}})).once
+              .with(Model.last.id, hash_including({metadata: {filename: "test.stl"}}), auto_extract: false).once
               .and have_been_enqueued
-              .with(Model.last.id, hash_including({metadata: {filename: "readme.txt"}})).once
+              .with(Model.last.id, hash_including({metadata: {filename: "readme.txt"}}), auto_extract: false).once
           end
         end
 
@@ -782,9 +784,9 @@ RSpec.describe "Models", :after_first_run do
           it "enqueues jobs to add all files to the same model" do # rubocop:disable RSpec/ExampleLength
             post_models
             expect(AddUploadedFileToModelJob).to have_been_enqueued
-              .with(Model.last.id, hash_including({metadata: {filename: "test.zip"}})).once
+              .with(Model.last.id, hash_including({metadata: {filename: "test.zip"}}), auto_extract: false).once
               .and have_been_enqueued
-              .with(Model.last.id, hash_including({metadata: {filename: "model.stl"}})).once
+              .with(Model.last.id, hash_including({metadata: {filename: "model.stl"}}), auto_extract: false).once
           end
         end
 

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -659,7 +659,7 @@ RSpec.describe "Models", :after_first_run do
 
           it "enqueues processing job to add file parameters" do # rubocop:disable RSpec/ExampleLength
             post_models
-            expect(ProcessUploadedFileJob).to have_been_enqueued.with(Model.last.id,
+            expect(AddUploadedFileToModelJob).to have_been_enqueued.with(Model.last.id,
               {
                 id: "upload_key",
                 storage: "cache",
@@ -693,7 +693,7 @@ RSpec.describe "Models", :after_first_run do
 
           it "sanitizes filename" do
             post_models
-            expect(ProcessUploadedFileJob).to have_been_enqueued
+            expect(AddUploadedFileToModelJob).to have_been_enqueued
               .with(Model.last.id,
                 hash_including({metadata: {filename: "test.stl"}})).once
           end
@@ -731,7 +731,7 @@ RSpec.describe "Models", :after_first_run do
             post_models
             example_model = Model.find_by(name: "Example")
             test_model = Model.find_by(name: "Test")
-            expect(ProcessUploadedFileJob).to have_been_enqueued
+            expect(AddUploadedFileToModelJob).to have_been_enqueued
               .with(test_model.id, hash_including({metadata: {filename: "test.zip"}})).once
               .and have_been_enqueued
               .with(example_model.id, hash_including({metadata: {filename: "example.zip"}})).once
@@ -758,7 +758,7 @@ RSpec.describe "Models", :after_first_run do
 
           it "enqueues a processing job for each file" do # rubocop:disable RSpec/ExampleLength
             post_models
-            expect(ProcessUploadedFileJob).to have_been_enqueued
+            expect(AddUploadedFileToModelJob).to have_been_enqueued
               .with(Model.last.id, hash_including({metadata: {filename: "test.stl"}})).once
               .and have_been_enqueued
               .with(Model.last.id, hash_including({metadata: {filename: "readme.txt"}})).once
@@ -781,7 +781,7 @@ RSpec.describe "Models", :after_first_run do
 
           it "enqueues jobs to add all files to the same model" do # rubocop:disable RSpec/ExampleLength
             post_models
-            expect(ProcessUploadedFileJob).to have_been_enqueued
+            expect(AddUploadedFileToModelJob).to have_been_enqueued
               .with(Model.last.id, hash_including({metadata: {filename: "test.zip"}})).once
               .and have_been_enqueued
               .with(Model.last.id, hash_including({metadata: {filename: "model.stl"}})).once

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -657,7 +657,7 @@ RSpec.describe "Models", :after_first_run do
             expect(model.path).to eq "tag1/tag2/only-used-for-single-model-upload##{model.id}"
           end
 
-          it "enqueues processing job to add file parameters" do # rubocop:disable RSpec/ExampleLength
+          it "enqueues processing job to add file" do # rubocop:disable RSpec/ExampleLength
             post_models
             expect(AddUploadedFileToModelJob).to have_been_enqueued.with(Model.last.id, {id: "upload_key", name: "test.stl"}, auto_extract: false).once
           end
@@ -710,6 +710,36 @@ RSpec.describe "Models", :after_first_run do
               .with(test_model.id, hash_including({name: "test.zip"}), auto_extract: true).once
               .and have_been_enqueued
               .with(example_model.id, hash_including({name: "example.zip"}), auto_extract: true).once
+          end
+
+          it "redirect to models list after upload" do
+            post_models
+            expect(response).to redirect_to("/models")
+          end
+        end
+
+        context "with a single compressed file", :as_contributor do
+          let(:files) {
+            {
+              "0" => {
+                id: "upload_1",
+                name: "test.zip"
+              }
+            }
+          }
+
+          it "creates one model" do
+            expect { post_models }.to change(Model, :count).by(1)
+          end
+
+          it "redirect to model after upload" do
+            post_models
+            expect(response).to redirect_to("/models/#{Model.last.to_param}")
+          end
+
+          it "enqueues processing job to add file" do # rubocop:disable RSpec/ExampleLength
+            post_models
+            expect(AddUploadedFileToModelJob).to have_been_enqueued.with(Model.last.id, {id: "upload_1", name: "test.zip"}, auto_extract: true).once
           end
         end
 

--- a/spec/requests/models_spec.rb
+++ b/spec/requests/models_spec.rb
@@ -609,6 +609,10 @@ RSpec.describe "Models", :after_first_run do
       end
 
       describe "POST /models" do
+        before do
+          allow(SiteSettings).to receive(:show_libraries).and_return(true)
+        end
+
         let(:creator) { create(:creator) }
         let(:collection) { create(:collection) }
         let(:post_models) {
@@ -638,30 +642,36 @@ RSpec.describe "Models", :after_first_run do
             }
           }
 
-          it "enqueues processing job with all parameters" do # rubocop:disable RSpec/ExampleLength
-            expect { post_models }
-              .to have_enqueued_job(ProcessUploadedFileJob)
-              .with(Library.first.id,
-                [{
-                  id: "upload_key",
-                  storage: "cache",
-                  metadata: {
-                    filename: "test.stl"
-                  }
-                }],
-                owner: current_user,
-                creator_id: creator.id.to_s,
-                collection_ids: [collection.id],
-                license: "MIT",
-                sensitive: true,
-                permission_preset: "public",
-                tag_list: ["tag1", "tag2"],
-                name: "Only used for single model upload").once
+          it "creates model with all the right details" do # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+            post_models
+            model = Model.find_by(name: "Only used for single model upload")
+            expect(model.library).to eq library
+            expect(model.creator).to eq creator
+            expect(model.collections).to include collection
+            expect(model.license).to eq "MIT"
+            expect(model.sensitive).to be true
+            expect(model.public?).to be true
+            expect(model.tag_list).to eq ["tag1", "tag2"]
+            expect(model.name).to eq "Only used for single model upload"
+            expect(model.owners).to include current_user
+            expect(model.path).to eq "tag1/tag2/only-used-for-single-model-upload##{model.id}"
           end
 
-          it "redirect back to index after upload" do
+          it "enqueues processing job to add file parameters" do # rubocop:disable RSpec/ExampleLength
             post_models
-            expect(response).to redirect_to("/models")
+            expect(ProcessUploadedFileJob).to have_been_enqueued.with(Model.last.id,
+              {
+                id: "upload_key",
+                storage: "cache",
+                metadata: {
+                  filename: "test.stl"
+                }
+              }).once
+          end
+
+          it "redirect to model after upload" do
+            post_models
+            expect(response).to redirect_to("/models/#{Model.last.to_param}")
           end
 
           it "rate limits model uploads" do
@@ -684,9 +694,8 @@ RSpec.describe "Models", :after_first_run do
           it "sanitizes filename" do
             post_models
             expect(ProcessUploadedFileJob).to have_been_enqueued
-              .with(Library.first.id,
-                array_including(hash_including({metadata: {filename: "test.stl"}})),
-                hash_including({})).once
+              .with(Model.last.id,
+                hash_including({metadata: {filename: "test.stl"}})).once
           end
         end
 
@@ -704,18 +713,28 @@ RSpec.describe "Models", :after_first_run do
             }
           }
 
-          it "enqueues separate archive processing jobs" do # rubocop:disable RSpec/ExampleLength
-            post_models
-            expect(ProcessUploadedFileJob).to have_been_enqueued
-              .with(Library.first.id, hash_including({metadata: {filename: "test.zip"}}), hash_including({})).once
-              .and have_been_enqueued
-              .with(Library.first.id, hash_including({metadata: {filename: "example.zip"}}), hash_including({})).once
+          it "creates two models" do
+            expect { post_models }.to change(Model, :count).by(2)
           end
 
-          it "does not provide model name field" do # rubocop:disable RSpec/ExampleLength
+          it "creates model named for first zip" do
             post_models
+            expect(Model.find_by(name: "Example")).to be_valid
+          end
+
+          it "creates model named for second zip" do
+            post_models
+            expect(Model.find_by(name: "Test")).to be_valid
+          end
+
+          it "enqueues separate jobs to add files to models" do # rubocop:disable RSpec/ExampleLength
+            post_models
+            example_model = Model.find_by(name: "Example")
+            test_model = Model.find_by(name: "Test")
             expect(ProcessUploadedFileJob).to have_been_enqueued
-              .with(Library.first.id, hash_including({}), hash_not_including({name: "Only for single model upload"})).twice
+              .with(test_model.id, hash_including({metadata: {filename: "test.zip"}})).once
+              .and have_been_enqueued
+              .with(example_model.id, hash_including({metadata: {filename: "example.zip"}})).once
           end
         end
 
@@ -733,21 +752,16 @@ RSpec.describe "Models", :after_first_run do
             }
           }
 
-          it "enqueues a single processing job for all files combined" do # rubocop:disable RSpec/ExampleLength
-            post_models
-            expect(ProcessUploadedFileJob).to have_been_enqueued
-              .with(Library.first.id,
-                array_including(
-                  hash_including({metadata: {filename: "test.stl"}}),
-                  hash_including({metadata: {filename: "readme.txt"}})
-                ),
-                hash_including({})).once
+          it "creates one model" do
+            expect { post_models }.to change(Model, :count).by(1)
           end
 
-          it "provides model name field" do # rubocop:disable RSpec/ExampleLength
+          it "enqueues a processing job for each file" do # rubocop:disable RSpec/ExampleLength
             post_models
             expect(ProcessUploadedFileJob).to have_been_enqueued
-              .with(Library.first.id, array_including, hash_including({name: "Only used for single model upload"}))
+              .with(Model.last.id, hash_including({metadata: {filename: "test.stl"}})).once
+              .and have_been_enqueued
+              .with(Model.last.id, hash_including({metadata: {filename: "readme.txt"}})).once
           end
         end
 
@@ -765,15 +779,12 @@ RSpec.describe "Models", :after_first_run do
             }
           }
 
-          it "enqueues one processing job for all files combined" do # rubocop:disable RSpec/ExampleLength
+          it "enqueues jobs to add all files to the same model" do # rubocop:disable RSpec/ExampleLength
             post_models
             expect(ProcessUploadedFileJob).to have_been_enqueued
-              .with(Library.first.id,
-                array_including(
-                  hash_including({metadata: {filename: "test.zip"}}),
-                  hash_including({metadata: {filename: "model.stl"}})
-                ),
-                hash_including({})).once
+              .with(Model.last.id, hash_including({metadata: {filename: "test.zip"}})).once
+              .and have_been_enqueued
+              .with(Model.last.id, hash_including({metadata: {filename: "model.stl"}})).once
           end
         end
 


### PR DESCRIPTION
Now, instead of doing all the work in the background, models are created immediately during the request cycle. Then, in the background, the uploaded files are added. If the uploaded file was an archive, it will be extracted in the background as well after being stored in the model.

The change for the user experience should be that if uploading a single model (either as a zip or as files), they should go straight to it and then see files pop in live as they're added.

Resolves #5785
Resolves #6293 