### PR TITLE
Update the docker tzdata to 2026c-r0

### DIFF
--- a/docker/base.dockerfile
+++ b/docker/base.dockerfile
@@ -4,7 +4,7 @@ FROM ruby:3.4.9-alpine3.24 AS base
 WORKDIR /usr/src/app
 
 RUN apk add --no-cache \
-  tzdata=2026b-r0
+  tzdata=2026c-r0
 
 RUN gem install bundler -v 2.5.23
 RUN bundle config set --local deployment 'true'


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [x] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] ~This PR will change existing database contents.~
- [ ] ~This PR introduces a breaking change to existing installations.~

## Summary

Updates tzdata in docker images to 2026c.

## Linked issues

resolves #6765

## Description of changes

As reported in #6765, tzdata 2026b appears to be out-of-date and prevents docker image building. Updating to 2026c appears to fix this.
