### PR TITLE
Fix missing previews after archive extraction

### DIFF
--- a/app/jobs/extract_archive_job.rb
+++ b/app/jobs/extract_archive_job.rb
@@ -49,6 +49,10 @@ class ExtractArchiveJob < ApplicationJob
       reader.extract(entry, Archive::EXTRACT_SECURE, destination: File.join(model.library.path, model.path))
       new_file = ApplicationRecord.suppressing_turbo_broadcasts { model.model_files.find_or_create_by(filename: filename) }
       new_file.parse_metadata_later
+      # If there's no preview yet, and the new file is previewable, set it so we see something as soon as possible. Proper preview will be selected later.
+      if model.preview_file.blank?
+        model.update preview_file: new_file if FileHandlers.handlers_for(environment: :preview_frame, mime_type: new_file.mime_type).any?
+      end
     end
   end
 end

--- a/app/jobs/extract_archive_job.rb
+++ b/app/jobs/extract_archive_job.rb
@@ -8,6 +8,7 @@ class ExtractArchiveJob < ApplicationJob
     return unless file.is_archive?
 
     unzip_into_model(file)
+    file.model.parse_metadata_later
 
     if remove_when_complete
       file.delete_from_disk_and_destroy

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -213,7 +213,7 @@ class Model < ApplicationRecord
   end
 
   def valid_preview_files
-    model_files.select { it.is_image? || it.is_video? || it.has_render? || FileHandlers::Three.can_load?(it.mime_type) || FileHandlers.handlers_for(environment: :preview_frame, mime_type: it.mime_type).any? }
+    model_files.select { it.has_render? || FileHandlers.handlers_for(environment: :preview_frame, mime_type: it.mime_type).any? }
   end
 
   def image_files

--- a/spec/jobs/extract_archive_job_spec.rb
+++ b/spec/jobs/extract_archive_job_spec.rb
@@ -74,4 +74,15 @@ RSpec.describe ExtractArchiveJob do
         .to change { model_file.reload.size }
     end
   end
+
+  it "queues up metadata parsing after extraction" do # rubocop:todo RSpec/ExampleLength
+    Tempfile.create(%w[test .zip]) do |file|
+      Zip::File.open(file, create: true) do |zipfile|
+        zipfile.get_output_stream("test.stl") { |f| f.puts "solid" }
+      end
+      model_file = model.model_files.create(filename: "test.zip", attachment: Rack::Test::UploadedFile.new(file))
+      expect { described_class.perform_now(model_file.id, remove_when_complete: true) }
+        .to have_enqueued_job(Scan::Model::ParseMetadataJob).with(model.id).once
+    end
+  end
 end

--- a/spec/jobs/extract_archive_job_spec.rb
+++ b/spec/jobs/extract_archive_job_spec.rb
@@ -85,4 +85,15 @@ RSpec.describe ExtractArchiveJob do
         .to have_enqueued_job(Scan::Model::ParseMetadataJob).with(model.id).once
     end
   end
+
+  it "sets a preview file if anything becomes available" do # rubocop:todo RSpec/ExampleLength
+    Tempfile.create(%w[test .zip]) do |file|
+      Zip::File.open(file, create: true) do |zipfile|
+        zipfile.get_output_stream("test.stl") { |f| f.puts "solid" }
+      end
+      model_file = model.model_files.create(filename: "test.zip", attachment: Rack::Test::UploadedFile.new(file))
+      described_class.perform_now(model_file.id, remove_when_complete: true)
+      expect(model.reload.preview_file&.filename).to eq "test.stl"
+    end
+  end
 end


### PR DESCRIPTION
Select a preview straight away, then re-parse model metadata after complete archive extraction.