### PR TITLE
Improve file relation selector

### DIFF
--- a/app/lib/media_type.rb
+++ b/app/lib/media_type.rb
@@ -72,8 +72,6 @@ module MediaType
     end
     memo_wise :indexable_extensions
 
-    private
-
     def category_types(category)
       Mime::LOOKUP.filter { |k, v| is_in_category?(v, category) }.values
     end

--- a/app/models/model.rb
+++ b/app/models/model.rb
@@ -216,12 +216,21 @@ class Model < ApplicationRecord
     model_files.select { it.has_render? || FileHandlers.handlers_for(environment: :preview_frame, mime_type: it.mime_type).any? }
   end
 
+  def files_in_media_category(category)
+    model_files.without_special.where(
+      ModelFile.arel_table[:filename].matches_any(
+        MediaType.category_extensions(category).map { "%\\.#{Model.sanitize_sql_like(it)}" },
+        "\\"
+      )
+    )
+  end
+
   def image_files
-    model_files.select(&:is_image?)
+    files_in_media_category(:image)
   end
 
   def three_d_files
-    model_files.select(&:is_3d_model?)
+    files_in_media_category(:model)
   end
 
   def exists_on_storage?

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -301,6 +301,11 @@ class ModelFile < ApplicationRecord
     MediaType::CATEGORIES.find { |category, list| mime_type.to_sym.in? list }&.first # rubocop:disable Pundit/UsePolicyScope
   end
 
+  # Gets a list of files in the same model and category
+  def similar_files
+    model.files_in_media_category(media_category).where.not(id: id)
+  end
+
   private
 
   def rescan_duplicates

--- a/app/models/model_file.rb
+++ b/app/models/model_file.rb
@@ -297,6 +297,10 @@ class ModelFile < ApplicationRecord
     end
   end
 
+  def media_category
+    MediaType::CATEGORIES.find { |category, list| mime_type.to_sym.in? list }&.first # rubocop:disable Pundit/UsePolicyScope
+  end
+
   private
 
   def rescan_duplicates

--- a/app/views/model_files/_relationship_fields.html.erb
+++ b/app/views/model_files/_relationship_fields.html.erb
@@ -18,7 +18,7 @@
             {class: "form-control"} %>
     </td>
     <td>
-      <%= f.select :objekt_id, @model.model_files.without_special.map { [it.name_and_filename, it.public_id] },
+      <%= f.select :objekt_id, @file.similar_files.map { [it.filename, it.public_id] },
             {selected: f.object&.objekt&.public_id},
             {class: "form-control"} %>
     </td>

--- a/spec/models/model_file_spec.rb
+++ b/spec/models/model_file_spec.rb
@@ -72,6 +72,10 @@ RSpec.describe ModelFile do
       expect(part.dimensions).to eq(Mittsu::Vector3.new(10, 15, 20))
     end
 
+    it "works out media category" do
+      expect(part.media_category).to eq :model
+    end
+
     it "calculates file size when attached" do
       expect(part.size).to eq(284)
     end

--- a/spec/models/model_spec.rb
+++ b/spec/models/model_spec.rb
@@ -772,6 +772,28 @@ RSpec.describe Model do
     expect(model.file_extensions).to contain_exactly("obj", "stl")
   end
 
+  context "with files in various categories" do
+    subject(:model) { create(:model) }
+
+    before do
+      create(:model_file, model: model, filename: "model.stl")
+      create(:model_file, model: model, filename: "doc.txt")
+      create(:model_file, model: model, filename: "image.png")
+    end
+
+    it "generates list of files in model category" do
+      expect(model.files_in_media_category(:model).map(&:filename)).to contain_exactly("model.stl")
+    end
+
+    it "generates list of files in image category" do
+      expect(model.files_in_media_category(:image).map(&:filename)).to contain_exactly("image.png")
+    end
+
+    it "generates list of files in document category" do
+      expect(model.files_in_media_category(:document).map(&:filename)).to contain_exactly("doc.txt")
+    end
+  end
+
   context "when adding links" do
     let(:url) { "https://example.com" }
     let(:model) { create(:model, links_attributes: [{url: url}]) }


### PR DESCRIPTION
Reduce visual clutter by only showing filename, only show similar files, and don't show self. Part of dealing with #6922.