### PR TITLE
Solution (#3822): Allow or block registrations based on IP address

### DIFF
--- a/path/to/Gemfile
+++ b/path/to/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gem 'rack-ip', '~> 1.0'

--- a/path/to/app/controllers/users/registrations_controller.rb
+++ b/path/to/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,28 @@
+# Registrations controller
+#
+# This controller handles user registrations.
+#
+# Requirements:
+# - rack-ip gem
+#
+# Usage:
+# - Add this controller to your Rails application.
+# - Configure the whitelist or blacklist in the `config/initializers/whitelist.rb` or `config/initializers/blacklist.rb` files.
+
+class UsersController::RegistrationsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    # Get the user's IP address
+    ip_address = request.env['HTTP_X_FORWARDED_FOR'] || request.env['REMOTE_ADDR']
+
+    # Check if the IP address is in the whitelist or blacklist
+    if config.rack_ip.whitelist.include?(ip_address) || !config.rack_ip.blacklist.include?(ip_address)
+      # Allow registration
+      super
+    else
+      # Block registration
+      render json: { error: 'Registration blocked due to IP address restrictions' }, status: :forbidden
+    end
+  end
+end

--- a/path/to/config/initializers/blacklist.rb
+++ b/path/to/config/initializers/blacklist.rb
@@ -1,0 +1,18 @@
+# Blacklist initializer
+#
+# This initializer defines a blacklist of blocked IP addresses.
+#
+# Requirements:
+# - None
+#
+# Usage:
+# - Add this initializer to your Rails application.
+# - Configure the blacklist in this file.
+#
+# Example:
+#   - Block registrations from IP addresses in the blacklist:
+#     config.rack_ip.blacklist = ['192.168.1.3', '192.168.1.4']
+
+Manyfold::RackIp.configure do |config|
+  config.rack_ip.blacklist = ['192.168.1.3', '192.168.168.4']
+end

--- a/path/to/config/initializers/rack_ip.rb
+++ b/path/to/config/initializers/rack_ip.rb
@@ -1,0 +1,26 @@
+# Rack IP initializer
+#
+# This initializer configures Rack IP to block or allow registrations based on IP address.
+#
+# Requirements:
+# - rack-ip gem
+#
+# Usage:
+# - Add this initializer to your Rails application.
+# - Configure the whitelist or blacklist in the `config/initializers/whitelist.rb` or `config/initializers/blacklist.rb` files.
+#
+# Example:
+#   - Allow registrations from IP addresses in the whitelist:
+#     config.rack_ip.whitelist = ['192.168.1.1', '192.168.1.2']
+#   - Block registrations from IP addresses in the blacklist:
+#     config.rack_ip.blacklist = ['192.168.1.3', '192.168.1.4']
+
+require 'rack/ip'
+
+module Manyfold
+  class RackIp
+    def self.configure(app)
+      app.config.rack_ip = Rack::IP.new(app.config.rack_ip)
+    end
+  end
+end

--- a/path/to/config/initializers/whitelist.rb
+++ b/path/to/config/initializers/whitelist.rb
@@ -1,0 +1,18 @@
+# Whitelist initializer
+#
+# This initializer defines a whitelist of allowed IP addresses.
+#
+# Requirements:
+# - None
+#
+# Usage:
+# - Add this initializer to your Rails application.
+# - Configure the whitelist in this file.
+#
+# Example:
+#   - Allow registrations from IP addresses in the whitelist:
+#     config.rack_ip.whitelist = ['192.168.1.1', '192.168.1.2']
+
+Manyfold::RackIp.configure do |config|
+  config.rack_ip.whitelist = ['192.168.1.1', '192.168.1.2']
+end


### PR DESCRIPTION
This pull request adds the rack-ip gem to the project and implements a whitelist/blacklist system to allow/block registrations based on IP address. To test this feature, configure the whitelist or blacklist in the `config/initializers/whitelist.py` or `config/initializers/blacklist.py` files and test with valid and invalid IP addresses. Run the tests to ensure that the feature is working correctly.