### PR TITLE
Add write-back URL to file API requests

### DIFF
--- a/app/api/v0/openapi.json
+++ b/app/api/v0/openapi.json
@@ -3035,6 +3035,11 @@
             "type": "string",
             "example": "https://example.com/models/abc123/model_files/def456.stl"
           },
+          "updateContentUrl": {
+            "type": "string",
+            "example": "https://example.com/models/abc123/model_files/def456.stl?sig=fdsklfjdksl",
+            "description": "A signed URL that can be used to save back edited file contents via a PUT request. Signature is valid for 1 hour. Only included if user has write permissions to the file."
+          },
           "contentSize": {
             "type": "integer",
             "example": 12345

--- a/app/controllers/model_files_controller.rb
+++ b/app/controllers/model_files_controller.rb
@@ -27,7 +27,7 @@ class ModelFilesController < ApplicationController
       @related = Naturally.sort([@file, @file.related_files, @file.files_related_to_me].flatten.uniq, by: :name_and_filename) if @file.relationships.any? || @file.reverse_relationships.any?
       respond_to do |format|
         format.html
-        format.manyfold_api_v0 { render json: ManyfoldApi::V0::ModelFileSerializer.new(@file).serialize }
+        format.manyfold_api_v0 { render json: ManyfoldApi::V0::ModelFileSerializer.new(@file, current_user: current_user).serialize }
         format.any(*MediaType.indexable_types.map(&:to_sym)) do
           attachment = @file.attachment(params[:derivative]) || @file.attachment
           send_file_content attachment, derivative: params[:derivative], disposition: (params[:download] == "true") ? :attachment : :inline

--- a/app/serializers/manyfold_api/v0/application_serializer.rb
+++ b/app/serializers/manyfold_api/v0/application_serializer.rb
@@ -1,8 +1,9 @@
 module ManyfoldApi::V0
   class ApplicationSerializer
-    def initialize(object, pager: nil)
+    def initialize(object, pager: nil, current_user: nil)
       @object = object
       @pager = pager
+      @current_user = current_user
     end
 
     def context

--- a/app/serializers/manyfold_api/v0/model_file_serializer.rb
+++ b/app/serializers/manyfold_api/v0/model_file_serializer.rb
@@ -5,7 +5,7 @@ module ManyfoldApi::V0
         "@context": context,
         name: @object.name,
         isPartOf: model_ref(@object.model),
-        contentUrl: Rails.application.routes.url_helpers.model_model_file_raw_path(@object.model, @object.filename),
+        contentUrl: Rails.application.routes.url_helpers.model_model_file_raw_url(@object.model, @object.filename),
         encodingFormat: @object.mime_type.to_s,
         contentSize: @object.size,
         description: @object.notes,

--- a/app/serializers/manyfold_api/v0/model_file_serializer.rb
+++ b/app/serializers/manyfold_api/v0/model_file_serializer.rb
@@ -1,11 +1,15 @@
 module ManyfoldApi::V0
   class ModelFileSerializer < ApplicationSerializer
     def serialize
+      if ModelFilePolicy.new(@current_user, @object).update?
+        @write_sig = @object.signed_id expires_in: 1.hour, purpose: "write"
+      end
       file_ref(@object).merge(
         "@context": context,
         name: @object.name,
         isPartOf: model_ref(@object.model),
         contentUrl: Rails.application.routes.url_helpers.model_model_file_raw_url(@object.model, @object.filename),
+        updateContentUrl: (Rails.application.routes.url_helpers.model_model_file_raw_url(@object.model, @object.filename, sig: @write_sig) if @write_sig),
         encodingFormat: @object.mime_type.to_s,
         contentSize: @object.size,
         description: @object.notes,
@@ -33,6 +37,7 @@ module ManyfoldApi::V0
           name: {type: :string, example: "Benchy"},
           encodingFormat: {type: :string, example: "model/stl"},
           contentUrl: {type: :string, example: "https://example.com/models/abc123/model_files/def456.stl"},
+          updateContentUrl: {type: :string, example: "https://example.com/models/abc123/model_files/def456.stl?sig=fdsklfjdksl", description: "A signed URL that can be used to save back edited file contents via a PUT request. Signature is valid for 1 hour. Only included if user has write permissions to the file."}, # rubocop:disable I18n/RailsI18n/DecorateString
           contentSize: {type: :integer, example: 12345},
           # Attributes from model
           isPartOf: {type: :object, properties: {

--- a/spec/requests/api/v0/model_files_spec.rb
+++ b/spec/requests/api/v0/model_files_spec.rb
@@ -75,7 +75,7 @@ describe "ModelFiles", :after_first_run, :multiuser do # rubocop:disable RSpec/E
         end
 
         run_test! "includes raw content URL" do
-          expect(response.parsed_body["contentUrl"]).to eq "/models/#{model.to_param}/raw/#{file.filename}"
+          expect(response.parsed_body["contentUrl"]).to eq "http://localhost:3214/models/#{model.to_param}/raw/#{file.filename}"
         end
       end
 

--- a/spec/serializers/manyfold_api/v0/model_file_serializer_spec.rb
+++ b/spec/serializers/manyfold_api/v0/model_file_serializer_spec.rb
@@ -2,7 +2,7 @@ require "rails_helper"
 
 RSpec.describe ManyfoldApi::V0::ModelFileSerializer do
   context "when generating a JSON-LD representation" do
-    subject(:serializer) { described_class.new(object) }
+    subject(:serializer) { described_class.new(object, current_user: user) }
 
     let(:output) { serializer.serialize }
     let(:object) {
@@ -13,6 +13,7 @@ RSpec.describe ManyfoldApi::V0::ModelFileSerializer do
         caption: "caption goes here",
         notes: "description goes here")
     }
+    let(:user) { nil }
 
     it "includes name" do
       expect(output[:name]).to eq "Test Model"
@@ -20,6 +21,30 @@ RSpec.describe ManyfoldApi::V0::ModelFileSerializer do
 
     it "includes URL for content" do
       expect(output[:contentUrl]).to eq "http://localhost:3214/models/#{object.model.to_param}/raw/files/test%20model.stl"
+    end
+
+    it "does not include write-back URL if user isn't specified" do
+      expect(output[:updateContentUrl]).to be_nil
+    end
+
+    context "with a user without write permission" do
+      let(:user) { create(:user) }
+
+      it "does not include write-back URL" do
+        expect(output[:updateContentUrl]).to be_nil
+      end
+    end
+
+    context "with a user with write permission" do
+      let(:user) { create(:user) }
+
+      before do
+        object.model.grant_permission_to "edit", user
+      end
+
+      it "includes write-back URL" do
+        expect(output[:updateContentUrl]).to match(/http:\/\/localhost:3214\/models\/#{object.model.to_param}\/raw\/files\/test%20model\.stl\?sig=[a-zA-Z0-9]*/)
+      end
     end
 
     it "includes notes" do

--- a/spec/serializers/manyfold_api/v0/model_file_serializer_spec.rb
+++ b/spec/serializers/manyfold_api/v0/model_file_serializer_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+RSpec.describe ManyfoldApi::V0::ModelFileSerializer do
+  context "when generating a JSON-LD representation" do
+    subject(:serializer) { described_class.new(object) }
+
+    let(:output) { serializer.serialize }
+    let(:object) {
+      create(:model_file,
+        filename: "files/test model.stl",
+        presupported: true,
+        y_up: true,
+        caption: "caption goes here",
+        notes: "description goes here")
+    }
+
+    it "includes name" do
+      expect(output[:name]).to eq "Test Model"
+    end
+
+    it "includes URL for content" do
+      expect(output[:contentUrl]).to eq "http://localhost:3214/models/#{object.model.to_param}/raw/files/test%20model.stl"
+    end
+
+    it "includes notes" do
+      expect(output[:description]).to eq "description goes here"
+    end
+
+    it "includes caption" do
+      expect(output[:caption]).to eq "caption goes here"
+    end
+
+    it "includes presupported flag" do
+      expect(output[:presupported]).to be true
+    end
+
+    it "includes orientation" do
+      expect(output[:up]).to eq "+y"
+    end
+  end
+end


### PR DESCRIPTION
Resolves #4971 

The file API response now includes a short-lived (1 hour) signed URL which can be used to PUT a file back after external editing. If the signature expires, it will need to be re-requested from the API. The signature is only generated if the user has write permissions to the file.

@coderofsalvation hopefully this is what you were wanting! Got there in the end...