### PR TITLE
Fix regression in safe folder name generation

### DIFF
--- a/app/models/concerns/path_builder.rb
+++ b/app/models/concerns/path_builder.rb
@@ -35,7 +35,7 @@ module PathBuilder
     return nil if object.nil?
     (
       library.safe_folder_names ?
-      Zaru.sanitize!(object.name).downcase.tr(" ", "-") :
+      Zaru.sanitize!(object.slug) :
       Zaru.sanitize!(object.name)
     ).first(ApplicationRecord::SAFE_NAME_LENGTH[:maximum])
   end

--- a/spec/models/concerns/path_builder_spec.rb
+++ b/spec/models/concerns/path_builder_spec.rb
@@ -126,6 +126,27 @@ RSpec.describe PathBuilder do
     end
   end
 
+  context "when generating safe folder names" do
+    {
+      "Squirtle Don't Feel So Good" => "squirtle-don-t-feel-so-good",
+      "Liadan, Oracle of the Varan´az ghar" => "liadan-oracle-of-the-varan-az-ghar",
+      "Catbus (My Neighbor Totoro)" => "catbus-my-neighbor-totoro",
+      "Arugês - The Cursed" => "aruges-the-cursed",
+      "Kor’garal Bodoluk" => "kor-garal-bodoluk",
+      "Daram, the Sullen Knight" => "daram-the-sullen-knight",
+      "Apex Predator & Artemis Predators" => "apex-predator-artemis-predators",
+      "Cyberpunk - Traffic Police - Police Highway Patrol" => "cyberpunk-traffic-police-police-highway-patrol"
+    }.each_pair do |name, path|
+      context "with \"#{name}\"" do
+        let(:model) { create(:model, name: name) }
+
+        it "generates correct safe version" do
+          expect(model.formatted_path).to eq "new/#{path}##{model.id}"
+        end
+      end
+    end
+  end
+
   context "with a model in multiple collections" do
     it "uses the oldest collection with singular {collection} token" do
       c1 = create(:collection, name: "Newer Collection", created_at: 1.hour.ago)


### PR DESCRIPTION
Resolves #6625

Go back to used slug for safe folder names, but run them through Zaru as well for safety.