### PR TITLE
Allow plugins to add new "selectable" types

### DIFF
--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -213,7 +213,7 @@ class Model < ApplicationRecord
   end
 
   def valid_preview_files
-    model_files.select { it.is_image? || it.is_video? || it.has_render? || FileHandlers::Three.can_load?(it.mime_type) }
+    model_files.select { it.is_image? || it.is_video? || it.has_render? || FileHandlers::Three.can_load?(it.mime_type) || FileHandlers.handlers_for(environment: :preview_frame, mime_type: it.mime_type).any? }
   end
 
   def image_files

--- a/app/views/models/_file.html.erb
+++ b/app/views/models/_file.html.erb
@@ -43,7 +43,7 @@
                 <%= DropdownDivider() %>
               <% end %>
               <%= DropdownItem icon: "pencil-fill", label: t(".edit"), path: edit_model_model_file_path(@model, file) if policy(file).edit? %>
-              <%= DropdownItem icon: "image", label: t(".set_as_preview"), path: model_path(@model, "model[preview_file_id]": file.id), method: :patch if policy(@model).edit? && Components::Renderers::Three.supports?(file) || file.is_image? %>
+              <%= DropdownItem icon: "image", label: t(".set_as_preview"), path: model_path(@model, "model[preview_file_id]": file.id), method: :patch if policy(@model).edit? && (Components::Renderers::Three.supports?(file) || file.is_image? || FileHandlers.handlers_for(environment: :preview_frame, mime_type: file.mime_type).any?) %>
               <%= DropdownItem icon: "trash", label: t(".delete"), path: model_model_file_path(@model, file), method: :delete, confirm: translate("model_files.destroy.confirm") if policy(file).destroy? %>
             <% end %>
           </div>


### PR DESCRIPTION
This commit aims at making sure a plugin handling a new mime-type can also make sure those types can be selected as preview, both in the settings, and via the "Select as preview" button.

## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [x] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

This PR allows registered plugins to add a new filetype as "previewable", i.e. can be selected in the model settings, and can have the "Select as preview" button.

This opens the door to an HTML viewer plugin, or a Lychee plugin allowing to preview the file (I have implemented those two plugins if you want more insights)

## Description of changes

The changes are just adding a condition to the previously mentioned places by checking if a plugin can handle the provided extension.

P.S: This is my very first PR, so please be gentle :pray: 