### PR TITLE
Improve wording of archive extraction behaviour on upload page

### DIFF
--- a/config/locales/models/en.yml
+++ b/config/locales/models/en.yml
@@ -60,7 +60,7 @@ en:
     merge:
       success: Models merged successfully.
     new:
-      archives-only: Upload only compressed archives (ZIP, RAR, etc), and each file will be extracted and become a separate model.
+      archives-only: Upload only compressed archives (ZIP, RAR, etc), and each archive will be extracted into a separate model.
       description: 'Add new models by uploading files! The models that are created depend on what you upload:'
       files:
         label: Select Files

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,7 +39,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@csstools/css-color-parser@npm:^4.1.10, @csstools/css-color-parser@npm:^4.1.9":
+"@csstools/css-color-parser@npm:^4.1.10":
   version: 4.1.10
   resolution: "@csstools/css-color-parser@npm:4.1.10"
   dependencies:


### PR DESCRIPTION
Resolves #6736

@benbelly this improves the help text on upload, which on re-reading, was indeed pretty unclear. It should be more obvious now that one archive becomes one model.