### PR TITLE
Pin footer to viewport bottom on short pages

### DIFF
--- a/app/frontend/stylesheets/src/layout.scss
+++ b/app/frontend/stylesheets/src/layout.scss
@@ -14,3 +14,17 @@
 	overflow-y: hidden;
 	position: relative;
 }
+
+// Sticky footer: make the body a full-height flex column so the footer is
+// pinned to the bottom of the viewport. When the main content is short, the
+// empty space is absorbed by #content (which grows) instead of the footer
+// stretching or leaving a gap below it.
+body {
+	display: flex;
+	flex-direction: column;
+	min-height: 100vh;
+}
+
+#content {
+	flex: 1 0 auto;
+}


### PR DESCRIPTION
## Checklist

🚨 Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository. 🚨

- [x] Make sure you are making a pull request against our **main branch** (left side)
- [x] Check that that your branch is up to date with our main.
- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request *your* main!
- [x] Check that the tests and code linter both pass.
- [x] If you're a new contributor, please sign our [contributor license agreement](https://cla-assistant.io/manyfold3d/manyfold).

## Warnings

- [ ] This PR will change existing database contents.
- [ ] This PR introduces a breaking change to existing installations.

## Summary

On pages where the main content is mostly empty, the footer sat immediately after the content and left a large empty gap below it.

## Linked issues

None.

## Description of changes

Footer is pinned to the bottom of the viewport; the empty space on short pages is absorbed by the main content area instead of the footer
