### PR TITLE
Split chitu file types into project and sliced file formats

### DIFF
--- a/config/initializers/register_media_types.rb
+++ b/config/initializers/register_media_types.rb
@@ -77,11 +77,12 @@ MediaType.register "application/vnd.mhd", :mha, additional_extensions: ["mhd"], 
 MediaType.register "application/vnd.nrrd", :nrrd, additional_extensions: ["nhdr"], category: :model # NRRD ("nearly raw raster data")
 MediaType.register "application/vnd.splat", :splat, category: :model # 3D Gaussian Splatting
 MediaType.register "application/vnd.spz", :spz, category: :model # Compressed 3D Gaussian Splatting
+MediaType.register "model/x-lychee", :lychee, additional_extensions: ["lys", "lyt"], category: :model
+MediaType.register "model/x-chitubox", :chitubox, category: :model
 
 # Slicer formats
 MediaType.register "text/x-gcode", :gcode, additional_extensions: ["bgcode"], category: :slicer
-MediaType.register "model/x-lychee", :lychee, additional_extensions: ["lys", "lyt"], category: :model
-MediaType.register "application/x-chitubox", :chitubox, additional_extensions: ["ctb", "cbddlp"], category: :slicer
+MediaType.register "application/x-chitu-slices", :ctb, additional_extensions: ["cbddlp"], category: :slicer
 MediaType.register "application/x-prusa-sl1", :sl1, additional_extensions: ["sl1s"], category: :slicer
 MediaType.register "application/x-phrozen", :prz, additional_extensions: ["phz"], category: :slicer
 MediaType.register "application/x-photon", :photon, additional_extensions: ["photons"], category: :slicer

--- a/spec/lib/media_type_spec.rb
+++ b/spec/lib/media_type_spec.rb
@@ -71,8 +71,8 @@ RSpec.describe MediaType do
   end
 
   context "when indexing slicer files" do
-    it "includes Chitubox files" do # rubocop:todo RSpec/MultipleExpectations
-      expect(described_class.indexable_types).to include("application/x-chitubox")
+    it "includes sliced Chitu files" do # rubocop:todo RSpec/MultipleExpectations
+      expect(described_class.indexable_types).to include("application/x-chitu-slices")
       expect(described_class.indexable_extensions).to include("cbddlp")
     end
 


### PR DESCRIPTION
Previously, this treated chitubox files the same as ctb/cbddlp, but that's not right, it's a project file like lychee.